### PR TITLE
fix(bootstrap): respect ~/.ssh/config when connecting to servers

### DIFF
--- a/fraisier/cli/bootstrap.py
+++ b/fraisier/cli/bootstrap.py
@@ -14,15 +14,20 @@ from .main import main
 @click.option("--environment", "-e", required=True, help="Environment to bootstrap")
 @click.option(
     "--ssh-user",
-    default="root",
-    show_default=True,
-    help="Privileged SSH user for the initial connection",
+    default=None,
+    help="SSH user for initial connection (default: ~/.ssh/config or root)",
+)
+@click.option(
+    "--ssh-port",
+    default=None,
+    type=int,
+    help="SSH port (default: from ~/.ssh/config or 22)",
 )
 @click.option(
     "--ssh-key",
     default=None,
     type=click.Path(),
-    help="Path to SSH private key",
+    help="Path to SSH private key (default: from ~/.ssh/config)",
 )
 @click.option(
     "--server",
@@ -36,7 +41,8 @@ from .main import main
 def bootstrap(
     ctx: click.Context,
     environment: str,
-    ssh_user: str,
+    ssh_user: str | None,
+    ssh_port: int | None,
     ssh_key: str | None,
     server: str | None,
     dry_run: bool,
@@ -58,6 +64,7 @@ def bootstrap(
     """
     from fraisier.bootstrap import ServerBootstrapper
     from fraisier.runners import SSHRunner
+    from fraisier.ssh_config import resolve_ssh_config
 
     config = require_config(ctx)
 
@@ -73,10 +80,17 @@ def bootstrap(
             f"Bootstrap requires a target host. Add it or use --server <host>."
         )
 
+    # Resolve SSH defaults from ~/.ssh/config; CLI flags take precedence.
+    host_config = resolve_ssh_config(server)
+    resolved_user = ssh_user or host_config.user or "root"
+    resolved_port = ssh_port if ssh_port is not None else (host_config.port or 22)
+    resolved_key = str(ssh_key) if ssh_key else host_config.identity_file
+
     runner = SSHRunner(
         host=server,
-        user=ssh_user,
-        key_path=str(ssh_key) if ssh_key else None,
+        user=resolved_user,
+        port=resolved_port,
+        key_path=resolved_key,
     )
 
     console.print(

--- a/fraisier/ssh_config.py
+++ b/fraisier/ssh_config.py
@@ -1,0 +1,76 @@
+"""Resolve SSH connection parameters from ~/.ssh/config via OpenSSH."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SSHHostConfig:
+    """Resolved SSH settings for a given hostname."""
+
+    user: str | None = None
+    port: int | None = None
+    identity_file: str | None = None
+
+
+def resolve_ssh_config(hostname: str) -> SSHHostConfig:
+    """Resolve effective SSH settings for *hostname* using ``ssh -G``.
+
+    Runs ``ssh -G <hostname>`` which outputs the fully-resolved configuration
+    that OpenSSH would use for the given host.  This respects ``~/.ssh/config``
+    entries including ``Host``, ``Match``, ``Include``, wildcards, etc.
+
+    Returns an :class:`SSHHostConfig` with the resolved values, or an empty
+    config (all ``None``) if resolution fails (e.g. ``ssh`` not found).
+    """
+    try:
+        result = subprocess.run(
+            ["ssh", "-G", hostname],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as e:
+        logger.debug("ssh -G failed: %s", e)
+        return SSHHostConfig()
+
+    if result.returncode != 0:
+        logger.debug(
+            "ssh -G %s returned %d: %s", hostname, result.returncode, result.stderr
+        )
+        return SSHHostConfig()
+
+    return _parse_ssh_g_output(result.stdout)
+
+
+def _parse_ssh_g_output(output: str) -> SSHHostConfig:
+    """Parse the key/value output of ``ssh -G``."""
+    user: str | None = None
+    port: int | None = None
+    identity_file: str | None = None
+
+    for line in output.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        key, value = parts[0].lower(), parts[1]
+
+        if key == "user":
+            user = value
+        elif key == "port":
+            with contextlib.suppress(ValueError):
+                port = int(value)
+        elif key == "identityfile" and not value.startswith("~/.ssh/id_"):
+            # ssh -G always outputs default identity files (~/.ssh/id_rsa,
+            # ~/.ssh/id_ecdsa, etc.) even when no IdentityFile is configured.
+            # We only capture explicitly-configured identity files.
+            identity_file = value
+
+    return SSHHostConfig(user=user, port=port, identity_file=identity_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.4"
+version = "0.4.5"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -76,6 +76,10 @@ class TestBootstrapHelp:
         result = runner.invoke(main, ["bootstrap", "--help"])
         assert "--ssh-user" in result.output
 
+    def test_help_lists_ssh_port(self, runner):
+        result = runner.invoke(main, ["bootstrap", "--help"])
+        assert "--ssh-port" in result.output
+
 
 class TestBootstrapMissingServer:
     def test_error_when_server_not_configured(self, runner, config_file_no_server):
@@ -282,3 +286,119 @@ class TestBootstrapOutput:
         assert (
             "--environment" in result.output or "environment" in result.output.lower()
         )
+
+
+class TestBootstrapSSHConfigResolution:
+    """Tests that bootstrap resolves SSH parameters from ~/.ssh/config."""
+
+    def _capture_runner(self, config_file, cli_args, ssh_host_config=None):
+        """Invoke bootstrap and capture the SSHRunner passed to ServerBootstrapper."""
+        from fraisier.ssh_config import SSHHostConfig
+
+        if ssh_host_config is None:
+            ssh_host_config = SSHHostConfig()
+
+        captured: list = []
+
+        def fake_bootstrapper(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            return m
+
+        _bs_path = "fraisier.bootstrap.ServerBootstrapper"
+        _ssh_path = "fraisier.ssh_config.resolve_ssh_config"
+        with (
+            patch(_bs_path, side_effect=fake_bootstrapper),
+            patch(_ssh_path, return_value=ssh_host_config),
+        ):
+            cli_runner = CliRunner()
+            result = cli_runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "--yes",
+                    *cli_args,
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured) == 1
+        return captured[0]
+
+    def test_defaults_without_ssh_config(self, config_file_with_server):
+        runner = self._capture_runner(config_file_with_server, [])
+        assert runner.user == "root"
+        assert runner.port == 22
+        assert runner.key_path is None
+
+    def test_ssh_config_provides_port(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(port=2222)
+        runner = self._capture_runner(config_file_with_server, [], ssh_host_config=cfg)
+        assert runner.port == 2222
+
+    def test_ssh_config_provides_user(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(user="deployer")
+        runner = self._capture_runner(config_file_with_server, [], ssh_host_config=cfg)
+        assert runner.user == "deployer"
+
+    def test_ssh_config_provides_identity_file(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(identity_file="/home/user/.ssh/deploy_key")
+        runner = self._capture_runner(config_file_with_server, [], ssh_host_config=cfg)
+        assert runner.key_path == "/home/user/.ssh/deploy_key"
+
+    def test_cli_port_overrides_ssh_config(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(port=2222)
+        runner = self._capture_runner(
+            config_file_with_server, ["--ssh-port", "3333"], ssh_host_config=cfg
+        )
+        assert runner.port == 3333
+
+    def test_cli_user_overrides_ssh_config(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(user="deployer")
+        runner = self._capture_runner(
+            config_file_with_server, ["--ssh-user", "admin"], ssh_host_config=cfg
+        )
+        assert runner.user == "admin"
+
+    def test_cli_key_overrides_ssh_config(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(identity_file="/home/user/.ssh/deploy_key")
+        runner = self._capture_runner(
+            config_file_with_server,
+            ["--ssh-key", "/other/key"],
+            ssh_host_config=cfg,
+        )
+        assert runner.key_path == "/other/key"
+
+    def test_all_ssh_config_values_applied(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(
+            user="deployer", port=2222, identity_file="/home/user/.ssh/deploy_key"
+        )
+        runner = self._capture_runner(config_file_with_server, [], ssh_host_config=cfg)
+        assert runner.user == "deployer"
+        assert runner.port == 2222
+        assert runner.key_path == "/home/user/.ssh/deploy_key"

--- a/tests/test_ssh_config.py
+++ b/tests/test_ssh_config.py
@@ -1,0 +1,116 @@
+"""Tests for fraisier.ssh_config — SSH config resolution via ssh -G."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from fraisier.ssh_config import SSHHostConfig, _parse_ssh_g_output, resolve_ssh_config
+
+# ── Sample ssh -G output ────────────────────────────────────────────
+
+_SSH_G_CUSTOM = """\
+user deployer
+hostname myserver.example.com
+port 2222
+identityfile /home/user/.ssh/deploy_key
+identityfile ~/.ssh/id_ed25519
+identityfile ~/.ssh/id_rsa
+"""
+
+_SSH_G_DEFAULTS_ONLY = """\
+user lionel
+hostname example.com
+port 22
+identityfile ~/.ssh/id_rsa
+identityfile ~/.ssh/id_ecdsa
+identityfile ~/.ssh/id_ed25519
+"""
+
+
+class TestParseSSHGOutput:
+    def test_extracts_custom_port(self):
+        result = _parse_ssh_g_output(_SSH_G_CUSTOM)
+        assert result.port == 2222
+
+    def test_extracts_user(self):
+        result = _parse_ssh_g_output(_SSH_G_CUSTOM)
+        assert result.user == "deployer"
+
+    def test_extracts_explicit_identity_file(self):
+        result = _parse_ssh_g_output(_SSH_G_CUSTOM)
+        assert result.identity_file == "/home/user/.ssh/deploy_key"
+
+    def test_ignores_default_identity_files(self):
+        result = _parse_ssh_g_output(_SSH_G_DEFAULTS_ONLY)
+        assert result.identity_file is None
+
+    def test_default_port_still_parsed(self):
+        result = _parse_ssh_g_output(_SSH_G_DEFAULTS_ONLY)
+        assert result.port == 22
+
+    def test_empty_output(self):
+        result = _parse_ssh_g_output("")
+        assert result == SSHHostConfig()
+
+    def test_malformed_lines_ignored(self):
+        result = _parse_ssh_g_output("badline\nport 443\n")
+        assert result.port == 443
+        assert result.user is None
+
+    def test_invalid_port_ignored(self):
+        result = _parse_ssh_g_output("port notanumber\n")
+        assert result.port is None
+
+
+class TestResolveSSHConfig:
+    def test_returns_parsed_config_on_success(self):
+        fake = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=_SSH_G_CUSTOM, stderr=""
+        )
+        with patch("fraisier.ssh_config.subprocess.run", return_value=fake):
+            result = resolve_ssh_config("myserver.example.com")
+
+        assert result.user == "deployer"
+        assert result.port == 2222
+        assert result.identity_file == "/home/user/.ssh/deploy_key"
+
+    def test_returns_empty_on_nonzero_exit(self):
+        fake = subprocess.CompletedProcess(
+            args=[], returncode=255, stdout="", stderr="ssh: error"
+        )
+        with patch("fraisier.ssh_config.subprocess.run", return_value=fake):
+            result = resolve_ssh_config("badhost")
+
+        assert result == SSHHostConfig()
+
+    def test_returns_empty_when_ssh_not_found(self):
+        with patch(
+            "fraisier.ssh_config.subprocess.run",
+            side_effect=FileNotFoundError("ssh not found"),
+        ):
+            result = resolve_ssh_config("example.com")
+
+        assert result == SSHHostConfig()
+
+    def test_returns_empty_on_timeout(self):
+        with patch(
+            "fraisier.ssh_config.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ssh", timeout=10),
+        ):
+            result = resolve_ssh_config("slowhost")
+
+        assert result == SSHHostConfig()
+
+    def test_passes_hostname_to_ssh(self):
+        fake = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("fraisier.ssh_config.subprocess.run", return_value=fake) as mock_run:
+            resolve_ssh_config("myserver.example.com")
+
+        mock_run.assert_called_once_with(
+            ["ssh", "-G", "myserver.example.com"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #85

- Bootstrap now resolves SSH parameters (user, port, identity file) from `~/.ssh/config` via `ssh -G <hostname>` before connecting, matching how OpenSSH resolves config (Includes, Match blocks, wildcards)
- Adds missing `--ssh-port` CLI flag
- Precedence: CLI flags > `~/.ssh/config` > hardcoded defaults (`root`/`22`)
- Bumps version to 0.4.5

## Test plan

- [x] 13 new tests for `resolve_ssh_config()` (parsing, error handling, timeouts)
- [x] 9 new tests for bootstrap CLI (config resolution, CLI override precedence)
- [x] Full suite passes (2149 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)