### PR TITLE
fix(bootstrap): prepend safe PATH to SSH commands

### DIFF
--- a/fraisier/runners.py
+++ b/fraisier/runners.py
@@ -63,6 +63,8 @@ class SSHRunner:
     connection details.
     """
 
+    _SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
     def __init__(
         self,
         host: str,
@@ -160,11 +162,15 @@ class SSHRunner:
         check: bool = True,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        # Build the remote command string; prepend env exports for SSH
+        # Build the remote command string; prepend env exports for SSH.
+        # Always inject a safe PATH so sbin directories are available in
+        # non-interactive SSH sessions (see #87).
         remote_cmd = shlex.join(cmd)
+        merged_env = {"PATH": self._SAFE_PATH}
         if env:
-            exports = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
-            remote_cmd = f"{exports} {remote_cmd}"
+            merged_env.update(env)
+        exports = " ".join(f"{k}={shlex.quote(v)}" for k, v in merged_env.items())
+        remote_cmd = f"{exports} {remote_cmd}"
         if cwd:
             remote_cmd = f"cd {shlex.quote(cwd)} && {remote_cmd}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.5"
+version = "0.4.6"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -106,6 +106,44 @@ class TestSSHRunner:
         assert "restart" in remote
         assert "api" in remote
 
+    def test_run_prepends_safe_path(self):
+        runner = SSHRunner(host="h", user="u")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="ok", stderr=""
+            )
+            runner.run(["usermod", "-aG", "www-data", "deploy"])
+
+        remote = mock_run.call_args[0][0][-1]
+        assert remote.startswith("PATH=")
+        assert "/usr/local/sbin" in remote
+        assert "/usr/sbin" in remote
+        assert "/sbin" in remote
+        assert "usermod" in remote
+
+    def test_run_with_env_merges_with_safe_path(self):
+        runner = SSHRunner(host="h", user="u")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.run(["echo", "hi"], env={"FOO": "bar"})
+
+        remote = mock_run.call_args[0][0][-1]
+        assert "PATH=" in remote
+        assert "FOO=bar" in remote
+
+    def test_run_with_env_path_overrides_safe_default(self):
+        runner = SSHRunner(host="h", user="u")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.run(["echo"], env={"PATH": "/custom/bin"})
+
+        remote = mock_run.call_args[0][0][-1]
+        assert "PATH=/custom/bin" in remote
+
     def test_run_with_cwd_prepends_cd(self):
         runner = SSHRunner(host="h", user="u")
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary
- SSHRunner.run() now prepends `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` to every remote command, ensuring system admin tools (`useradd`, `usermod`, `systemctl`, etc.) are found in non-interactive SSH sessions
- User-provided `env` dict can still override PATH if needed
- Closes #87

## Test plan
- [x] `test_run_prepends_safe_path` — verifies PATH with sbin dirs is always prepended
- [x] `test_run_with_env_merges_with_safe_path` — user env vars merge alongside PATH
- [x] `test_run_with_env_path_overrides_safe_default` — explicit PATH in env takes precedence
- [x] All 2152 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)