### PR TITLE
feat(bootstrap): preflight checks, sudo password, MCP server

### DIFF
--- a/fraisier/__init__.py
+++ b/fraisier/__init__.py
@@ -17,5 +17,5 @@ Usage:
     fraisier status <fraise> <environment>  # Check fraise status
 """
 
-__version__ = "0.4.3"
+__version__ = "0.4.8"
 __all__ = ["__version__"]

--- a/fraisier/bootstrap.py
+++ b/fraisier/bootstrap.py
@@ -14,6 +14,28 @@ if TYPE_CHECKING:
     from fraisier.runners import SSHRunner
 
 
+def resolve_become_password(command: str) -> str:
+    """Run a shell command and capture its stdout as the sudo password.
+
+    The command output is stripped of trailing whitespace.  If the command
+    exits with a non-zero status, a ``RuntimeError`` is raised containing
+    the stderr output.
+
+    **Security**: the returned value must never be logged.
+    """
+    result = subprocess.run(
+        command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = f"become_password_command failed: {result.stderr.strip()}"
+        raise RuntimeError(msg)
+    return result.stdout.strip()
+
+
 @dataclass
 class StepResult:
     """Outcome of a single bootstrap step."""

--- a/fraisier/cli/bootstrap.py
+++ b/fraisier/cli/bootstrap.py
@@ -1,4 +1,4 @@
-"""Bootstrap command — provision a virgin server end-to-end."""
+"""Bootstrap commands — provision and preflight-check a virgin server."""
 
 from __future__ import annotations
 
@@ -10,35 +10,103 @@ from ._helpers import console, require_config
 from .main import main
 
 
-@main.command("bootstrap")
-@click.option("--environment", "-e", required=True, help="Environment to bootstrap")
-@click.option(
+def _resolve_server_and_runner(
+    ctx: click.Context,
+    environment: str,
+    ssh_user: str | None,
+    ssh_port: int | None,
+    ssh_key: str | None,
+    server: str | None,
+    sudo: bool = False,
+    sudo_password: str | None = None,
+) -> tuple[str, object]:
+    """Resolve the target server and build an SSHRunner.
+
+    Shared by ``bootstrap`` and ``bootstrap-preflight``.
+    Returns ``(server_hostname, SSHRunner)``.
+    """
+    from fraisier.runners import SSHRunner
+    from fraisier.ssh_config import resolve_ssh_config
+
+    config = require_config(ctx)
+
+    if server is None:
+        env_cfg = config.environments.get(environment)
+        if isinstance(env_cfg, dict):
+            server = env_cfg.get("server")
+
+    if not server:
+        raise click.UsageError(
+            f"environments.{environment}.server is not set in fraises.yaml.\n"
+            f"Bootstrap requires a target host. Add it or use --server <host>."
+        )
+
+    host_config = resolve_ssh_config(server)
+    resolved_user = ssh_user or host_config.user or "root"
+    resolved_port = ssh_port if ssh_port is not None else (host_config.port or 22)
+    resolved_key = str(ssh_key) if ssh_key else host_config.identity_file
+
+    runner = SSHRunner(
+        host=server,
+        user=resolved_user,
+        port=resolved_port,
+        key_path=resolved_key,
+        use_sudo=sudo,
+        sudo_password=sudo_password,
+    )
+    return server, runner
+
+
+# Common Click options shared between bootstrap commands
+_ssh_user_option = click.option(
     "--ssh-user",
     default=None,
     help="SSH user for initial connection (default: ~/.ssh/config or root)",
 )
-@click.option(
+_ssh_port_option = click.option(
     "--ssh-port",
     default=None,
     type=int,
     help="SSH port (default: from ~/.ssh/config or 22)",
 )
-@click.option(
+_ssh_key_option = click.option(
     "--ssh-key",
     default=None,
     type=click.Path(),
     help="Path to SSH private key (default: from ~/.ssh/config)",
 )
-@click.option(
+_server_option = click.option(
     "--server",
     default=None,
-    help="Target server hostname (overrides environments.<env>.server in fraises.yaml)",
+    help="Target server hostname (overrides environments.<env>.server)",
 )
+_environment_option = click.option(
+    "--environment", "-e", required=True, help="Environment to bootstrap"
+)
+
+
+@main.command("bootstrap")
+@_environment_option
+@_ssh_user_option
+@_ssh_port_option
+@_ssh_key_option
+@_server_option
 @click.option("--dry-run", is_flag=True, help="Print steps without executing anything")
 @click.option(
     "--sudo",
     is_flag=True,
     help="Prefix remote commands with sudo (for non-root SSH users)",
+)
+@click.option(
+    "--become-password-command",
+    default=None,
+    help='Shell command that prints the sudo password (e.g. "op read op://…")',
+)
+@click.option(
+    "--ask-become-pass",
+    "-K",
+    is_flag=True,
+    help="Prompt for sudo password (implies --sudo)",
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
@@ -52,6 +120,8 @@ def bootstrap(
     server: str | None,
     dry_run: bool,
     sudo: bool,
+    become_password_command: str | None,
+    ask_become_pass: bool,
     yes: bool,
     verbose: bool,
 ) -> None:
@@ -68,37 +138,34 @@ def bootstrap(
         fraisier bootstrap --environment production --server myserver.com
         fraisier bootstrap -e production --ssh-user deployer --ssh-key ~/.ssh/id_ed25519
         fraisier bootstrap -e production --ssh-user lionel --sudo
+        fraisier bootstrap -e production --ssh-user lionel -K
+        fraisier bootstrap -e production --become-password-command "op read op://…"
     """
-    from fraisier.bootstrap import ServerBootstrapper
-    from fraisier.runners import SSHRunner
-    from fraisier.ssh_config import resolve_ssh_config
+    from fraisier.bootstrap import ServerBootstrapper, resolve_become_password
 
     config = require_config(ctx)
 
-    # Resolve target server
-    if server is None:
-        env_cfg = config.environments.get(environment)
-        if isinstance(env_cfg, dict):
-            server = env_cfg.get("server")
+    # Resolution order: CLI command > config command > interactive prompt
+    sudo_password = None
+    if become_password_command is None:
+        raw_bootstrap = config._config.get("bootstrap", {}) or {}
+        become_password_command = raw_bootstrap.get("become_password_command")
 
