### PR TITLE
fix(dbops): inject database from admin_url for all PG CLI tools

### DIFF
--- a/fraisier/bootstrap_freebsd.py
+++ b/fraisier/bootstrap_freebsd.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from fraisier.bootstrap import ServerBootstrapper, StepResult
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from fraisier.config import FraisierConfig
     from fraisier.runners import SSHRunner
 
@@ -25,7 +27,7 @@ class FreebsdBootstrapper(ServerBootstrapper):
         config: FraisierConfig,
         environment: str,
         runner: SSHRunner,
-        fraises_yaml_path: str,
+        fraises_yaml_path: Path,
         dry_run: bool = False,
         verbose: bool = False,
     ) -> None:

--- a/fraisier/dbops/operations.py
+++ b/fraisier/dbops/operations.py
@@ -15,6 +15,16 @@ from urllib.parse import urlparse
 
 from fraisier.dbops._validation import validate_pg_identifier
 
+# PostgreSQL CLI tools that accept a database/maintenance-db flag.
+# psql and pg_restore use -d; createdb and dropdb use --maintenance-db.
+# pg_dump takes the database as a positional argument — no flag needed.
+_DB_FLAG_FOR_TOOL: dict[str, str] = {
+    "psql": "-d",
+    "pg_restore": "-d",
+    "createdb": "--maintenance-db",
+    "dropdb": "--maintenance-db",
+}
+
 
 def _parse_connection_flags(connection_url: str) -> tuple[list[str], dict[str, str]]:
     """Extract CLI flags and env vars from a PostgreSQL connection URL.
@@ -46,9 +56,21 @@ def _pg_cmd(
     Host, port, user and password are taken from the URL and injected
     into the command (``-h -p -U``) and environment (``PGPASSWORD``).
 
+    The database path from the URL is also forwarded when the caller has
+    not already specified one: ``-d`` for psql/pg_restore,
+    ``--maintenance-db`` for createdb/dropdb.
+
     Returns (exit_code, stdout, stderr).
     """
     conn_flags, extra_env = _parse_connection_flags(connection_url)
+
+    db_flag = _DB_FLAG_FOR_TOOL.get(cmd[0])
+    if db_flag and db_flag not in cmd:
+        parsed = urlparse(connection_url)
+        db = parsed.path.lstrip("/")
+        if db:
+            conn_flags = [*conn_flags, db_flag, db]
+
     full_cmd = [cmd[0], *conn_flags, *cmd[1:]]
     run_env = {**os.environ, **extra_env} if extra_env else None
 

--- a/fraisier/service_managers/systemd.py
+++ b/fraisier/service_managers/systemd.py
@@ -102,7 +102,7 @@ class SystemdServiceManager(ServiceManager):
         service_name: str = "",
         timeout: int = 60,
         check: bool = True,
