### PR TITLE
fix(bootstrap): pin server-side fraisier to client version — v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.12] - 2026-04-04
+
+### Fixed
+- **Bootstrap step 4 always pins server-side fraisier to the client version** (#101) — `uv tool install`
+  was skipping the install if fraisier was already present on the server, leaving a stale version.
+  It now runs `uv tool install --force fraisier==<client_version>` unconditionally, ensuring the
+  server and client are always in sync.
+
+---
+
 ## [0.4.10] - 2026-04-04
 
 ### Fixed

--- a/fraisier/__init__.py
+++ b/fraisier/__init__.py
@@ -17,5 +17,5 @@ Usage:
     fraisier status <fraise> <environment>  # Check fraise status
 """
 
-__version__ = "0.4.10"
+__version__ = "0.4.12"
 __all__ = ["__version__"]

--- a/fraisier/bootstrap.py
+++ b/fraisier/bootstrap.py
@@ -193,6 +193,8 @@ class ServerBootstrapper:
         )
 
     def _install_fraisier(self) -> StepResult:
+        from fraisier import __version__
+
         uv_path = f"/home/{self.deploy_user}/.local/bin/uv"
         return self._run_remote(
             "Install fraisier for deploy user",
@@ -203,16 +205,7 @@ class ServerBootstrapper:
                 "-H",
                 "bash",
                 "-c",
-                f"{uv_path} tool install fraisier",
-            ],
-            already_done_cmd=[
-                "sudo",
-                "-u",
-                self.deploy_user,
-                "-H",
-                "bash",
-                "-c",
-                f"{uv_path} tool list 2>/dev/null | grep -q fraisier",
+                f"{uv_path} tool install --force fraisier=={__version__}",
             ],
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.11"
+version = "0.4.12"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -235,17 +235,20 @@ class TestInstallUv:
 
 
 class TestInstallFraisier:
-    def test_skips_when_fraisier_installed(self, bootstrapper, mock_runner):
-        step = bootstrapper._install_fraisier()
-        assert step.success is True
-        assert step.already_done is True
+    def test_always_installs_pinned_version(self, bootstrapper, mock_runner):
+        from fraisier import __version__
 
-    def test_installs_when_missing(self, bootstrapper, mock_runner):
-        mock_runner.run.side_effect = [_err(), _OK]
         step = bootstrapper._install_fraisier()
         assert step.success is True
         install_cmd = mock_runner.run.call_args[0][0]
-        assert any("fraisier" in part for part in install_cmd)
+        cmd_str = " ".join(install_cmd)
+        assert "--force" in cmd_str
+        assert f"fraisier=={__version__}" in cmd_str
+
+    def test_failure_returns_failed_step(self, bootstrapper, mock_runner):
+        mock_runner.run.side_effect = _err("permission denied")
+        step = bootstrapper._install_fraisier()
+        assert step.success is False
 
 
 class TestCreateDirectories:

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.4.11"
+version = "0.4.12"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bootstrap step 4 now runs `uv tool install --force fraisier==<client_version>` unconditionally, fixing the version mismatch described in #101
- Removes the `already_done_cmd` skip check that was leaving stale fraisier versions on the server
- Bumps to v0.4.12 and syncs `__init__.py` (was behind at 0.4.10)

## Test plan

- [x] `test_always_installs_pinned_version` — asserts `--force` and `fraisier==<version>` are in the install command
- [x] `test_failure_returns_failed_step` — covers the error path
- [x] All 50 bootstrap tests pass, lints clean

## Beta test result

Beta tester confirmed steps 1–9 all pass cleanly. Step 10 was failing on 0.4.11 because the server was still running 0.4.11 (missing the `ENVIRONMENT` argument for `validate-setup`). Once 0.4.12 is published and bootstrap re-runs, step 4 will install 0.4.12 on the server and the full 10/10 will pass.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)