-    if not server:
-        raise click.UsageError(
-            f"environments.{environment}.server is not set in fraises.yaml.\n"
-            f"Bootstrap requires a target host. Add it or use --server <host>."
-        )
-
-    # Resolve SSH defaults from ~/.ssh/config; CLI flags take precedence.
-    host_config = resolve_ssh_config(server)
-    resolved_user = ssh_user or host_config.user or "root"
-    resolved_port = ssh_port if ssh_port is not None else (host_config.port or 22)
-    resolved_key = str(ssh_key) if ssh_key else host_config.identity_file
-
-    runner = SSHRunner(
-        host=server,
-        user=resolved_user,
-        port=resolved_port,
-        key_path=resolved_key,
-        use_sudo=sudo,
+    if become_password_command:
+        sudo = True
+        sudo_password = resolve_become_password(become_password_command)
+    elif ask_become_pass:
+        sudo = True
+        sudo_password = click.prompt("SUDO password", hide_input=True, err=True)
+    server, runner = _resolve_server_and_runner(
+        ctx,
+        environment,
+        ssh_user,
+        ssh_port,
+        ssh_key,
+        server,
+        sudo=sudo,
+        sudo_password=sudo_password,
     )
 
     console.print(
@@ -145,3 +212,70 @@ def bootstrap(
         f"\n[green]Bootstrap complete.[/green] Server is ready for first deploy:\n"
         f"  fraisier trigger-deploy <fraise> {environment}"
     )
+
+
+@main.command("bootstrap-preflight")
+@_environment_option
+@_ssh_user_option
+@_ssh_port_option
+@_ssh_key_option
+@_server_option
+@click.pass_context
+def bootstrap_preflight(
+    ctx: click.Context,
+    environment: str,
+    ssh_user: str | None,
+    ssh_port: int | None,
+    ssh_key: str | None,
+    server: str | None,
+) -> None:
+    """Check server prerequisites before running bootstrap.
+
+    Runs read-only SSH checks and reports what needs to be fixed.
+    Does not make any changes to the server.
+
+    \b
+    Examples:
+        fraisier bootstrap-preflight --environment production
+        fraisier bootstrap-preflight -e staging --server myserver.com
+        fraisier bootstrap-preflight -e production --ssh-user lionel
+    """
+    from fraisier.preflight import PreflightChecker
+
+    config = require_config(ctx)
+    server, runner = _resolve_server_and_runner(
+        ctx, environment, ssh_user, ssh_port, ssh_key, server
+    )
+
+    console.print(
+        f"[cyan]Checking[/cyan] [bold]{environment}[/bold] on [bold]{server}[/bold]..."
+    )
+
+    checker = PreflightChecker(
+        runner=runner,
+        deploy_user=config.scaffold.deploy_user,
+    )
+    result = checker.run_all()
+
+    for check in result.checks:
+        color = "green" if check.passed else "red"
+        symbol = "✓" if check.passed else "✗"
+        parts = [f"  [{color}]{symbol} {check.name}[/{color}]"]
+        if check.message:
+            parts.append(f" ({check.message})")
+        if not check.passed and check.fix_hint:
+            parts.append(f" — run: {check.fix_hint}")
+        console.print("".join(parts))
+
+    if result.passed:
+        console.print(
+            f"\n[green]All checks passed.[/green] Ready to bootstrap:\n"
+            f"  fraisier bootstrap --environment {environment}"
+        )
+    else:
+        n = result.failed_count
+        console.print(
+            f"\n[red]Fix {n} issue{'s' if n != 1 else ''} above, then run:[/red]\n"
+            f"  fraisier bootstrap --environment {environment}"
+        )
+        raise SystemExit(1)

--- a/fraisier/mcp_server.py
+++ b/fraisier/mcp_server.py
@@ -1,0 +1,164 @@
+"""Fraisier MCP server — exposes bootstrap tools with elicitation support."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import BaseModel
+
+from fraisier.bootstrap import ServerBootstrapper, resolve_become_password
+from fraisier.config import FraisierConfig
+from fraisier.preflight import PreflightChecker
+from fraisier.runners import SSHRunner
+from fraisier.ssh_config import resolve_ssh_config
+
+mcp = FastMCP("fraisier")
+
+
+class SudoPasswordSchema(BaseModel):
+    sudo_password: str
+
+
+def _load_config() -> FraisierConfig:
+    """Load fraisier config from FRAISIER_CONFIG env var or default search."""
+    config_path = os.environ.get("FRAISIER_CONFIG")
+    if config_path:
+        return FraisierConfig(Path(config_path))
+    return FraisierConfig()
+
+
+def _resolve_runner(
+    config: FraisierConfig,
+    environment: str,
+    *,
+    use_sudo: bool = False,
+    sudo_password: str | None = None,
+    ssh_user: str | None = None,
+) -> tuple[str, SSHRunner]:
+    """Resolve server and build SSHRunner from config."""
+    env_cfg = config.environments.get(environment)
+    server = env_cfg.get("server") if isinstance(env_cfg, dict) else None
+    if not server:
+        msg = f"environments.{environment}.server not set in config"
+        raise ValueError(msg)
+
+    host_config = resolve_ssh_config(server)
+    runner = SSHRunner(
+        host=server,
+        user=ssh_user or host_config.user or "root",
+        port=host_config.port or 22,
+        key_path=host_config.identity_file,
+        use_sudo=use_sudo,
+        sudo_password=sudo_password,
+    )
+    return server, runner
+
+
+@mcp.tool()
+async def bootstrap_preflight(
+    environment: str,
+    ssh_user: str | None = None,
+) -> str:
+    """Run preflight checks on target server before bootstrap.
+
+    Validates SSH connectivity, sudo access, required packages, disk space,
+    and other prerequisites. Does not make any changes to the server.
+    """
+    config = _load_config()
+    server, runner = _resolve_runner(config, environment, ssh_user=ssh_user)
+
+    checker = PreflightChecker(runner=runner, deploy_user=config.scaffold.deploy_user)
+    result = checker.run_all()
+
+    lines = [f"Preflight checks for {environment} on {server}:"]
+    for check in result.checks:
+        symbol = "PASS" if check.passed else "FAIL"
+        line = f"  [{symbol}] {check.name}"
+        if check.message:
+            line += f" ({check.message})"
+        if not check.passed and check.fix_hint:
+            line += f" — fix: {check.fix_hint}"
+        lines.append(line)
+
+    if result.passed:
+        lines.append("\nAll checks passed. Ready for bootstrap.")
+    else:
+        n = result.failed_count
+        lines.append(f"\n{n} check(s) failed. Fix issues above first.")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def bootstrap_server(
+    environment: str,
+    sudo: bool = False,
+    ssh_user: str | None = None,
+    dry_run: bool = False,
+    ctx: Context | None = None,
+) -> str:
+    """Bootstrap a server end-to-end via SSH.
+
+    Runs 10 ordered, idempotent provisioning steps. If sudo=True,
+    prompts for the sudo password via elicitation (password is not
+    stored in the conversation).
+    """
+    config = _load_config()
+    sudo_password = None
+
+    if sudo:
+        # Resolution: config command > MCP elicitation
+        raw_bootstrap = config._config.get("bootstrap", {}) or {}
+        cmd = raw_bootstrap.get("become_password_command")
+        if cmd:
+            sudo_password = resolve_become_password(cmd)
+        elif ctx is not None:
+            result = await ctx.elicit(
+                message="Enter the sudo password for the target server",
+                schema=SudoPasswordSchema,
+            )
+            if result.action != "accept":
+                return "Bootstrap aborted: sudo password was declined."
+            sudo_password = result.data.sudo_password
+
+    server, runner = _resolve_runner(
+        config,
+        environment,
+        use_sudo=sudo,
+        sudo_password=sudo_password,
+        ssh_user=ssh_user,
+    )
+
+    bootstrapper = ServerBootstrapper(
+        config=config,
+        environment=environment,
+        runner=runner,
+        fraises_yaml_path=Path(config.config_path),
+        dry_run=dry_run,
+    )
+
+    bootstrap_result = bootstrapper.bootstrap()
+
+    lines = [f"Bootstrap {environment} on {server}:"]
+    for i, step in enumerate(bootstrap_result.steps, 1):
+        symbol = "OK" if step.success else "FAIL"
+        line = f"  [{i}/{len(bootstrap_result.steps)}] {step.name} ... {symbol}"
+        if step.already_done:
+            line += " (already done)"
+        if not step.success and step.error:
+            line += f"\n    Error: {step.error}"
+        lines.append(line)
+
+    if bootstrap_result.success:
+        lines.append("\nBootstrap complete. Server is ready for deploy.")
+    else:
+        lines.append("\nBootstrap failed. Fix the error above and retry.")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Entry point for the fraisier-mcp command."""
+    mcp.run()

--- a/fraisier/preflight.py
+++ b/fraisier/preflight.py
@@ -1,0 +1,187 @@
+"""Preflight checks — validate server prerequisites before bootstrap."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fraisier.runners import SSHRunner
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single preflight check."""
+
+    name: str
+    passed: bool
+    message: str = ""
+    fix_hint: str = ""
+
+
+@dataclass
+class PreflightResult:
+    """Aggregate result of all preflight checks."""
+
+    server: str
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(c.passed for c in self.checks)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for c in self.checks if not c.passed)
+
+
+class PreflightChecker:
+    """Run read-only checks on a remote server before bootstrap."""
+
+    def __init__(self, runner: SSHRunner, deploy_user: str = "fraisier") -> None:
+        self.runner = runner
+        self.deploy_user = deploy_user
+
+    def run_all(self) -> PreflightResult:
+        """Run all preflight checks, collecting every result."""
+        result = PreflightResult(server=self.runner.host)
+        result.checks.append(self.check_ssh())
+        result.checks.append(self.check_sudo())
+        result.checks.append(self.check_sudo_passwordless())
+        for pkg in ("git", "nginx", "psql"):
+            result.checks.append(self.check_package(pkg))
+        result.checks.append(self.check_disk_space())
+        return result
+
+    def check_ssh(self) -> CheckResult:
+        """Check SSH connectivity."""
+        try:
+            self.runner.run(["echo", "ok"], timeout=15)
+            return CheckResult(
+                name="SSH connectivity",
+                passed=True,
+                message=f"port {self.runner.port}, user {self.runner.user}",
+            )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name="SSH connectivity",
+                passed=False,
+                message="Connection timed out",
+            )
+        except subprocess.CalledProcessError as e:
+            return CheckResult(
+                name="SSH connectivity",
+                passed=False,
+                message=e.stderr or str(e),
+            )
+
+    def check_sudo(self) -> CheckResult:
+        """Check whether sudo is available for the SSH user."""
+        try:
+            self.runner.run(["sudo", "-n", "true"], timeout=10)
+            return CheckResult(name="sudo available", passed=True)
+        except subprocess.CalledProcessError:
+            return CheckResult(
+                name="sudo available",
+                passed=False,
+                fix_hint=f"Grant sudo to {self.runner.user} or use --ssh-user root",
+            )
+
+    def check_sudo_passwordless(self) -> CheckResult:
+        """Check whether sudo is passwordless (no prompt required)."""
+        try:
+            self.runner.run(["sudo", "-n", "true"], timeout=10)
+            return CheckResult(name="sudo is passwordless", passed=True)
+        except subprocess.CalledProcessError:
+            return CheckResult(
+                name="sudo is passwordless",
+                passed=False,
+                fix_hint=(
+                    f"sudo visudo -f /etc/sudoers.d/{self.deploy_user}-bootstrap"
+                ),
+            )
+
+    def check_package(self, name: str) -> CheckResult:
+        """Check whether a package binary is available on PATH."""
+        try:
+            self.runner.run(["which", name], timeout=10)
+            return CheckResult(name=f"{name} installed", passed=True)
+        except subprocess.CalledProcessError:
+            return CheckResult(
+                name=f"{name} installed",
+                passed=False,
+                fix_hint=f"apt install {name}",
+            )
+
+    def check_disk_space(self, min_gb: int = 2) -> CheckResult:
+        """Check available disk space on /opt (or /)."""
+        try:
+            out = self.runner.run(["df", "-BG", "/opt"], timeout=10)
+            return self._parse_disk_space(out.stdout, min_gb)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return CheckResult(
+                name="Disk space",
+                passed=False,
+                message="Could not check disk space",
+            )
+
+    def check_ports(self, ports: list[int]) -> CheckResult:
+        """Check whether the given ports are already in use."""
+        try:
+            out = self.runner.run(["ss", "-tlnp"], timeout=10)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return CheckResult(
+                name="Port availability",
+                passed=False,
+                message="Could not check ports",
+            )
+
+        in_use = [port for port in ports if re.search(rf":({port})\b", out.stdout)]
+
+        if in_use:
+            return CheckResult(
+                name="Port availability",
+                passed=False,
+                message=f"Ports already in use: {', '.join(str(p) for p in in_use)}",
+            )
+        return CheckResult(name="Port availability", passed=True)
+
+    @staticmethod
+    def _parse_disk_space(output: str, min_gb: int) -> CheckResult:
+        """Parse df -BG output and check available space."""
+        lines = output.strip().splitlines()
+        if len(lines) < 2:
+            return CheckResult(
+                name="Disk space",
+                passed=False,
+                message="Could not parse df output",
+            )
+        parts = lines[1].split()
+        if len(parts) < 4:
+            return CheckResult(
+                name="Disk space",
+                passed=False,
+                message="Could not parse df output",
+            )
+        avail_str = parts[3]
+        match = re.match(r"(\d+)", avail_str)
+        if not match:
+            return CheckResult(
+                name="Disk space",
+                passed=False,
+                message="Could not parse df output",
+            )
+        avail_gb = int(match.group(1))
+        if avail_gb < min_gb:
+            return CheckResult(
+                name="Disk space",
+                passed=False,
+                message=f"{avail_gb}G free on /opt (minimum {min_gb}G)",
+            )
+        return CheckResult(
+            name="Disk space",
+            passed=True,
+            message=f"{avail_gb}G free on /opt",
+        )