-    ) -> types.SimpleNamespace:
+    ) -> types.SimpleNamespace | subprocess.CompletedProcess[str]:
         """Run a systemctl command via socket, wrapper, or sudo.
 
         Returns the result mimicking subprocess.CompletedProcess.

--- a/tests/test_dbops_operations.py
+++ b/tests/test_dbops_operations.py
@@ -39,6 +39,8 @@ class TestPgCmd:
             "5432",
             "-U",
             "postgres",
+            "-d",
+            "mydb",
             "-c",
             "SELECT 1",
         ]
@@ -73,6 +75,97 @@ class TestPgCmd:
         env = mock_run.call_args.kwargs["env"]
         assert env is not None
         assert env["PGPASSWORD"] == "pass"
+
+
+class TestPgCmdDatabaseInjection:
+    """Test that _pg_cmd injects the database from the URL (#185)."""
+
+    def test_injects_db_from_url_when_no_d_flag(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["psql", "-c", "SELECT 1"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
+
+    def test_does_not_inject_db_when_d_already_present(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["psql", "-d", "mydb", "-c", "SELECT 1"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert cmd.count("-d") == 1
+        assert cmd[cmd.index("-d") + 1] == "mydb"
+
+    def test_no_db_injection_when_url_path_empty(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["psql", "-c", "SELECT 1"],
+                connection_url="postgresql://user@localhost/",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "-d" not in cmd
+
+    def test_injects_db_from_socket_url(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["psql", "-c", "SELECT 1"],
+                connection_url="postgresql:///postgres?host=/var/run/postgresql",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
+
+    def test_injects_maintenance_db_for_createdb(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["createdb", "newdb"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "--maintenance-db" in cmd
+        assert cmd[cmd.index("--maintenance-db") + 1] == "postgres"
+
+    def test_injects_maintenance_db_for_dropdb(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["dropdb", "--if-exists", "olddb"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "--maintenance-db" in cmd
+        assert cmd[cmd.index("--maintenance-db") + 1] == "postgres"
+
+    def test_does_not_inject_maintenance_db_when_already_present(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["createdb", "--maintenance-db", "template1", "newdb"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert cmd.count("--maintenance-db") == 1
+        assert cmd[cmd.index("--maintenance-db") + 1] == "template1"
+
+    def test_no_injection_for_pg_dump(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            _pg_cmd(
+                ["pg_dump", "-Fc", "mydb"],
+                connection_url="postgresql://user@localhost/postgres",
+            )
+        cmd = mock_run.call_args[0][0]
+        assert "-d" not in cmd
+        assert "--maintenance-db" not in cmd
 
 
 class TestRunPsql:
@@ -142,6 +235,15 @@ class TestCheckDbExists:
             )
             assert check_db_exists("mydb", connection_url=_TEST_URL) is False
 
+    def test_check_db_exists_uses_url_database(self):
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="1\n", stderr="")
+            check_db_exists("mydb", connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
+
     def test_check_db_exists_rejects_injection(self):
         with pytest.raises(ValueError, match="Invalid database name"):
             check_db_exists("mydb; DROP TABLE users", connection_url=_TEST_URL)
@@ -159,6 +261,15 @@ class TestTerminateBackends:
         cmd = mock_run.call_args[0][0]
         assert "psql" in cmd
         assert any("pg_terminate_backend" in arg for arg in cmd)
+
+    def test_terminate_backends_uses_url_database(self):
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="t\n", stderr="")
+            terminate_backends("mydb", connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
 
     def test_terminate_backends_rejects_injection(self):
         with pytest.raises(ValueError, match="Invalid database name"):
@@ -207,6 +318,26 @@ class TestDropDb:
         sql = cmd[sql_index]
         assert "DROP DATABASE IF EXISTS testdb WITH (FORCE)" in sql
 
+    def test_drop_db_force_uses_url_database(self):
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            drop_db("testdb", force=True, connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "psql"
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
+
+    def test_drop_db_simple_uses_maintenance_db(self):
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            drop_db("testdb", connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "dropdb"
+        assert "--maintenance-db" in cmd
+        assert cmd[cmd.index("--maintenance-db") + 1] == "postgres"
+
     def test_drop_db_rejects_injection(self):
         with pytest.raises(ValueError, match="Invalid database name"):
             drop_db("test; rm -rf /", connection_url=_TEST_URL)
@@ -245,6 +376,16 @@ class TestCreateDb:
         assert "appuser" in cmd
         assert "newdb" in cmd
         assert "sudo" not in cmd
+
+    def test_create_db_uses_maintenance_db(self):
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            create_db("newdb", connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "createdb"
+        assert "--maintenance-db" in cmd
+        assert cmd[cmd.index("--maintenance-db") + 1] == "postgres"
 
     def test_create_db_rejects_bad_template(self):
         with pytest.raises(ValueError, match="Invalid template name"):

--- a/tests/test_dbops_templates.py
+++ b/tests/test_dbops_templates.py
@@ -90,6 +90,22 @@ class TestConnectionUrlPassthrough:
         assert all(u == _TEST_URL for u in captured_urls)
 
 
+class TestCleanupTemplatesDatabaseInjection:
+    """Verify cleanup_templates gets -d from the URL (#185)."""
+
+    def test_cleanup_templates_uses_url_database(self, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        url = "postgresql://user@localhost/postgres"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            cleanup_templates("mydb", connection_url=url)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "psql"
+        assert "-d" in cmd
+        assert cmd[cmd.index("-d") + 1] == "postgres"
+
+
 class TestCleanupTemplatesSQL:
     """Verify cleanup_templates uses parameterized SQL, not f-string interpolation."""
 

--- a/tests/test_ship_pr.py
+++ b/tests/test_ship_pr.py
@@ -23,6 +23,7 @@ class TestGetPRBackend:
 
     def test_unsupported_stores_provider_name(self):
         backend = get_pr_backend("gitea")
+        assert isinstance(backend, UnimplementedPRBackend)
         assert backend._provider == "gitea"
 
 

--- a/tests/test_zfs_config.py
+++ b/tests/test_zfs_config.py
@@ -12,13 +12,7 @@ class TestZFSConfig:
 
     def test_zfs_config_required_fields(self):
         """Test ZFS config with all required fields."""
-        config_data = {
-            "enabled": True,
-            "pool": "zroot",
-            "data_dataset": "pgsql/data",
-        }
-
-        config = ZFSConfig(**config_data)
+        config = ZFSConfig(enabled=True, pool="zroot", data_dataset="pgsql/data")
 
         assert config.enabled is True
         assert config.pool == "zroot"
@@ -30,17 +24,15 @@ class TestZFSConfig:
 
     def test_zfs_config_all_fields(self):
         """Test ZFS config with all optional fields set."""
-        config_data = {
-            "enabled": True,
-            "pool": "tank",
-            "data_dataset": "app/data",
-            "snapshot_prefix": "prod_backup_",
-            "clone_prefix": "deploy_",
-            "max_snapshot_age_days": 14,
-            "snapshot_retention": 20,
-        }
-
-        config = ZFSConfig(**config_data)
+        config = ZFSConfig(
+            enabled=True,
+            pool="tank",
+            data_dataset="app/data",
+            snapshot_prefix="prod_backup_",
+            clone_prefix="deploy_",
+            max_snapshot_age_days=14,
+            snapshot_retention=20,
+        )
 
         assert config.enabled is True
         assert config.pool == "tank"
@@ -52,13 +44,7 @@ class TestZFSConfig:
 
     def test_zfs_config_defaults(self):
         """Test ZFS config defaults when not specified."""
-        config_data = {
-            "enabled": False,
-            "pool": "zroot",
-            "data_dataset": "data",
-        }
-
-        config = ZFSConfig(**config_data)
+        config = ZFSConfig(enabled=False, pool="zroot", data_dataset="data")
 
         assert config.enabled is False
         assert config.pool == "zroot"

--- a/tests/test_zfs_snapshots.py
+++ b/tests/test_zfs_snapshots.py
@@ -157,11 +157,14 @@ class TestZFSSnapshotOperations:
             MagicMock(returncode=0, stdout="", stderr=""),  # Second call succeeds
         ]
 
-        self.zfs_ops._generate_snapshot_name = MagicMock(
+        mock_gen = MagicMock(
             side_effect=["snap_20220101_120000", "snap_20220101_120001"]
         )
 
-        with patch("fraisier.zfs.operations.time.sleep") as mock_sleep:
+        with (
+            patch("fraisier.zfs.operations.time.sleep") as mock_sleep,
+            patch.object(self.zfs_ops, "_generate_snapshot_name", mock_gen),
+        ):
             result = self.zfs_ops.create_snapshot("zroot/data")
 
             assert result == "zroot/data@snap_20220101_120001"
@@ -180,11 +183,12 @@ class TestZFSSnapshotOperations:
             stderr="cannot create snapshot 'zroot/data@snap_20220101_120000': dataset already exists",
         )
 
-        self.zfs_ops._generate_snapshot_name = MagicMock(
-            return_value="snap_20220101_120000"
-        )
+        mock_gen = MagicMock(return_value="snap_20220101_120000")
 
-        with patch("fraisier.zfs.operations.time.sleep"):
+        with (
+            patch("fraisier.zfs.operations.time.sleep"),
+            patch.object(self.zfs_ops, "_generate_snapshot_name", mock_gen),
+        ):
             with pytest.raises(ZFSOperationFailedError):
                 self.zfs_ops.create_snapshot("zroot/data")
 


### PR DESCRIPTION
## Summary

- `_pg_cmd` now extracts the database path from `connection_url` and injects `-d <db>` (for psql/pg_restore) or `--maintenance-db <db>` (for createdb/dropdb) when the caller hasn't already specified one. A `_DB_FLAG_FOR_TOOL` lookup table makes the mapping explicit.
- Fixes 6 affected call sites: `terminate_backends`, `drop_db` (both force modes), `check_db_exists`, `create_db`, and `prune_templates` — all were failing with `FATAL: database "<unix-user>" does not exist` when the deploy user had no matching PostgreSQL database.
- Resolves all pre-existing `ty` type-checking errors across the codebase (bootstrap_freebsd Path type, systemd return type, test type narrowing).

## Test plan

- [x] 8 unit tests in `TestPgCmdDatabaseInjection` covering: psql `-d` injection, no double-injection when `-d` present, empty path, socket URLs, createdb/dropdb `--maintenance-db`, no injection for pg_dump
- [x] 6 integration tests across `TestCheckDbExists`, `TestTerminateBackends`, `TestDropDb`, `TestCreateDb`, `TestCleanupTemplatesDatabaseInjection`
- [x] All 2994 existing tests pass
- [x] `ty check` — zero errors
- [x] `ruff check` + `ruff format` — clean

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)