### PR TITLE
Release v0.5.25

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.5.24"
+version = "0.5.25"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Prepare release v0.5.25 with fixes for health command issues.

## Changes
- Fix #130: fraisier health only shows last environment
- Fix #131: URL column strips scheme for remote services  
- Fix #132: Add Environment column to health table

## Release Notes
- Version bumped to 0.5.25
- Changelog updated
- GitHub release created

## Verification
✅ Lints pass
✅ Type checks (existing issues unrelated)
✅ All changes committed and tagged