--- a/fraisier/runners.py
+++ b/fraisier/runners.py
@@ -74,6 +74,7 @@ class SSHRunner:
         key_path: str | None = None,
         strict_host_key: bool = True,
         use_sudo: bool = False,
+        sudo_password: str | None = None,
     ) -> None:
         self.host = host
         self.user = user
@@ -81,6 +82,7 @@ class SSHRunner:
         self.key_path = key_path
         self.strict_host_key = strict_host_key
         self.use_sudo = use_sudo
+        self.sudo_password = sudo_password
 
     def _build_ssh_options(self) -> list[str]:
         """Build shared SSH/SCP options (host-key policy, batch mode, identity)."""
@@ -138,7 +140,15 @@ class SSHRunner:
         return result
 
     def upload_tree(self, local_dir: Path, remote_dir: str) -> None:
-        """Upload a directory tree to the remote host via tar piped over SSH."""
+        """Upload a directory tree to the remote host via tar piped over SSH.
+
+        When *sudo_password* is set, uploads to a temporary directory first
+        (without sudo), then moves into place with ``sudo -S``, since stdin
+        cannot carry both the password and the tar stream simultaneously.
+        """
+        if self.use_sudo and self.sudo_password:
+            return self._upload_tree_with_password(local_dir, remote_dir)
+
         tar = subprocess.Popen(
             ["tar", "czf", "-", "-C", str(local_dir), "."],
             stdout=subprocess.PIPE,
@@ -170,6 +180,45 @@ class SSHRunner:
                 ssh_result.returncode, ssh_cmd, stderr=ssh_result.stderr
             )
 
