### PR TITLE
fix(bootstrap): fix double-sudo stdin failure and stale version install (#103, #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.14] - 2026-04-04
+
+### Fixed
+- **Bootstrap double-sudo fails silently for steps 4 and 10** (#104) — when using `--sudo`
+  with a non-root SSH user, the outer `sudo -S` consumed the password from stdin, leaving the
+  inner `sudo -u <deploy_user>` with no stdin to read from. Steps 3, 4, and 10 now use
+  `sudo -n -u` (non-interactive), which prevents any stdin read since root needs no password
+  to switch users.
+- **Bootstrap step 4 installs wrong fraisier version on server** (#103) — `_install_fraisier`
+  read the version from the hardcoded `__init__.__version__` string, which could be stale
+  relative to `pyproject.toml`. It now uses `importlib.metadata.version("fraisier")`, which
+  always reflects the actually-installed package version.
+
+---
+
 ## [0.4.13] - 2026-04-04
 
 ### Fixed

--- a/fraisier/__init__.py
+++ b/fraisier/__init__.py
@@ -17,5 +17,5 @@ Usage:
     fraisier status <fraise> <environment>  # Check fraise status
 """
 
-__version__ = "0.4.12"
+__version__ = "0.4.14"
 __all__ = ["__version__"]

--- a/fraisier/bootstrap.py
+++ b/fraisier/bootstrap.py
@@ -7,6 +7,7 @@ import shlex
 import subprocess
 import tempfile
 from dataclasses import dataclass, field
+from importlib.metadata import version as importlib_version
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -182,6 +183,7 @@ class ServerBootstrapper:
             "Install uv for deploy user",
             [
                 "sudo",
+                "-n",
                 "-u",
                 self.deploy_user,
                 "-H",
@@ -193,19 +195,19 @@ class ServerBootstrapper:
         )
 
     def _install_fraisier(self) -> StepResult:
-        from fraisier import __version__
-
+        client_version = importlib_version("fraisier")
         uv_path = f"/home/{self.deploy_user}/.local/bin/uv"
         return self._run_remote(
             "Install fraisier for deploy user",
             [
                 "sudo",
+                "-n",
                 "-u",
                 self.deploy_user,
                 "-H",
                 "bash",
                 "-c",
-                f"{uv_path} tool install --force fraisier=={__version__}",
+                f"{uv_path} tool install --force fraisier=={client_version}",
             ],
         )
 
@@ -327,6 +329,7 @@ class ServerBootstrapper:
                 f"Validate setup ({fraise})",
                 [
                     "sudo",
+                    "-n",
                     "-u",
                     self.deploy_user,
                     "-H",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.13"
+version = "0.4.14"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -233,21 +233,35 @@ class TestInstallUv:
         check_cmd = mock_runner.run.call_args[0][0]
         assert any("myapp_deploy" in part for part in check_cmd)
 
+    def test_uses_noninteractive_sudo(self, bootstrapper, mock_runner):
+        """Inner sudo must use -n to avoid consuming stdin when outer sudo is active."""
+        mock_runner.run.side_effect = [_err(), _OK]
+        bootstrapper._install_uv()
+        install_cmd = mock_runner.run.call_args[0][0]
+        assert install_cmd[:3] == ["sudo", "-n", "-u"]
+
 
 class TestInstallFraisier:
     def test_always_installs_pinned_version(self, bootstrapper, mock_runner):
-        from fraisier import __version__
-
-        step = bootstrapper._install_fraisier()
+        with patch("fraisier.bootstrap.importlib_version", return_value="1.2.3"):
+            step = bootstrapper._install_fraisier()
         assert step.success is True
         install_cmd = mock_runner.run.call_args[0][0]
         cmd_str = " ".join(install_cmd)
         assert "--force" in cmd_str
-        assert f"fraisier=={__version__}" in cmd_str
+        assert "fraisier==1.2.3" in cmd_str
+
+    def test_uses_noninteractive_sudo(self, bootstrapper, mock_runner):
+        """Inner sudo must use -n to avoid consuming stdin when outer sudo is active."""
+        with patch("fraisier.bootstrap.importlib_version", return_value="0.4.14"):
+            bootstrapper._install_fraisier()
+        install_cmd = mock_runner.run.call_args[0][0]
+        assert install_cmd[:3] == ["sudo", "-n", "-u"]
 
     def test_failure_returns_failed_step(self, bootstrapper, mock_runner):
-        mock_runner.run.side_effect = _err("permission denied")
-        step = bootstrapper._install_fraisier()
+        with patch("fraisier.bootstrap.importlib_version", return_value="0.4.14"):
+            mock_runner.run.side_effect = _err("permission denied")
+            step = bootstrapper._install_fraisier()
         assert step.success is False
 
 
@@ -441,6 +455,12 @@ class TestValidate:
         assert "nonexistent" in step.error
         mock_runner.run.assert_not_called()
 
+    def test_uses_noninteractive_sudo(self, bootstrapper, mock_runner):
+        """Inner sudo must use -n to avoid consuming stdin when outer sudo is active."""
+        bootstrapper._validate()
+        cmd = mock_runner.run.call_args[0][0]
+        assert cmd[:3] == ["sudo", "-n", "-u"]
+
     def test_stops_at_first_failing_fraise(self, mock_runner, tmp_path):
         p = tmp_path / "fraises.yaml"
         p.write_text(_TWO_FRAISE_YAML)
@@ -465,14 +485,16 @@ class TestBootstrapFlow:
     def test_dry_run_succeeds_without_any_runner_calls(
         self, dry_bootstrapper, mock_runner
     ):
-        result = dry_bootstrapper.bootstrap()
+        with patch("fraisier.bootstrap.importlib_version", return_value="0.4.14"):
+            result = dry_bootstrapper.bootstrap()
         assert result.success is True
         mock_runner.run.assert_not_called()
         mock_runner.upload.assert_not_called()
         mock_runner.upload_tree.assert_not_called()
 
     def test_dry_run_produces_ten_steps(self, dry_bootstrapper):
-        result = dry_bootstrapper.bootstrap()
+        with patch("fraisier.bootstrap.importlib_version", return_value="0.4.14"):
+            result = dry_bootstrapper.bootstrap()
         assert len(result.steps) == 10
 
     def test_aborts_after_first_failure(self, bootstrapper, mock_runner):

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.4.12"
+version = "0.4.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **#104** — Steps 3, 4, and 10 used `sudo -u <deploy_user>` internally. When running `bootstrap --sudo` with a become password, the outer `sudo -S` consumed the password from stdin, leaving the inner `sudo` with nothing to read — causing a silent failure on step 4 and a visible failure on step 10. Fixed by using `sudo -n -u` (non-interactive): root needs no password to switch users, so `-n` simply prevents any stdin consumption.
- **#103** — `_install_fraisier` read the pinned version from `fraisier.__version__` (a hardcoded string in `__init__.py`), which was stale. It now uses `importlib.metadata.version("fraisier")`, which always reflects the installed package version as declared in `pyproject.toml`.
- Bumps to **v0.4.14**.

## Test plan

- [ ] `pytest tests/test_bootstrap.py` passes (53 tests)
- [ ] `fraisier bootstrap -e <env> --ssh-user <non-root> -K` completes all 10 steps without silent failures
- [ ] Server receives the correct fraisier version after step 4