### PR TITLE
fix(scaffold): make relative ExecStart paths absolute (#90)

### DIFF
--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -688,7 +688,11 @@ class ScaffoldRenderer:
         app_path = env_config.get("app_path", f"/opt/{fraise['name']}")
 
         # Resolve exec_command: service.exec > fraise-level > None (template default)
+        # Prepend app_path when the executable is a relative path so systemd
+        # gets the absolute path it requires (see #90).
         exec_command = service.exec or fraise.get("exec_command")
+        if exec_command and not exec_command.startswith("/"):
+            exec_command = f"{app_path}/{exec_command}"
 
         # Resolve memory_max: service > scaffold default
         memory_max = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.6"
+version = "0.4.7"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -793,6 +793,63 @@ scaffold:
         assert "ExecStart=/usr/local/bin/fraiseql-cli serve --port 4000" in content
         assert "uvicorn" not in content
 
+    def test_relative_exec_command_gets_app_path_prepended(self, tmp_path):
+        """Relative exec_command is made absolute with app_path (#90)."""
+        config = self._make_config(
+            tmp_path,
+            """
+name: tp
+fraises:
+  myapp:
+    type: api
+    exec_command: .venv/bin/uvicorn myapp:app --host 0.0.0.0 --port 8000
+    environments:
+      production:
+        app_path: /var/www/myapp
+        worker_count: 1
+scaffold:
+  output_dir: {output}
+""".format(output=str(tmp_path / "output")),
+        )
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        renderer = ScaffoldRenderer(config)
+        renderer.render()
+
+        svc = tmp_path / "output" / "systemd" / "tp_myapp_production.service"
+        content = svc.read_text()
+        assert (
+            "ExecStart=/var/www/myapp/.venv/bin/uvicorn myapp:app"
+            " --host 0.0.0.0 --port 8000" in content
+        )
+
+    def test_absolute_exec_command_unchanged(self, tmp_path):
+        """Absolute exec_command is not modified."""
+        config = self._make_config(
+            tmp_path,
+            """
+name: tp
+fraises:
+  myapp:
+    type: api
+    exec_command: /usr/local/bin/custom-server --port 8000
+    environments:
+      production:
+        app_path: /var/www/myapp
+        worker_count: 1
+scaffold:
+  output_dir: {output}
+""".format(output=str(tmp_path / "output")),
+        )
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        renderer = ScaffoldRenderer(config)
+        renderer.render()
+
+        svc = tmp_path / "output" / "systemd" / "tp_myapp_production.service"
+        content = svc.read_text()
+        assert "ExecStart=/usr/local/bin/custom-server --port 8000" in content
+
     def test_defaults_when_no_app_path_or_health_check(self, tmp_path):
         """Falls back to /opt/<name> and port 8000 when not configured."""
         config = self._make_config(

--- a/uv.lock
+++ b/uv.lock
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.4.5"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- When `exec_command` is a relative path (e.g. `.venv/bin/uvicorn ...`), prepend `app_path` so the generated systemd unit has a valid absolute `ExecStart`
- Absolute paths are left unchanged
- Bumps version to 0.4.7

Closes #90

## Test plan
- [ ] `uv run pytest tests/test_scaffold.py -k exec_command` — 2 new tests + 1 existing
- [ ] Full suite passes (2163 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)