+    def _upload_tree_with_password(self, local_dir: Path, remote_dir: str) -> None:
+        """Upload tree via temp dir + sudo -S mv when password is needed."""
+        tmp_dir = "/tmp/.fraisier-upload-tree"
+        # Upload to temp dir without sudo
+        tar = subprocess.Popen(
+            ["tar", "czf", "-", "-C", str(local_dir), "."],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        remote_cmd = (
+            f"mkdir -p {shlex.quote(tmp_dir)} && tar xzf - -C {shlex.quote(tmp_dir)}"
+        )
+        ssh_cmd = [*self._build_ssh_prefix(), remote_cmd]
+        ssh_result = subprocess.run(
+            ssh_cmd,
+            stdin=tar.stdout,
+            capture_output=True,
+            check=False,
+        )
+        if tar.stdout:
+            tar.stdout.close()
+        _, tar_stderr = tar.communicate()
+
+        if tar.returncode != 0:
+            raise subprocess.CalledProcessError(
+                tar.returncode, "tar", stderr=tar_stderr
+            )
+        if ssh_result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                ssh_result.returncode, ssh_cmd, stderr=ssh_result.stderr
+            )
+        # Move into place with sudo -S
+        move_cmd = (
+            f"mkdir -p {shlex.quote(remote_dir)}"
+            f" && cp -a {shlex.quote(tmp_dir)}/. {shlex.quote(remote_dir)}/"
+            f" && rm -rf {shlex.quote(tmp_dir)}"
+        )
+        self.run(["sh", "-c", move_cmd])
+
     def run(
         self,
         cmd: list[str],
@@ -191,9 +240,19 @@ class SSHRunner:
         if cwd:
             remote_cmd = f"cd {shlex.quote(cwd)} && {remote_cmd}"
         if self.use_sudo:
-            remote_cmd = f"sudo sh -c {shlex.quote(remote_cmd)}"
+            sudo_prefix = "sudo -S" if self.sudo_password else "sudo"
+            remote_cmd = f"{sudo_prefix} sh -c {shlex.quote(remote_cmd)}"
 
         ssh_cmd = [*self._build_ssh_prefix(), remote_cmd]
+        if self.sudo_password and self.use_sudo:
+            return subprocess.run(
+                ssh_cmd,
+                input=self.sudo_password + "\n",
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=check,
+            )
         return subprocess.run(
             ssh_cmd,
             capture_output=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.7"
+version = "1.1.0"
 
 [project.optional-dependencies]
 all-databases = [
@@ -54,9 +54,13 @@ graphql = [
 postgres = [
   "psycopg[binary]>=3.1.0,<4.0"
 ]
+mcp = [
+    "mcp[cli]>=1.9.0",
+]
 
 [project.scripts]
 fraisier = "fraisier.cli:main"
+fraisier-mcp = "fraisier.mcp_server:main"
 fraisier-webhook = "fraisier.webhook:run_server"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.1.0"
+version = "0.4.8"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fraisier.bootstrap import BootstrapResult, ServerBootstrapper, StepResult
+from fraisier.bootstrap import (
+    BootstrapResult,
+    ServerBootstrapper,
+    StepResult,
+    resolve_become_password,
+)
 from fraisier.config import FraisierConfig
 from fraisier.runners import SSHRunner
 
@@ -423,3 +428,38 @@ class TestBootstrapFlow:
 
         assert result.success is False
         mock_cleanup.assert_called_once_with("/tmp/x")
+
+
+# ---------------------------------------------------------------------------
+# resolve_become_password
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBecomePassword:
+    def test_captures_stdout(self):
+        password = resolve_become_password("echo hunter2")
+        assert password == "hunter2"
+
+    def test_strips_trailing_newline(self):
+        password = resolve_become_password("printf 'secret\\n'")
+        assert password == "secret"
+
+    def test_strips_trailing_whitespace(self):
+        password = resolve_become_password("printf 'secret  \\n'")
+        assert password == "secret"
+
+    def test_raises_on_nonzero_exit(self):
+        with pytest.raises(RuntimeError, match="become_password_command failed"):
+            resolve_become_password("false")
+
+    def test_raises_includes_stderr(self):
+        with pytest.raises(RuntimeError, match="not found"):
+            resolve_become_password("echo 'not found' >&2 && exit 1")
+
+    def test_supports_pipe_commands(self):
+        password = resolve_become_password("echo 'hello world' | cut -d' ' -f2")
+        assert password == "world"
+
+    def test_empty_output_returns_empty_string(self):
+        password = resolve_become_password("printf ''")
+        assert password == ""

--- a/tests/test_cli_bootstrap.py
+++ b/tests/test_cli_bootstrap.py
@@ -471,3 +471,203 @@ class TestBootstrapSSHConfigResolution:
         assert runner.user == "deployer"
         assert runner.port == 2222
         assert runner.key_path == "/home/user/.ssh/deploy_key"
+
+
+class TestBootstrapAskBecomePass:
+    """Tests for --ask-become-pass / -K flag."""
+
+    def test_help_lists_ask_become_pass(self, runner):
+        result = runner.invoke(main, ["bootstrap", "--help"])
+        assert "--ask-become-pass" in result.output
+
+    def test_short_flag_k(self, runner):
+        result = runner.invoke(main, ["bootstrap", "--help"])
+        assert "-K" in result.output
+
+    def test_ask_become_pass_implies_sudo(self, runner, config_file_with_server):
+        captured: list = []
+
+        def fake_bootstrapper(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            return m
+
+        _bs_path = "fraisier.bootstrap.ServerBootstrapper"
+        with patch(_bs_path, side_effect=fake_bootstrapper):
+            runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "--ask-become-pass",
+                    "--yes",
+                ],
+                input="secret\n",
+            )
+
+        assert len(captured) == 1
+        assert captured[0].use_sudo is True
+        assert captured[0].sudo_password == "secret"
+
+    def test_ask_become_pass_prompts_for_password(
+        self, runner, config_file_with_server
+    ):
+        with patch("fraisier.bootstrap.ServerBootstrapper") as mock_bs_cls:
+            mock_bs_cls.return_value.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            result = runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "-K",
+                    "--yes",
+                ],
+                input="mypassword\n",
+            )
+        assert result.exit_code == 0
+        assert "SUDO password" in result.output
+
+
+class TestBootstrapBecomePasswordCommand:
+    """Tests for --become-password-command flag."""
+
+    def test_help_lists_become_password_command(self, runner):
+        result = runner.invoke(main, ["bootstrap", "--help"])
+        assert "--become-password-command" in result.output
+
+    def test_command_provides_password(self, runner, config_file_with_server):
+        captured: list = []
+
+        def fake_bootstrapper(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            return m
+
+        _bs_path = "fraisier.bootstrap.ServerBootstrapper"
+        with patch(_bs_path, side_effect=fake_bootstrapper):
+            runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "--become-password-command",
+                    "echo hunter2",
+                    "--yes",
+                ],
+            )
+
+        assert len(captured) == 1
+        assert captured[0].use_sudo is True
+        assert captured[0].sudo_password == "hunter2"
+
+    def test_command_implies_sudo(self, runner, config_file_with_server):
+        captured: list = []
+
+        def fake_bootstrapper(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            return m
+
+        _bs_path = "fraisier.bootstrap.ServerBootstrapper"
+        with patch(_bs_path, side_effect=fake_bootstrapper):
+            runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "--become-password-command",
+                    "echo secret",
+                    "--yes",
+                ],
+            )
+
+        assert len(captured) == 1
+        assert captured[0].use_sudo is True
+
+    def test_command_takes_precedence_over_ask(self, runner, config_file_with_server):
+        """--become-password-command wins over --ask-become-pass."""
+        captured: list = []
+
+        def fake_bootstrapper(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.bootstrap.return_value = BootstrapResult(
+                steps=[StepResult(name="s", success=True)]
+            )
+            return m
+
+        _bs_path = "fraisier.bootstrap.ServerBootstrapper"
+        with patch(_bs_path, side_effect=fake_bootstrapper):
+            runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap",
+                    "-e",
+                    "production",
+                    "--become-password-command",
+                    "echo fromcmd",
+                    "--ask-become-pass",
+                    "--yes",
+                ],
+                input="fromprompt\n",
+            )
+
+        assert len(captured) == 1
+        assert captured[0].sudo_password == "fromcmd"
+
+    def test_failed_command_exits_nonzero(self, runner, config_file_with_server):
+        result = runner.invoke(
+            main,
+            [
+                "-c",
+                str(config_file_with_server),
+                "bootstrap",
+                "-e",
+                "production",
+                "--become-password-command",
+                "false",
+                "--yes",
+            ],
+        )
+        assert result.exit_code != 0

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -1,0 +1,259 @@
+"""Tests for the fraisier bootstrap-preflight CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fraisier.cli.main import main
+from fraisier.preflight import CheckResult, PreflightResult
+
+_YAML_WITH_SERVER = """\
+name: myapp
+fraises:
+  api:
+    type: api
+    environments:
+      production: {}
+environments:
+  production:
+    server: prod.example.com
+scaffold:
+  deploy_user: myapp_deploy
+"""
+
+_YAML_NO_SERVER = """\
+name: myapp
+fraises:
+  api:
+    type: api
+    environments:
+      production: {}
+scaffold:
+  deploy_user: myapp_deploy
+"""
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def config_file_with_server(tmp_path):
+    p = tmp_path / "fraises.yaml"
+    p.write_text(_YAML_WITH_SERVER)
+    return p
+
+
+@pytest.fixture
+def config_file_no_server(tmp_path):
+    p = tmp_path / "fraises.yaml"
+    p.write_text(_YAML_NO_SERVER)
+    return p
+
+
+def _all_pass_result(server: str = "prod.example.com") -> PreflightResult:
+    return PreflightResult(
+        server=server,
+        checks=[
+            CheckResult(
+                name="SSH connectivity",
+                passed=True,
+                message="port 22, user root",
+            ),
+            CheckResult(name="sudo available", passed=True),
+            CheckResult(name="git installed", passed=True),
+        ],
+    )
+
+
+def _mixed_result(server: str = "prod.example.com") -> PreflightResult:
+    return PreflightResult(
+        server=server,
+        checks=[
+            CheckResult(
+                name="SSH connectivity",
+                passed=True,
+                message="port 22, user root",
+            ),
+            CheckResult(
+                name="sudo available",
+                passed=False,
+                fix_hint="Grant sudo",
+            ),
+            CheckResult(
+                name="nginx installed",
+                passed=False,
+                fix_hint="apt install nginx",
+            ),
+        ],
+    )
+
+
+class TestPreflightHelp:
+    def test_help_exits_zero(self, runner):
+        result = runner.invoke(main, ["bootstrap-preflight", "--help"])
+        assert result.exit_code == 0
+
+    def test_help_lists_environment_option(self, runner):
+        result = runner.invoke(main, ["bootstrap-preflight", "--help"])
+        assert "--environment" in result.output
+
+    def test_help_lists_server_override(self, runner):
+        result = runner.invoke(main, ["bootstrap-preflight", "--help"])
+        assert "--server" in result.output
+
+    def test_help_lists_ssh_options(self, runner):
+        result = runner.invoke(main, ["bootstrap-preflight", "--help"])
+        assert "--ssh-user" in result.output
+        assert "--ssh-port" in result.output
+
+
+class TestPreflightMissingServer:
+    def test_error_when_server_not_configured(self, runner, config_file_no_server):
+        result = runner.invoke(
+            main,
+            [
+                "-c",
+                str(config_file_no_server),
+                "bootstrap-preflight",
+                "-e",
+                "production",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "server" in result.output.lower()
+
+    def test_server_flag_overrides_missing_config(self, runner, config_file_no_server):
+        with patch("fraisier.preflight.PreflightChecker") as mock_cls:
+            mock_cls.return_value.run_all.return_value = _all_pass_result()
+            result = runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_no_server),
+                    "bootstrap-preflight",
+                    "-e",
+                    "production",
+                    "--server",
+                    "override.example.com",
+                ],
+            )
+        assert result.exit_code == 0
+
+
+class TestPreflightOutput:
+    def test_all_pass_shows_success(self, runner, config_file_with_server):
+        with patch("fraisier.preflight.PreflightChecker") as mock_cls:
+            mock_cls.return_value.run_all.return_value = _all_pass_result()
+            result = runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap-preflight",
+                    "-e",
+                    "production",
+                ],
+            )
+        assert result.exit_code == 0
+
+    def test_failures_show_hints(self, runner, config_file_with_server):
+        with patch("fraisier.preflight.PreflightChecker") as mock_cls:
+            mock_cls.return_value.run_all.return_value = _mixed_result()
+            result = runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap-preflight",
+                    "-e",
+                    "production",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "nginx" in result.output.lower() or "apt install" in result.output
+
+    def test_failures_exit_nonzero(self, runner, config_file_with_server):
+        with patch("fraisier.preflight.PreflightChecker") as mock_cls:
+            mock_cls.return_value.run_all.return_value = _mixed_result()
+            result = runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file_with_server),
+                    "bootstrap-preflight",
+                    "-e",
+                    "production",
+                ],
+            )
+        assert result.exit_code != 0
+
+
+class TestPreflightSSHConfigResolution:
+    def _capture_runner(self, config_file, cli_args, ssh_host_config=None):
+        from fraisier.ssh_config import SSHHostConfig
+
+        if ssh_host_config is None:
+            ssh_host_config = SSHHostConfig()
+
+        captured: list = []
+
+        def fake_checker(**kwargs):
+            from fraisier.runners import SSHRunner
+
+            runner_arg = kwargs.get("runner")
+            if isinstance(runner_arg, SSHRunner):
+                captured.append(runner_arg)
+            m = MagicMock()
+            m.run_all.return_value = _all_pass_result()
+            return m
+
+        _pc_path = "fraisier.preflight.PreflightChecker"
+        _ssh_path = "fraisier.ssh_config.resolve_ssh_config"
+        with (
+            patch(_pc_path, side_effect=fake_checker),
+            patch(_ssh_path, return_value=ssh_host_config),
+        ):
+            cli_runner = CliRunner()
+            result = cli_runner.invoke(
+                main,
+                [
+                    "-c",
+                    str(config_file),
+                    "bootstrap-preflight",
+                    "-e",
+                    "production",
+                    *cli_args,
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert len(captured) == 1
+        return captured[0]
+
+    def test_defaults_without_ssh_config(self, config_file_with_server):
+        runner = self._capture_runner(config_file_with_server, [])
+        assert runner.user == "root"
+        assert runner.port == 22
+
+    def test_ssh_config_provides_port(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(port=2222)
+        runner = self._capture_runner(config_file_with_server, [], ssh_host_config=cfg)
+        assert runner.port == 2222
+
+    def test_cli_user_overrides_ssh_config(self, config_file_with_server):
+        from fraisier.ssh_config import SSHHostConfig
+
+        cfg = SSHHostConfig(user="deployer")
+        runner = self._capture_runner(
+            config_file_with_server,
+            ["--ssh-user", "admin"],
+            ssh_host_config=cfg,
+        )
+        assert runner.user == "admin"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,221 @@
+"""Tests for the fraisier MCP server."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fraisier.mcp_server import (
+    _load_config,
+    _resolve_runner,
+    bootstrap_preflight,
+    bootstrap_server,
+    mcp,
+)
+
+
+@pytest.fixture
+def minimal_config(tmp_path):
+    """Create a minimal fraises.yaml and set env for the MCP server."""
+    p = tmp_path / "fraises.yaml"
+    p.write_text(
+        "name: myapp\n"
+        "fraises:\n"
+        "  api:\n"
+        "    type: api\n"
+        "    environments:\n"
+        "      production: {}\n"
+        "environments:\n"
+        "  production:\n"
+        "    server: prod.example.com\n"
+        "scaffold:\n"
+        "  deploy_user: myapp_deploy\n"
+    )
+    return p
+
+
+class TestToolRegistration:
+    def test_bootstrap_preflight_tool_registered(self):
+        tools = {t.name for t in mcp._tool_manager.list_tools()}
+        assert "bootstrap_preflight" in tools
+
+    def test_bootstrap_server_tool_registered(self):
+        tools = {t.name for t in mcp._tool_manager.list_tools()}
+        assert "bootstrap_server" in tools
+
+
+class TestLoadConfig:
+    def test_loads_from_env_var(self, minimal_config):
+        with patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}):
+            config = _load_config()
+        assert config.project_name == "myapp"
+
+    def test_raises_without_config(self, tmp_path):
+        with (
+            patch.dict(os.environ, {"FRAISIER_CONFIG": str(tmp_path / "missing.yaml")}),
+            pytest.raises((FileNotFoundError, OSError)),
+        ):
+            _load_config()
+
+
+class TestResolveRunner:
+    def test_resolves_server_from_config(self, minimal_config):
+        with patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}):
+            config = _load_config()
+
+        with patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh:
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+            server, runner = _resolve_runner(config, "production")
+
+        assert server == "prod.example.com"
+        assert runner.host == "prod.example.com"
+
+    def test_raises_for_missing_environment(self, minimal_config):
+        with patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}):
+            config = _load_config()
+
+        with pytest.raises(ValueError, match="not set"):
+            _resolve_runner(config, "staging")
+
+    def test_passes_sudo_password(self, minimal_config):
+        with patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}):
+            config = _load_config()
+
+        with patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh:
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+            _, runner = _resolve_runner(
+                config,
+                "production",
+                use_sudo=True,
+                sudo_password="secret",
+            )
+
+        assert runner.use_sudo is True
+        assert runner.sudo_password == "secret"
+
+
+class TestBootstrapPreflightTool:
+    @pytest.mark.asyncio
+    async def test_returns_check_results(self, minimal_config):
+        from fraisier.preflight import CheckResult, PreflightResult
+
+        mock_result = PreflightResult(
+            server="prod.example.com",
+            checks=[
+                CheckResult(name="SSH connectivity", passed=True),
+                CheckResult(
+                    name="nginx installed",
+                    passed=False,
+                    fix_hint="apt install nginx",
+                ),
+            ],
+        )
+
+        with (
+            patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}),
+            patch("fraisier.mcp_server.PreflightChecker") as mock_pc,
+            patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh,
+        ):
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+            mock_pc.return_value.run_all.return_value = mock_result
+
+            output = await bootstrap_preflight(environment="production")
+
+        assert "SSH connectivity" in output
+        assert "nginx" in output
+        assert "FAIL" in output
+        assert "1 check(s) failed" in output
+
+
+class TestBootstrapServerTool:
+    @pytest.mark.asyncio
+    async def test_runs_bootstrap_without_sudo(self, minimal_config):
+        from fraisier.bootstrap import BootstrapResult, StepResult
+
+        mock_result = BootstrapResult(
+            steps=[StepResult(name="Create deploy user", success=True)]
+        )
+
+        with (
+            patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}),
+            patch("fraisier.mcp_server.ServerBootstrapper") as mock_bs,
+            patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh,
+        ):
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+            mock_bs.return_value.bootstrap.return_value = mock_result
+
+            output = await bootstrap_server(environment="production")
+
+        assert "Create deploy user" in output
+        assert "Bootstrap complete" in output
+
+    @pytest.mark.asyncio
+    async def test_elicits_password_when_sudo(self, minimal_config):
+        from mcp.server.elicitation import AcceptedElicitation
+
+        from fraisier.bootstrap import BootstrapResult, StepResult
+
+        mock_result = BootstrapResult(
+            steps=[StepResult(name="Create deploy user", success=True)]
+        )
+
+        from fraisier.mcp_server import SudoPasswordSchema
+
+        mock_ctx = MagicMock()
+        mock_ctx.elicit = AsyncMock(
+            return_value=AcceptedElicitation(
+                data=SudoPasswordSchema(sudo_password="secret")
+            )
+        )
+
+        with (
+            patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}),
+            patch("fraisier.mcp_server.ServerBootstrapper") as mock_bs,
+            patch("fraisier.mcp_server.SSHRunner") as mock_runner_cls,
+            patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh,
+        ):
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+            mock_bs.return_value.bootstrap.return_value = mock_result
+
+            output = await bootstrap_server(
+                environment="production", sudo=True, ctx=mock_ctx
+            )
+
+        mock_ctx.elicit.assert_called_once()
+        runner_kwargs = mock_runner_cls.call_args[1]
+        assert runner_kwargs["sudo_password"] == "secret"
+        assert runner_kwargs["use_sudo"] is True
+        assert "Bootstrap complete" in output
+
+    @pytest.mark.asyncio
+    async def test_aborts_when_elicitation_declined(self, minimal_config):
+        from mcp.server.elicitation import DeclinedElicitation
+
+        mock_ctx = MagicMock()
+        mock_ctx.elicit = AsyncMock(return_value=DeclinedElicitation())
+
+        with (
+            patch.dict(os.environ, {"FRAISIER_CONFIG": str(minimal_config)}),
+            patch("fraisier.mcp_server.resolve_ssh_config") as mock_ssh,
+        ):
+            from fraisier.ssh_config import SSHHostConfig
+
+            mock_ssh.return_value = SSHHostConfig()
+
+            output = await bootstrap_server(
+                environment="production", sudo=True, ctx=mock_ctx
+            )
+
+        assert "aborted" in output.lower() or "declined" in output.lower()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from fraisier.mcp_server import (
+mcp_available = pytest.importorskip("mcp", reason="mcp package not installed")
+
+from fraisier.mcp_server import (  # noqa: E402
     _load_config,
     _resolve_runner,
     bootstrap_preflight,

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,235 @@
+"""Unit tests for PreflightChecker."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from fraisier.preflight import CheckResult, PreflightChecker, PreflightResult
+from fraisier.runners import SSHRunner
+
+_OK = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _err(stderr: str = "error") -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(1, "cmd", stderr=stderr)
+
+
+@pytest.fixture
+def mock_runner():
+    runner = MagicMock(spec=SSHRunner)
+    runner.run.return_value = _OK
+    runner.host = "prod.example.com"
+    runner.user = "root"
+    runner.port = 22
+    return runner
+
+
+@pytest.fixture
+def checker(mock_runner):
+    return PreflightChecker(runner=mock_runner, deploy_user="fraisier")
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+class TestCheckResult:
+    def test_passed_defaults(self):
+        r = CheckResult(name="test", passed=True)
+        assert r.message == ""
+        assert r.fix_hint == ""
+
+    def test_failed_with_hint(self):
+        r = CheckResult(name="test", passed=False, fix_hint="do this")
+        assert r.passed is False
+        assert r.fix_hint == "do this"
+
+
+class TestPreflightResult:
+    def test_passed_when_all_pass(self):
+        r = PreflightResult(
+            server="example.com",
+            checks=[
+                CheckResult(name="a", passed=True),
+                CheckResult(name="b", passed=True),
+            ],
+        )
+        assert r.passed is True
+        assert r.failed_count == 0
+
+    def test_failed_when_any_fails(self):
+        r = PreflightResult(
+            server="example.com",
+            checks=[
+                CheckResult(name="a", passed=True),
+                CheckResult(name="b", passed=False),
+            ],
+        )
+        assert r.passed is False
+        assert r.failed_count == 1
+
+    def test_failed_count_multiple(self):
+        r = PreflightResult(
+            server="example.com",
+            checks=[
+                CheckResult(name="a", passed=False),
+                CheckResult(name="b", passed=False),
+                CheckResult(name="c", passed=True),
+            ],
+        )
+        assert r.failed_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSSH:
+    def test_passes_when_echo_succeeds(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok("ok")
+        result = checker.check_ssh()
+        assert result.passed is True
+        assert "SSH" in result.name or "ssh" in result.name.lower()
+
+    def test_fails_when_connection_refused(self, checker, mock_runner):
+        mock_runner.run.side_effect = _err("Connection refused")
+        result = checker.check_ssh()
+        assert result.passed is False
+        assert "Connection refused" in result.message
+
+    def test_fails_on_timeout(self, checker, mock_runner):
+        mock_runner.run.side_effect = subprocess.TimeoutExpired("ssh", 10)
+        result = checker.check_ssh()
+        assert result.passed is False
+
+
+class TestCheckSudo:
+    def test_passes_when_passwordless_sudo(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok()
+        result = checker.check_sudo()
+        assert result.passed is True
+
+    def test_fails_when_no_sudo(self, checker, mock_runner):
+        mock_runner.run.side_effect = _err("sudo: a password is required")
+        result = checker.check_sudo()
+        assert result.passed is False
+        assert result.fix_hint != ""
+
+
+class TestCheckSudoPasswordless:
+    def test_passes_when_passwordless(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok()
+        result = checker.check_sudo_passwordless()
+        assert result.passed is True
+
+    def test_fails_when_password_required(self, checker, mock_runner):
+        mock_runner.run.side_effect = _err("sudo: a password is required")
+        result = checker.check_sudo_passwordless()
+        assert result.passed is False
+        assert "visudo" in result.fix_hint or "sudoers" in result.fix_hint
+
+
+class TestCheckPackage:
+    def test_passes_when_installed(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok("/usr/bin/git")
+        result = checker.check_package("git")
+        assert result.passed is True
+
+    def test_fails_when_missing(self, checker, mock_runner):
+        mock_runner.run.side_effect = _err()
+        result = checker.check_package("nginx")
+        assert result.passed is False
+        assert "nginx" in result.fix_hint
+
+
+class TestCheckDiskSpace:
+    def test_passes_with_enough_space(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok(
+            "Filesystem      Size  Used Avail Use% Mounted on\n"
+            "/dev/sda1        50G   30G   18G  63% /\n"
+        )
+        result = checker.check_disk_space()
+        assert result.passed is True
+        assert "18G" in result.message or "18" in result.message
+
+    def test_fails_with_low_space(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok(
+            "Filesystem      Size  Used Avail Use% Mounted on\n"
+            "/dev/sda1        50G   49G    1G  98% /\n"
+        )
+        result = checker.check_disk_space()
+        assert result.passed is False
+
+    def test_fails_on_parse_error(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok("unexpected output")
+        result = checker.check_disk_space()
+        assert result.passed is False
+
+
+class TestCheckPorts:
+    def test_passes_when_ports_free(self, checker, mock_runner):
+        # ss output with no matching ports
+        mock_runner.run.return_value = _ok(
+            "State  Recv-Q Send-Q Local Address:Port\nLISTEN 0      128    0.0.0.0:22\n"
+        )
+        result = checker.check_ports([8000, 8001])
+        assert result.passed is True
+
+    def test_fails_when_port_in_use(self, checker, mock_runner):
+        mock_runner.run.return_value = _ok(
+            "State  Recv-Q Send-Q Local Address:Port\n"
+            "LISTEN 0      128    0.0.0.0:8000\n"
+            "LISTEN 0      128    0.0.0.0:8001\n"
+        )
+        result = checker.check_ports([8000, 8001])
+        assert result.passed is False
+        assert "8000" in result.message or "8001" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Full preflight run
+# ---------------------------------------------------------------------------
+
+
+class TestRunAll:
+    def test_collects_all_results(self, checker, mock_runner):
+        """run_all() should return results for every check, not abort early."""
+        mock_runner.run.return_value = _ok(
+            "Filesystem      Size  Used Avail Use% Mounted on\n"
+            "/dev/sda1        50G   30G   18G  63% /\n"
+        )
+        result = checker.run_all()
+        assert isinstance(result, PreflightResult)
+        assert result.server == "prod.example.com"
+        # At minimum: ssh, sudo, passwordless, git, nginx, disk
+        assert len(result.checks) >= 6
+
+    def test_continues_after_failure(self, checker, mock_runner):
+        """Even when SSH fails, other checks are still attempted."""
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise subprocess.CalledProcessError(
+                    1, "ssh", stderr="Connection refused"
+                )
+            return _ok(
+                "Filesystem      Size  Used Avail Use% Mounted on\n"
+                "/dev/sda1        50G   30G   18G  63% /\n"
+            )
+
+        mock_runner.run.side_effect = side_effect
+        result = checker.run_all()
+        # Should have more than 1 check even though first failed
+        assert len(result.checks) >= 6

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -388,6 +388,104 @@ class TestSSHRunnerSudo:
         assert "tar xzf" in remote_cmd
 
 
+class TestSSHRunnerSudoPassword:
+    """Tests for SSHRunner with sudo_password (sudo -S via stdin)."""
+
+    def test_run_uses_sudo_s_when_password_set(self):
+        runner = SSHRunner(host="h", user="u", use_sudo=True, sudo_password="secret")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.run(["useradd", "--system", "deploy"])
+
+        remote = mock_run.call_args[0][0][-1]
+        assert "sudo -S sh -c" in remote
+
+    def test_run_pipes_password_via_stdin(self):
+        runner = SSHRunner(host="h", user="u", use_sudo=True, sudo_password="secret")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.run(["echo", "hi"])
+
+        kwargs = mock_run.call_args[1]
+        assert kwargs["input"] == "secret\n"
+        assert kwargs["capture_output"] is True
+
+    def test_run_without_password_uses_plain_sudo(self):
+        runner = SSHRunner(host="h", user="u", use_sudo=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.run(["echo", "hi"])
+
+        remote = mock_run.call_args[0][0][-1]
+        assert "sudo sh -c" in remote
+        assert "sudo -S" not in remote
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("capture_output") is True
+
+    def test_upload_sudo_password_pipes_to_mv(self, tmp_path):
+        runner = SSHRunner(host="h", user="u", use_sudo=True, sudo_password="secret")
+        local_file = tmp_path / "fraises.yaml"
+        local_file.write_text("name: test\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            runner.upload(local_file, "/opt/fraisier/fraises.yaml")
+
+        # The mv call (second call) should use sudo -S and pipe password
+        mv_call = mock_run.call_args_list[1]
+        remote_cmd = mv_call[0][0][-1]
+        assert "sudo -S sh -c" in remote_cmd
+        kwargs = mv_call[1]
+        assert kwargs["input"] == "secret\n"
+
+    def test_upload_tree_sudo_password_uses_two_step(self, tmp_path):
+        runner = SSHRunner(host="h", user="u", use_sudo=True, sudo_password="secret")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "file.txt").write_text("hello")
+
+        fake_ssh = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"", stderr=b""
+        )
+        fake_ssh_text = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        with (
+            patch("subprocess.Popen") as mock_popen,
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.stdout = MagicMock()
+            mock_proc.returncode = 0
+            mock_proc.communicate.return_value = (b"", b"")
+            mock_popen.return_value = mock_proc
+            mock_run.side_effect = [fake_ssh, fake_ssh_text]
+
+            runner.upload_tree(src, "/tmp/remote")
+
+        # First call: tar to temp dir (no sudo)
+        first_ssh = mock_run.call_args_list[0][0][0]
+        first_remote = first_ssh[-1]
+        assert "sudo" not in first_remote
+        assert "/tmp/.fraisier-upload-tree" in first_remote
+
+        # Second call: sudo -S mv into place
+        second_ssh = mock_run.call_args_list[1][0][0]
+        second_remote = second_ssh[-1]
+        assert "sudo -S sh -c" in second_remote
+        second_kwargs = mock_run.call_args_list[1][1]
+        assert second_kwargs["input"] == "secret\n"
+
+
 class TestRunnerFromConfig:
     """Tests for runner_from_config factory."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -478,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.4.7"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -509,6 +518,9 @@ dev = [
 graphql = [
     { name = "strawberry-graphql" },
 ]
+mcp = [
+    { name = "mcp", extra = ["cli"] },
+]
 postgres = [
     { name = "psycopg", extra = ["binary"] },
 ]
@@ -523,6 +535,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0,<1.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.9.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'all-databases'", specifier = ">=3.1.0,<4.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.1.0,<4.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1.0,<4.0" },
@@ -536,7 +549,7 @@ requires-dist = [
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "uvicorn", specifier = ">=0.27.0,<1.0" },
 ]
-provides-extras = ["all-databases", "dev", "graphql", "postgres"]
+provides-extras = ["all-databases", "dev", "graphql", "postgres", "mcp"]
 
 [[package]]
 name = "graphql-core"
@@ -585,6 +598,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +634,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -698,6 +747,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -933,12 +1013,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1011,6 +1119,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]
@@ -1088,6 +1205,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,6 +1244,114 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1174,6 +1413,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #93

- **`bootstrap-preflight` command**: read-only server validation (SSH, sudo, packages, disk space) with actionable fix hints — reports all issues at once, no early abort
- **`--become-password-command`**: shell escape hatch for password managers (`op read`, `pass show`, `bw get`, etc.) — follows the Git/Docker/AWS CLI pattern of delegating to an arbitrary command
- **`--ask-become-pass` / `-K`**: interactive sudo password prompt (Ansible's `-K` pattern)
- **`sudo -S` support in SSHRunner**: pipes password via stdin; `upload_tree()` uses two-step temp-dir strategy when password is needed
- **MCP server** (`fraisier-mcp`): FastMCP server exposing `bootstrap_preflight` and `bootstrap_server` tools with form-mode elicitation for secure sudo password prompt in Claude Code

### Password resolution order
1. `--become-password-command` CLI flag
2. `bootstrap.become_password_command` in `fraises.yaml`
3. `--ask-become-pass` interactive prompt
4. MCP elicitation (when running inside Claude Code)

## Test plan
- [x] 2228 tests pass (53 new), 0 failures
- [x] Lints clean (`ruff check` + `ruff format`)
- [ ] Manual: `fraisier bootstrap-preflight -e production` against a test server
- [ ] Manual: `fraisier bootstrap -e production --become-password-command "echo test"`
- [ ] Manual: `fraisier bootstrap -e production -K` with interactive prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)