### PR TITLE
release: v0.16.4 — stamp template DB with build-time app_version (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.4] - 2026-05-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Template database version stamping** ([#198](https://github.com/fraiseql/fraisier/issues/198)). `RebuildStrategy` now writes a build-time version stamp into the source database's `public.tb_version.app_version` immediately before cloning the template. The atomic `CREATE DATABASE … TEMPLATE …` carries the stamp into the template, so downstream consumers (e.g. a reseed endpoint) can read `tb_version.app_version` from the template and reject reseeds from stale templates.
+  - The version is auto-discovered from `<project>/version.json` (preferred) or `<project>/pyproject.toml`. No `fraises.yaml` change is required for standard projects.
+  - New optional `database.app_version` key in `fraises.yaml` to override auto-discovery. Invalid values (anything outside `[A-Za-z0-9._+\-]`, including PEP 440 epoch versions like `1!2.3.4`) cause `RebuildStrategy` to fail loudly at construction with a `ValueError` so typos do not silently produce unstamped templates.
+  - The stamp is best-effort: if no version is resolvable, if `tb_version` is missing, or if psql returns a non-zero exit, fraisier logs a warning and the rebuild succeeds normally — the protection is fail-safe on the consumer side.
+  - **Requires `public.tb_version` to contain at least one row.** The UPDATE has no WHERE clause and would silently affect zero rows on an empty table; fraisier detects this case (`"UPDATE 0"` in psql stdout) and emits a distinct warning ("`tb_version` is empty; template will be unstamped") instead of logging false-positive success. Projects must seed `tb_version` with one row as part of their schema for the stamp to take effect.
+  - The race against a reconnecting app overwriting the stamp between commit and clone is closed by a `terminate_backends → stamp → terminate_backends → create_db(template, template=source)` window inside the rebuild's `create_template` block. `CREATE DATABASE … TEMPLATE …` itself fails closed if any backend slipped through.
+
+### Upgrade notes
+
+- Templates created by earlier fraisier versions are not stamped. Consumers that strictly reject unstamped templates will refuse reseeds from these pre-existing templates until the next rebuild. Operators should either trigger a rebuild after upgrade, or implement a grace period in their consumer that treats a missing stamp as "unknown" rather than "stale" during the cutover.
+
 ## [0.16.3] - 2026-05-18
 
 ### Fixed

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -315,6 +315,99 @@ fraisier db migrate my_api -e production
 fraisier db migrate my_api -e production -d down
 ```
 
+### Rebuild strategy: template version stamp
+
+When `database.strategy: rebuild` and `database.create_template: true`, fraisier
+writes the build-time application version into the source DB's
+`public.tb_version.app_version` column immediately **before** cloning the
+template. The atomic `CREATE DATABASE … TEMPLATE …` carries the stamp into the
+template, so a downstream "reseed from template" endpoint can verify that the
+template matches the running application before restoring.
+
+The stamped version is resolved from, in order:
+
+1. `database.app_version` in `fraises.yaml` (explicit override; rarely needed).
+   An invalid value here (anything outside `[A-Za-z0-9._+\-]`, including PEP 440
+   epoch forms like `1!2.3.4`) is rejected at construction with a `ValueError`
+   — typos are not silently accepted.
+2. `<app_path>/version.json` `version` field (preferred — written by the
+   deployer).
+3. `<app_path>/pyproject.toml` `[project].version` (fallback).
+
+If none resolve, or if `public.tb_version` does not exist, or if `tb_version`
+exists but contains zero rows, fraisier logs a warning and continues without
+stamping. The protection is fail-safe: a missing or mismatched stamp causes
+the *consumer* to refuse a reseed, not fraisier to refuse a rebuild.
+
+**Schema requirement**: the stamp UPDATE has no WHERE clause and will silently
+no-op on an empty `tb_version`. Projects must seed `tb_version` with at least
+one row as part of their schema for the stamp to take effect. Fraisier emits
+a distinct warning (`"tb_version is empty …"`) in this case so the
+misconfiguration is visible in build logs.
+
+**Upgrade note**: templates built by fraisier versions before this feature
+shipped are unstamped. Consumers should either expect a rebuild after upgrade,
+or treat missing stamps as "unknown" during a cutover window rather than
+rejecting outright.
+
+#### Consumer-side check (worked example)
+
+The stamp lives in the template database, so the consumer must open a
+connection targeting the template name — there is no asyncpg API for switching
+databases on an existing connection. The example uses plain `asyncpg.connect`
+against a DSN whose path is the template name:
+
+```python
+import asyncpg
+from urllib.parse import urlparse, urlunparse
+
+
+def _dsn_for_db(base_dsn: str, db_name: str) -> str:
+    parsed = urlparse(base_dsn)
+    return urlunparse(parsed._replace(path=f"/{db_name}"))
+
+
+async def reseed_endpoint(
+    app_version: str,
+    template_name: str,
+    base_dsn: str,
+) -> None:
+    conn = await asyncpg.connect(_dsn_for_db(base_dsn, template_name))
+    try:
+        stamped = await conn.fetchval(
+            "SELECT app_version FROM public.tb_version LIMIT 1"
+        )
+    finally:
+        await conn.close()
+
+    if stamped is None:
+        # Either the template was built by a pre-stamping fraisier version,
+        # or the project's tb_version is empty. Decide policy:
+        # - Strict: reject and require a rebuild.
+        # - Lenient (cutover): accept, log a warning.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Template {template_name} has no version stamp. "
+                f"Rebuild the template before reseeding."
+            ),
+        )
+    if stamped != app_version:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Refusing to reseed: template {template_name} is stamped "
+                f"with app_version={stamped!r} but the running app is "
+                f"{app_version!r}. Rebuild before reseeding."
+            ),
+        )
+    # ... proceed with reseed ...
+```
+
+Projects using a connection pool can replace the bare `asyncpg.connect` with
+their pool's per-DB acquisition pattern (e.g. a registry of pools keyed by
+database name) — the SQL is the same.
+
 ---
 
 ## Multi-Environment Setup

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -67,6 +67,8 @@ fraises:
           name: myapp_development
           strategy: rebuild  # drop and recreate (dev only!)
           # admin_url: postgresql://postgres@/postgres?host=/var/run/postgresql  # for DROP/CREATE DB
+          # create_template: true   # snapshot the rebuilt DB as template_<name> for fast reseeds
+          # app_version: "1.2.3"    # optional override; auto-discovered from version.json / pyproject.toml otherwise
         health_check:
           url: https://api.myapp.dev/health
           timeout: 30

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -418,6 +418,8 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
             kwargs["template_name"] = self.database_config.get("template_name")
             if self.app_path:
                 kwargs["project_dir"] = Path(self.app_path)
+            if self.database_config.get("app_version"):
+                kwargs["app_version"] = self.database_config["app_version"]
         if resolved == "restore_migrate":
             kwargs["restore_config"] = self.database_config.get("restore", {})
             kwargs["db_name"] = self.database_config.get("name", "")

--- a/fraisier/strategies/__init__.py
+++ b/fraisier/strategies/__init__.py
@@ -59,13 +59,16 @@ def get_strategy(name: str, **kwargs: Any) -> Strategy:
         roles = kwargs.get("required_roles") or []
         project_dir = kwargs.get("project_dir")
         admin_url = kwargs.get("admin_url")
-        return RebuildStrategy(
-            required_roles=roles,
-            project_dir=project_dir,
-            admin_url=admin_url,
-            create_template=bool(kwargs.get("create_template", False)),
-            template_name=kwargs.get("template_name"),
-        )
+        rebuild_kwargs: dict[str, Any] = {
+            "required_roles": roles,
+            "project_dir": project_dir,
+            "admin_url": admin_url,
+            "create_template": bool(kwargs.get("create_template", False)),
+            "template_name": kwargs.get("template_name"),
+        }
+        if kwargs.get("app_version"):
+            rebuild_kwargs["app_version"] = kwargs["app_version"]
+        return RebuildStrategy(**rebuild_kwargs)
     if name == "restore_migrate":
         restore_cfg = kwargs.get("restore_config")
         if not restore_cfg or not isinstance(restore_cfg, dict):

--- a/fraisier/strategies/_core.py
+++ b/fraisier/strategies/_core.py
@@ -108,6 +108,7 @@ class RebuildStrategy(Strategy):
         admin_url: str | None = None,
         create_template: bool = False,
         template_name: str | None = None,
+        app_version: str | None = None,
     ) -> None:
         self._required_roles: list[str] = []
         for role in required_roles or []:
@@ -119,10 +120,74 @@ class RebuildStrategy(Strategy):
             validate_pg_identifier(template_name, "template name")
         self._create_template = create_template
         self._template_name = template_name
+        self._app_version = app_version
 
     def _resolved_template_name(self, db_name: str) -> str:
         """Return the template DB name: explicit or derived from db_name."""
         return self._template_name or f"template_{db_name}"
+
+    def _stamp_source_for_template(
+        self, db_name: str, connection_url: str
+    ) -> None:
+        """Best-effort: stamp the live DB so the template carries app_version.
+
+        Failures (no resolvable version, missing/empty ``tb_version``, psql
+        error) log at WARNING and never raise — the consumer side is
+        responsible for rejecting unstamped/stale templates.
+        """
+        from fraisier.versioning import APP_VERSION_RE, resolve_app_version
+
+        resolved = resolve_app_version(
+            self._project_dir, override=self._app_version
+        )
+        if resolved is None:
+            log.warning(
+                "Skipping pre-clone version stamp on %s: no app version "
+                "could be resolved (override=%r, project_dir=%s); "
+                "template will be unstamped",
+                db_name,
+                self._app_version,
+                self._project_dir,
+            )
+            return
+        version, source = resolved
+
+        if not APP_VERSION_RE.match(version):  # pragma: no cover
+            log.warning(
+                "Refusing to stamp %s: resolved version %r failed "
+                "interpolation re-validation",
+                db_name,
+                version,
+            )
+            return
+
+        sql = f"UPDATE public.tb_version SET app_version = '{version}'"
+        code, stdout, stderr = run_psql(
+            sql, db_name=db_name, connection_url=connection_url
+        )
+        if code != 0:
+            log.warning(
+                "Could not stamp %s with app_version=%s (from %s): %s",
+                db_name,
+                version,
+                source,
+                stderr.strip(),
+            )
+            return
+        if "UPDATE 0" in stdout:
+            log.warning(
+                "tb_version on %s is empty; template will be unstamped. "
+                "Project must seed tb_version with at least one row for "
+                "the stamp to take effect.",
+                db_name,
+            )
+            return
+        log.info(
+            "Stamped %s with app_version=%s (from %s) before template clone",
+            db_name,
+            version,
+            source,
+        )
 
     @staticmethod
     def _apply_sql(connection_url: str, sql_path: Path) -> None:
@@ -295,7 +360,15 @@ class RebuildStrategy(Strategy):
             template_name = self._resolved_template_name(db_name)
             terminate_backends(template_name, connection_url=admin_url)
             drop_db(template_name, connection_url=admin_url)
-            # Must terminate connections to source before cloning it.
+            # Kick any reconnected app off before stamping so the stamp is
+            # the last write to tb_version before the clone.
+            terminate_backends(db_name, connection_url=admin_url)
+            self._stamp_source_for_template(
+                db_name, connection_url=env.database_url
+            )
+            # Belt-and-suspenders: catch anything that reconnected between
+            # the stamp's psql exit and the clone. CREATE DATABASE … TEMPLATE …
+            # itself fails closed if any backend is still attached.
             terminate_backends(db_name, connection_url=admin_url)
             code, _, stderr = create_db(
                 template_name, template=db_name, connection_url=admin_url

--- a/fraisier/strategies/_core.py
+++ b/fraisier/strategies/_core.py
@@ -120,6 +120,18 @@ class RebuildStrategy(Strategy):
             validate_pg_identifier(template_name, "template name")
         self._create_template = create_template
         self._template_name = template_name
+        if app_version:
+            # Loud failure on a typo'd fraises.yaml value. Auto-discovered
+            # values from version.json / pyproject.toml are validated
+            # silently in resolve_app_version (warn-and-skip path).
+            from fraisier.versioning import APP_VERSION_RE
+
+            if not APP_VERSION_RE.match(app_version):
+                msg = (
+                    f"invalid app_version {app_version!r}: must match "
+                    f"{APP_VERSION_RE.pattern}"
+                )
+                raise ValueError(msg)
         self._app_version = app_version
 
     def _resolved_template_name(self, db_name: str) -> str:

--- a/fraisier/strategies/_core.py
+++ b/fraisier/strategies/_core.py
@@ -138,9 +138,7 @@ class RebuildStrategy(Strategy):
         """Return the template DB name: explicit or derived from db_name."""
         return self._template_name or f"template_{db_name}"
 
-    def _stamp_source_for_template(
-        self, db_name: str, connection_url: str
-    ) -> None:
+    def _stamp_source_for_template(self, db_name: str, connection_url: str) -> None:
         """Best-effort: stamp the live DB so the template carries app_version.
 
         Failures (no resolvable version, missing/empty ``tb_version``, psql
@@ -149,9 +147,7 @@ class RebuildStrategy(Strategy):
         """
         from fraisier.versioning import APP_VERSION_RE, resolve_app_version
 
-        resolved = resolve_app_version(
-            self._project_dir, override=self._app_version
-        )
+        resolved = resolve_app_version(self._project_dir, override=self._app_version)
         if resolved is None:
             log.warning(
                 "Skipping pre-clone version stamp on %s: no app version "
@@ -375,9 +371,7 @@ class RebuildStrategy(Strategy):
             # Kick any reconnected app off before stamping so the stamp is
             # the last write to tb_version before the clone.
             terminate_backends(db_name, connection_url=admin_url)
-            self._stamp_source_for_template(
-                db_name, connection_url=env.database_url
-            )
+            self._stamp_source_for_template(db_name, connection_url=env.database_url)
             # Belt-and-suspenders: catch anything that reconnected between
             # the stamp's psql exit and the clone. CREATE DATABASE … TEMPLATE …
             # itself fails closed if any backend is still attached.

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -18,21 +18,37 @@ _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 APP_VERSION_RE = re.compile(r"^[A-Za-z0-9._+\-]+$")
 
 
+def _validate_app_version(version: str, *, source: str) -> tuple[str, str] | None:
+    """Return ``(version, source)`` or ``None`` (with warning) on bad chars."""
+    if not APP_VERSION_RE.match(version):
+        log.warning(
+            "Rejecting app_version %r from %s: contains characters "
+            "unsafe for SQL interpolation",
+            version,
+            source,
+        )
+        return None
+    return version, source
+
+
 def resolve_app_version(
-    project_dir: Path | None,  # noqa: ARG001
+    project_dir: Path | None,
     *,
     override: str | None = None,
 ) -> tuple[str, str] | None:
     """Resolve a build-time app version for stamping into databases."""
     if override:
-        if not APP_VERSION_RE.match(override):
-            log.warning(
-                "Rejecting app_version %r from override: contains characters "
-                "unsafe for SQL interpolation",
-                override,
-            )
-            return None
-        return override, "override"
+        return _validate_app_version(override, source="override")
+
+    if project_dir is None:
+        return None
+
+    version_json = project_dir / "version.json"
+    if version_json.exists():
+        info = read_version(version_json)
+        if info is not None and info.version:
+            return _validate_app_version(info.version, source="version.json")
+
     return None
 
 

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -36,7 +36,21 @@ def resolve_app_version(
     *,
     override: str | None = None,
 ) -> tuple[str, str] | None:
-    """Resolve a build-time app version for stamping into databases."""
+    """Resolve a build-time app version for stamping into databases.
+
+    Precedence:
+        1. *override* (if non-empty).
+        2. ``<project_dir>/version.json`` ``version`` field.
+        3. ``<project_dir>/pyproject.toml`` ``[project].version``.
+
+    Returns ``(version, source)`` where *source* is one of ``"override"``,
+    ``"version.json"``, or ``"pyproject.toml"``. Returns ``None`` when no
+    source resolves a version, when reading a source raises (malformed
+    JSON, missing version line, OS error), or when the resolved value
+    contains characters unsafe for interpolation into a psql literal
+    (anything outside ``[A-Za-z0-9._+\\-]``). Never raises in normal
+    operation.
+    """
     if override:
         return _validate_app_version(override, source="override")
 

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -15,6 +15,27 @@ log = logging.getLogger(__name__)
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
+APP_VERSION_RE = re.compile(r"^[A-Za-z0-9._+\-]+$")
+
+
+def resolve_app_version(
+    project_dir: Path | None,  # noqa: ARG001
+    *,
+    override: str | None = None,
+) -> tuple[str, str] | None:
+    """Resolve a build-time app version for stamping into databases."""
+    if override:
+        if not APP_VERSION_RE.match(override):
+            log.warning(
+                "Rejecting app_version %r from override: contains characters "
+                "unsafe for SQL interpolation",
+                override,
+            )
+            return None
+        return override, "override"
+    return None
+
+
 _VERSION_FIELDS = frozenset(
     {
         "version",

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -55,7 +55,11 @@ def resolve_app_version(
 
     pyproject = project_dir / "pyproject.toml"
     if pyproject.exists():
-        version = read_pyproject_version(pyproject)
+        try:
+            version = read_pyproject_version(pyproject)
+        except (ValueError, OSError) as exc:
+            log.warning("Could not read version from %s: %s", pyproject, exc)
+            return None
         return _validate_app_version(version, source="pyproject.toml")
 
     return None

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -45,7 +45,11 @@ def resolve_app_version(
 
     version_json = project_dir / "version.json"
     if version_json.exists():
-        info = read_version(version_json)
+        try:
+            info = read_version(version_json)
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Could not read %s: %s", version_json, exc)
+            info = None
         if info is not None and info.version:
             return _validate_app_version(info.version, source="version.json")
 

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -49,6 +49,11 @@ def resolve_app_version(
         if info is not None and info.version:
             return _validate_app_version(info.version, source="version.json")
 
+    pyproject = project_dir / "pyproject.toml"
+    if pyproject.exists():
+        version = read_pyproject_version(pyproject)
+        return _validate_app_version(version, source="pyproject.toml")
+
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.16.3"
+version = "0.16.4"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/integration/test_rebuild_stamp_integration.py
+++ b/tests/integration/test_rebuild_stamp_integration.py
@@ -1,0 +1,105 @@
+"""Integration smoke test for ``_stamp_source_for_template`` against real PG.
+
+Run with: ``FRAISIER_INTEGRATION=1 uv run pytest \\
+    tests/integration/test_rebuild_stamp_integration.py``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+import psycopg
+import pytest
+
+from fraisier.dbops._url import replace_db_name
+from fraisier.strategies import RebuildStrategy
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("FRAISIER_INTEGRATION") != "1",
+        reason="set FRAISIER_INTEGRATION=1 to enable",
+    ),
+]
+
+
+@pytest.fixture
+def _stamp_test_db(pg_superuser_url):
+    """Create a fresh DB with a seeded ``public.tb_version`` row."""
+    db_name = f"stamptest_{uuid.uuid4().hex[:10]}"
+    with psycopg.connect(pg_superuser_url, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {db_name}")  # ty: ignore[no-matching-overload]
+
+    db_url = replace_db_name(pg_superuser_url, db_name)
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        conn.execute("CREATE TABLE public.tb_version (app_version text)")  # ty: ignore[no-matching-overload]
+        conn.execute(  # ty: ignore[no-matching-overload]
+            "INSERT INTO public.tb_version (app_version) VALUES ('0.0.0')"
+        )
+
+    yield db_url, db_name
+
+    with psycopg.connect(pg_superuser_url, autocommit=True) as conn:
+        conn.execute(  # ty: ignore[no-matching-overload]
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+        )
+        conn.execute(  # ty: ignore[no-matching-overload]
+            f"DROP DATABASE IF EXISTS {db_name} WITH (FORCE)"
+        )
+
+
+@pytest.fixture
+def _empty_tb_version_db(pg_superuser_url):
+    """Create a fresh DB with an empty ``public.tb_version`` (no INSERT)."""
+    db_name = f"stamptest_{uuid.uuid4().hex[:10]}"
+    with psycopg.connect(pg_superuser_url, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {db_name}")  # ty: ignore[no-matching-overload]
+
+    db_url = replace_db_name(pg_superuser_url, db_name)
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        conn.execute("CREATE TABLE public.tb_version (app_version text)")  # ty: ignore[no-matching-overload]
+
+    yield db_url, db_name
+
+    with psycopg.connect(pg_superuser_url, autocommit=True) as conn:
+        conn.execute(  # ty: ignore[no-matching-overload]
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            f"WHERE datname = '{db_name}' AND pid <> pg_backend_pid()"
+        )
+        conn.execute(  # ty: ignore[no-matching-overload]
+            f"DROP DATABASE IF EXISTS {db_name} WITH (FORCE)"
+        )
+
+
+def test_stamp_writes_value_into_tb_version(_stamp_test_db):
+    """The UPDATE actually populates ``tb_version.app_version`` against a seeded row."""
+    db_url, db_name = _stamp_test_db
+
+    strategy = RebuildStrategy(app_version="9.9.9")
+    strategy._stamp_source_for_template(db_name, connection_url=db_url)
+
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        row = conn.execute("SELECT app_version FROM public.tb_version").fetchone()
+    assert row is not None
+    assert row[0] == "9.9.9"
+
+
+def test_stamp_against_empty_tb_version_warns_and_inserts_nothing(
+    _empty_tb_version_db, caplog
+):
+    """Empty ``tb_version`` triggers warn-and-skip; no row is created."""
+    db_url, db_name = _empty_tb_version_db
+
+    strategy = RebuildStrategy(app_version="9.9.9")
+    with caplog.at_level(logging.WARNING, logger="fraisier.strategies._core"):
+        strategy._stamp_source_for_template(db_name, connection_url=db_url)
+
+    with psycopg.connect(db_url, autocommit=True) as conn:
+        row = conn.execute("SELECT count(*) FROM public.tb_version").fetchone()
+    assert row is not None
+    assert row[0] == 0
+    assert "tb_version" in caplog.text
+    assert "empty" in caplog.text

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -835,6 +835,19 @@ class TestAPIDeployerRebuildAppVersion:
         strategy, *_ = deployer._resolve_strategy()
         assert strategy._app_version == "9.9.9"
 
+    def test_omits_app_version_when_unset(self):
+        deployer = APIDeployer(
+            {
+                "app_path": "/tmp/x",
+                "database": {
+                    "strategy": "rebuild",
+                    "create_template": True,
+                },
+            }
+        )
+        strategy, *_ = deployer._resolve_strategy()
+        assert strategy._app_version is None
+
 
 class TestServiceFileStaleness:
     """_check_service_file_staleness warns when live unit differs from scaffold."""

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -818,6 +818,24 @@ class TestAPIDeployer:
         mock_watcher.save_hash.assert_not_called()
 
 
+class TestAPIDeployerRebuildAppVersion:
+    """APIDeployer plumbs database.app_version through to RebuildStrategy."""
+
+    def test_reads_app_version_from_database_config(self):
+        deployer = APIDeployer(
+            {
+                "app_path": "/tmp/x",
+                "database": {
+                    "strategy": "rebuild",
+                    "create_template": True,
+                    "app_version": "9.9.9",
+                },
+            }
+        )
+        strategy, *_ = deployer._resolve_strategy()
+        assert strategy._app_version == "9.9.9"
+
+
 class TestServiceFileStaleness:
     """_check_service_file_staleness warns when live unit differs from scaffold."""
 

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -848,6 +848,20 @@ class TestAPIDeployerRebuildAppVersion:
         strategy, *_ = deployer._resolve_strategy()
         assert strategy._app_version is None
 
+    def test_invalid_app_version_propagates(self):
+        deployer = APIDeployer(
+            {
+                "app_path": "/tmp/x",
+                "database": {
+                    "strategy": "rebuild",
+                    "create_template": True,
+                    "app_version": "1!2.3.4",
+                },
+            }
+        )
+        with pytest.raises(ValueError, match="app_version"):
+            deployer._resolve_strategy()
+
 
 class TestServiceFileStaleness:
     """_check_service_file_staleness warns when live unit differs from scaffold."""

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -610,3 +610,49 @@ class TestRebuildStrategyVersionStamp:
             stamp_calls[0].kwargs["connection_url"]
             == "postgresql://appuser@localhost/myapp"
         )
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_discovers_version_from_version_json(
+        self, _mock_rebuild_deps, tmp_path, caplog
+    ):
+        """With version.json discovery, the UPDATE carries the value and INFO logs the source."""
+        import logging
+
+        # The shared fixture globally patches ``Path.read_text`` to return a
+        # YAML config blob, which breaks real version.json reads here. Mock
+        # ``resolve_app_version`` directly to pin the wiring: constructor
+        # forwards project_dir, the resolver result drives the UPDATE and log.
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+            patch(
+                "fraisier.versioning.resolve_app_version",
+                return_value=("0.4.2", "version.json"),
+            ) as mock_resolve,
+            caplog.at_level(logging.INFO, logger="fraisier.strategies._core"),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                project_dir=tmp_path,
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        mock_resolve.assert_called_once_with(tmp_path, override=None)
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert len(stamp_calls) == 1
+        assert "SET app_version = '0.4.2'" in stamp_calls[0].args[0]
+        assert "from version.json" in caplog.text

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -850,3 +850,13 @@ class TestRebuildStrategyVersionStamp:
             if "UPDATE public.tb_version" in c.args[0]
         ]
         assert stamp_calls == []
+
+    def test_init_rejects_invalid_app_version(self):
+        """A non-empty app_version that fails the regex raises ValueError."""
+        with pytest.raises(ValueError, match=r"app_version"):
+            RebuildStrategy(app_version="1!2.3.4")
+
+    def test_init_accepts_empty_app_version(self):
+        """Empty app_version is treated as not-supplied; no raise."""
+        strategy = RebuildStrategy(app_version="")
+        assert strategy._app_version == ""

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -576,3 +576,37 @@ class TestRebuildStrategyVersionStamp:
             ("terminate", "myapp"),
             ("create", "template_myapp<-myapp"),
         ]
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_stamp_uses_env_database_url(self, _mock_rebuild_deps):
+        """The stamp uses env.database_url (app role), not admin_url."""
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert len(stamp_calls) == 1
+        assert (
+            stamp_calls[0].kwargs["connection_url"]
+            == "postgresql://appuser@localhost/myapp"
+        )

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -697,3 +697,49 @@ class TestRebuildStrategyVersionStamp:
         assert len(stamp_calls) == 1
         assert "SET app_version = '0.0.7'" in stamp_calls[0].args[0]
         assert "from pyproject.toml" in caplog.text
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_no_version_resolvable_warns_and_clones(
+        self, _mock_rebuild_deps, caplog
+    ):
+        """When no version resolves, warn and continue with the clone."""
+        import logging
+
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch(
+                "fraisier.strategies._core.create_db", return_value=(0, "", "")
+            ) as mock_create,
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+            patch(
+                "fraisier.versioning.resolve_app_version", return_value=None
+            ),
+            caplog.at_level(logging.WARNING, logger="fraisier.strategies._core"),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            result = strategy.execute(Path("confiture.yaml"))
+
+        assert result.success
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert stamp_calls == []
+        # Template clone still happens: create_db called twice (db + template).
+        assert mock_create.call_count == 2
+        template_call = mock_create.call_args_list[1]
+        assert template_call[0][0] == "template_myapp"
+        assert template_call[1]["template"] == "myapp"
+        assert "Skipping pre-clone version stamp" in caplog.text

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -656,3 +656,44 @@ class TestRebuildStrategyVersionStamp:
         assert len(stamp_calls) == 1
         assert "SET app_version = '0.4.2'" in stamp_calls[0].args[0]
         assert "from version.json" in caplog.text
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_discovers_version_from_pyproject(
+        self, _mock_rebuild_deps, tmp_path, caplog
+    ):
+        """pyproject.toml fallback drives the UPDATE and INFO log."""
+        import logging
+
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+            patch(
+                "fraisier.versioning.resolve_app_version",
+                return_value=("0.0.7", "pyproject.toml"),
+            ),
+            caplog.at_level(logging.INFO, logger="fraisier.strategies._core"),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                project_dir=tmp_path,
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert len(stamp_calls) == 1
+        assert "SET app_version = '0.0.7'" in stamp_calls[0].args[0]
+        assert "from pyproject.toml" in caplog.text

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -339,11 +339,12 @@ class TestRebuildStrategyTemplateCreation:
             )
             strategy.execute(Path("confiture.yaml"))
 
-        # Expected order: terminate myapp (main rebuild), terminate template_myapp, terminate myapp (before clone)
+        # Expected order: terminate myapp (initial rebuild), terminate template_myapp,
+        # terminate myapp (pre-stamp), terminate myapp (pre-clone, belt-and-suspenders).
         assert "myapp" in terminate_calls
         assert "template_myapp" in terminate_calls
-        # myapp terminated twice (initial + before clone)
-        assert terminate_calls.count("myapp") == 2
+        # myapp terminated three times: initial drop, pre-stamp, pre-clone.
+        assert terminate_calls.count("myapp") == 3
 
     @pytest.mark.usefixtures("_mock_rebuild_deps")
     def test_execute_with_template_drops_existing_template_first(
@@ -443,3 +444,40 @@ class TestRebuildStrategyTemplateCreation:
                 admin_url="postgresql://postgres@localhost/postgres",
             )
             strategy.execute(Path("confiture.yaml"))
+
+
+class TestRebuildStrategyVersionStamp:
+    """RebuildStrategy stamps the source DB before cloning the template (#198)."""
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_stamps_with_explicit_app_version(self, _mock_rebuild_deps):
+        """Explicit app_version is written into public.tb_version via run_psql."""
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert len(stamp_calls) == 1
+        call = stamp_calls[0]
+        assert "SET app_version = '1.2.3'" in call.args[0]
+        assert call.kwargs["db_name"] == "myapp"

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -514,3 +514,65 @@ class TestRebuildStrategyVersionStamp:
         assert not any(
             c.kwargs["db_name"] == "template_myapp" for c in stamp_calls
         )
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_race_free_ordering(self, _mock_rebuild_deps):
+        """terminate(template) → drop(template) → terminate(src) → stamp → terminate(src) → create(template)."""
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        sequence: list[tuple[str, str]] = []
+
+        def _record_term(db, **_kw):
+            sequence.append(("terminate", db))
+
+        def _record_drop(db, **_kw):
+            sequence.append(("drop", db))
+
+        def _record_create(db, **kw):
+            template = kw.get("template")
+            sequence.append(("create", db if template is None else f"{db}<-{template}"))
+            return (0, "", "")
+
+        def _record_psql(sql, **kw):
+            if "UPDATE public.tb_version" in sql:
+                sequence.append(("stamp", kw["db_name"]))
+            return (0, "UPDATE 1", "")
+
+        with (
+            patch(
+                "fraisier.strategies._core.terminate_backends",
+                side_effect=_record_term,
+            ),
+            patch("fraisier.strategies._core.drop_db", side_effect=_record_drop),
+            patch(
+                "fraisier.strategies._core.create_db", side_effect=_record_create
+            ),
+            patch(
+                "fraisier.strategies._core.run_psql", side_effect=_record_psql
+            ),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        # Filter to just the template-block operations (after the initial rebuild).
+        # The initial DB rebuild produces: terminate(myapp), drop(myapp), create(myapp).
+        # Then the template block runs:
+        #   terminate(template_myapp), drop(template_myapp),
+        #   terminate(myapp), stamp(myapp), terminate(myapp),
+        #   create(template_myapp<-myapp)
+        # Trim the leading 3 entries from the initial rebuild.
+        template_block = sequence[3:]
+        assert template_block == [
+            ("terminate", "template_myapp"),
+            ("drop", "template_myapp"),
+            ("terminate", "myapp"),
+            ("stamp", "myapp"),
+            ("terminate", "myapp"),
+            ("create", "template_myapp<-myapp"),
+        ]

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -820,3 +820,33 @@ class TestRebuildStrategyVersionStamp:
             and r.message.startswith("Stamped ")
         ]
         assert stamped_info == []
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_create_template_false_skips_stamp(self, _mock_rebuild_deps):
+        """create_template=False short-circuits: no UPDATE against tb_version."""
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+        ):
+            strategy = RebuildStrategy(
+                create_template=False,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert stamp_calls == []

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -776,3 +776,47 @@ class TestRebuildStrategyVersionStamp:
         assert mock_create.call_count == 2
         assert "Could not stamp" in caplog.text
         assert "relation tb_version does not exist" in caplog.text
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_empty_tb_version_warns_and_clones(self, _mock_rebuild_deps, caplog):
+        """UPDATE 0 against an empty tb_version warns and skips the INFO success log."""
+        import logging
+
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch(
+                "fraisier.strategies._core.create_db", return_value=(0, "", "")
+            ) as mock_create,
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 0", ""),
+            ),
+            caplog.at_level(logging.DEBUG, logger="fraisier.strategies._core"),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        assert mock_create.call_count == 2
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "tb_version" in r.message
+        ]
+        assert len(warning_records) == 1
+        # No INFO "Stamped" log for this run.
+        stamped_info = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.INFO
+            and r.message.startswith("Stamped ")
+        ]
+        assert stamped_info == []

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -481,3 +481,36 @@ class TestRebuildStrategyVersionStamp:
         call = stamp_calls[0]
         assert "SET app_version = '1.2.3'" in call.args[0]
         assert call.kwargs["db_name"] == "myapp"
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_stamps_source_db_not_template_db(self, _mock_rebuild_deps):
+        """The stamp targets the source DB, not the template DB (pre-clone)."""
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch("fraisier.strategies._core.create_db", return_value=(0, "", "")),
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(0, "UPDATE 1", ""),
+            ) as mock_run_psql,
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            strategy.execute(Path("confiture.yaml"))
+
+        stamp_calls = [
+            c
+            for c in mock_run_psql.call_args_list
+            if "UPDATE public.tb_version" in c.args[0]
+        ]
+        assert all(c.kwargs["db_name"] == "myapp" for c in stamp_calls)
+        assert not any(
+            c.kwargs["db_name"] == "template_myapp" for c in stamp_calls
+        )

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -743,3 +743,36 @@ class TestRebuildStrategyVersionStamp:
         assert template_call[0][0] == "template_myapp"
         assert template_call[1]["template"] == "myapp"
         assert "Skipping pre-clone version stamp" in caplog.text
+
+    @pytest.mark.usefixtures("_mock_rebuild_deps")
+    def test_psql_failure_warns_and_clones(self, _mock_rebuild_deps, caplog):
+        """psql non-zero exit logs WARNING with stderr and continues with clone."""
+        import logging
+
+        mocks = _mock_rebuild_deps
+        builder_instance = mocks["builder_cls"].return_value
+        builder_instance.build_split.return_value = FakeSplitResult()
+
+        with (
+            patch("fraisier.strategies._core.terminate_backends"),
+            patch("fraisier.strategies._core.drop_db"),
+            patch(
+                "fraisier.strategies._core.create_db", return_value=(0, "", "")
+            ) as mock_create,
+            patch(
+                "fraisier.strategies._core.run_psql",
+                return_value=(1, "", "relation tb_version does not exist"),
+            ),
+            caplog.at_level(logging.WARNING, logger="fraisier.strategies._core"),
+        ):
+            strategy = RebuildStrategy(
+                create_template=True,
+                app_version="1.2.3",
+                admin_url="postgresql://postgres@localhost/postgres",
+            )
+            result = strategy.execute(Path("confiture.yaml"))
+
+        assert result.success
+        assert mock_create.call_count == 2
+        assert "Could not stamp" in caplog.text
+        assert "relation tb_version does not exist" in caplog.text

--- a/tests/test_rebuild_split.py
+++ b/tests/test_rebuild_split.py
@@ -511,9 +511,7 @@ class TestRebuildStrategyVersionStamp:
             if "UPDATE public.tb_version" in c.args[0]
         ]
         assert all(c.kwargs["db_name"] == "myapp" for c in stamp_calls)
-        assert not any(
-            c.kwargs["db_name"] == "template_myapp" for c in stamp_calls
-        )
+        assert not any(c.kwargs["db_name"] == "template_myapp" for c in stamp_calls)
 
     @pytest.mark.usefixtures("_mock_rebuild_deps")
     def test_race_free_ordering(self, _mock_rebuild_deps):
@@ -546,12 +544,8 @@ class TestRebuildStrategyVersionStamp:
                 side_effect=_record_term,
             ),
             patch("fraisier.strategies._core.drop_db", side_effect=_record_drop),
-            patch(
-                "fraisier.strategies._core.create_db", side_effect=_record_create
-            ),
-            patch(
-                "fraisier.strategies._core.run_psql", side_effect=_record_psql
-            ),
+            patch("fraisier.strategies._core.create_db", side_effect=_record_create),
+            patch("fraisier.strategies._core.run_psql", side_effect=_record_psql),
         ):
             strategy = RebuildStrategy(
                 create_template=True,
@@ -699,9 +693,7 @@ class TestRebuildStrategyVersionStamp:
         assert "from pyproject.toml" in caplog.text
 
     @pytest.mark.usefixtures("_mock_rebuild_deps")
-    def test_no_version_resolvable_warns_and_clones(
-        self, _mock_rebuild_deps, caplog
-    ):
+    def test_no_version_resolvable_warns_and_clones(self, _mock_rebuild_deps, caplog):
         """When no version resolves, warn and continue with the clone."""
         import logging
 
@@ -719,9 +711,7 @@ class TestRebuildStrategyVersionStamp:
                 "fraisier.strategies._core.run_psql",
                 return_value=(0, "UPDATE 1", ""),
             ) as mock_run_psql,
-            patch(
-                "fraisier.versioning.resolve_app_version", return_value=None
-            ),
+            patch("fraisier.versioning.resolve_app_version", return_value=None),
             caplog.at_level(logging.WARNING, logger="fraisier.strategies._core"),
         ):
             strategy = RebuildStrategy(
@@ -816,8 +806,7 @@ class TestRebuildStrategyVersionStamp:
         stamped_info = [
             r
             for r in caplog.records
-            if r.levelno == logging.INFO
-            and r.message.startswith("Stamped ")
+            if r.levelno == logging.INFO and r.message.startswith("Stamped ")
         ]
         assert stamped_info == []
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -872,6 +872,12 @@ class TestGetStrategy:
         assert isinstance(s, RebuildStrategy)
         assert s._template_name == "snap_myapp"
 
+    def test_rebuild_forwards_app_version(self):
+        """get_strategy forwards app_version kwarg to RebuildStrategy."""
+        s = get_strategy("rebuild", create_template=True, app_version="1.2.3")
+        assert isinstance(s, RebuildStrategy)
+        assert s._app_version == "1.2.3"
+
     def test_restore_migrate(self):
         s = get_strategy(
             "restore_migrate",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -883,6 +883,11 @@ class TestGetStrategy:
         s = get_strategy("rebuild")
         assert s._app_version is None
 
+    def test_rebuild_empty_app_version_is_ignored(self):
+        """Empty-string app_version is dropped so auto-discovery runs."""
+        s = get_strategy("rebuild", create_template=True, app_version="")
+        assert s._app_version is None
+
     def test_restore_migrate(self):
         s = get_strategy(
             "restore_migrate",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -878,6 +878,11 @@ class TestGetStrategy:
         assert isinstance(s, RebuildStrategy)
         assert s._app_version == "1.2.3"
 
+    def test_rebuild_app_version_default_is_none(self):
+        """Without app_version kwarg, the strategy's _app_version is None."""
+        s = get_strategy("rebuild")
+        assert s._app_version is None
+
     def test_restore_migrate(self):
         s = get_strategy(
             "restore_migrate",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -888,6 +888,11 @@ class TestGetStrategy:
         s = get_strategy("rebuild", create_template=True, app_version="")
         assert s._app_version is None
 
+    def test_rebuild_invalid_app_version_raises(self):
+        """Invalid app_version propagates ValueError (not swallowed by factory)."""
+        with pytest.raises(ValueError, match="app_version"):
+            get_strategy("rebuild", create_template=True, app_version="1!2.3.4")
+
     def test_restore_migrate(self):
         s = get_strategy(
             "restore_migrate",

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -12,6 +12,7 @@ from fraisier.strategies import (
     PeeweeMigrateStrategy,
 )
 from fraisier.versioning import (
+    APP_VERSION_RE,
     VersionInfo,
     VersionSyncConfig,
     VersionSyncTarget,
@@ -23,6 +24,7 @@ from fraisier.versioning import (
     parse_semver,
     read_pyproject_version,
     read_version,
+    resolve_app_version,
     sync_version_to_targets,
     write_version,
 )
@@ -437,3 +439,11 @@ class TestGenerateVersionJson:
         info = generate_version_json(tmp_path)
         assert info.schema_hash == ""
         assert info.database_version == ""
+
+
+class TestResolveAppVersion:
+    """Test resolve_app_version helper for build-time stamping."""
+
+    def test_explicit_override_wins(self, tmp_path):
+        """Explicit override returns (value, "override") with no file lookups."""
+        assert resolve_app_version(tmp_path, override="1.2.3") == ("1.2.3", "override")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -485,3 +485,8 @@ class TestResolveAppVersion:
         """Override is consulted before version.json, even when version.json exists."""
         (tmp_path / "version.json").write_text('{"version": "1.0.0"}')
         assert resolve_app_version(tmp_path, override="9.9.9") == ("9.9.9", "override")
+
+    def test_empty_override_falls_through(self, tmp_path):
+        """Empty-string override is treated as not supplied; falls back to version.json."""
+        (tmp_path / "version.json").write_text('{"version": "1.0.0"}')
+        assert resolve_app_version(tmp_path, override="") == ("1.0.0", "version.json")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -509,3 +509,13 @@ class TestResolveAppVersion:
             result = resolve_app_version(tmp_path)
         assert result is None
         assert "version.json" in caplog.text
+
+    def test_pyproject_without_version_line_returns_none(self, tmp_path, caplog):
+        """pyproject.toml without a version = line returns None with warning."""
+        import logging
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+        with caplog.at_level(logging.WARNING, logger="fraisier.versioning"):
+            result = resolve_app_version(tmp_path)
+        assert result is None
+        assert "pyproject.toml" in caplog.text

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -467,3 +467,16 @@ class TestResolveAppVersion:
     def test_empty_project_dir_returns_none(self, tmp_path):
         """No version.json and no pyproject.toml returns None without raising."""
         assert resolve_app_version(tmp_path) is None
+
+    def test_malformed_version_in_version_json_rejected(self, tmp_path, caplog):
+        """A version containing SQL-unsafe characters is rejected with a warning."""
+        bad = "1.0.0'; DROP TABLE--"
+        (tmp_path / "version.json").write_text(f'{{"version": "{bad}"}}')
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="fraisier.versioning"):
+            result = resolve_app_version(tmp_path)
+        assert result is None
+        assert bad in caplog.text
+        assert "version.json" in caplog.text

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -447,3 +447,8 @@ class TestResolveAppVersion:
     def test_explicit_override_wins(self, tmp_path):
         """Explicit override returns (value, "override") with no file lookups."""
         assert resolve_app_version(tmp_path, override="1.2.3") == ("1.2.3", "override")
+
+    def test_version_json_discovery(self, tmp_path):
+        """version.json containing a valid version returns (value, "version.json")."""
+        (tmp_path / "version.json").write_text('{"version": "0.4.2"}')
+        assert resolve_app_version(tmp_path) == ("0.4.2", "version.json")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -490,3 +490,12 @@ class TestResolveAppVersion:
         """Empty-string override is treated as not supplied; falls back to version.json."""
         (tmp_path / "version.json").write_text('{"version": "1.0.0"}')
         assert resolve_app_version(tmp_path, override="") == ("1.0.0", "version.json")
+
+    def test_pep440_epoch_rejected(self, tmp_path, caplog):
+        """PEP 440 epoch versions (1!2.3.4) are rejected — documented limitation."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="fraisier.versioning"):
+            result = resolve_app_version(tmp_path, override="1!2.3.4")
+        assert result is None
+        assert "1!2.3.4" in caplog.text

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -452,3 +452,10 @@ class TestResolveAppVersion:
         """version.json containing a valid version returns (value, "version.json")."""
         (tmp_path / "version.json").write_text('{"version": "0.4.2"}')
         assert resolve_app_version(tmp_path) == ("0.4.2", "version.json")
+
+    def test_pyproject_fallback(self, tmp_path):
+        """With no version.json, pyproject.toml [project].version is used."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0.0.1"\n'
+        )
+        assert resolve_app_version(tmp_path) == ("0.0.1", "pyproject.toml")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -463,3 +463,7 @@ class TestResolveAppVersion:
     def test_missing_project_dir_returns_none(self):
         """project_dir=None and no override returns None."""
         assert resolve_app_version(None) is None
+
+    def test_empty_project_dir_returns_none(self, tmp_path):
+        """No version.json and no pyproject.toml returns None without raising."""
+        assert resolve_app_version(tmp_path) is None

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -499,3 +499,13 @@ class TestResolveAppVersion:
             result = resolve_app_version(tmp_path, override="1!2.3.4")
         assert result is None
         assert "1!2.3.4" in caplog.text
+
+    def test_malformed_version_json_returns_none(self, tmp_path, caplog):
+        """Malformed JSON in version.json is caught and the function returns None."""
+        import logging
+
+        (tmp_path / "version.json").write_text("{not: valid json")
+        with caplog.at_level(logging.WARNING, logger="fraisier.versioning"):
+            result = resolve_app_version(tmp_path)
+        assert result is None
+        assert "version.json" in caplog.text

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -519,3 +519,11 @@ class TestResolveAppVersion:
             result = resolve_app_version(tmp_path)
         assert result is None
         assert "pyproject.toml" in caplog.text
+
+    def test_empty_version_json_version_falls_through(self, tmp_path):
+        """Empty version field in version.json falls through to pyproject.toml."""
+        (tmp_path / "version.json").write_text('{"version": ""}')
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0.0.1"\n'
+        )
+        assert resolve_app_version(tmp_path) == ("0.0.1", "pyproject.toml")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -459,3 +459,7 @@ class TestResolveAppVersion:
             '[project]\nname = "x"\nversion = "0.0.1"\n'
         )
         assert resolve_app_version(tmp_path) == ("0.0.1", "pyproject.toml")
+
+    def test_missing_project_dir_returns_none(self):
+        """project_dir=None and no override returns None."""
+        assert resolve_app_version(None) is None

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -480,3 +480,8 @@ class TestResolveAppVersion:
         assert result is None
         assert bad in caplog.text
         assert "version.json" in caplog.text
+
+    def test_override_beats_files(self, tmp_path):
+        """Override is consulted before version.json, even when version.json exists."""
+        (tmp_path / "version.json").write_text('{"version": "1.0.0"}')
+        assert resolve_app_version(tmp_path, override="9.9.9") == ("9.9.9", "override")

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.16.2"
+version = "0.16.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.16.3"
+version = "0.16.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Closes #198. `RebuildStrategy` now writes a build-time version stamp into `public.tb_version.app_version` of the source DB immediately before cloning the template, so downstream consumers can detect stale templates.
- Stamp is best-effort: warns and continues on missing `tb_version`, empty table (`UPDATE 0`), or psql error. Race-free ordering inside `create_template`: `terminate(template) → drop(template) → terminate(source) → stamp → terminate(source) → create(template, template=source)`.
- New optional `database.app_version` in `fraises.yaml` overrides auto-discovery from `version.json` / `pyproject.toml`. Invalid override values raise `ValueError` at construction (loud failure on typos).

## Test plan
- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run ty check` — no new diagnostics on touched modules (2 new `_app_version` accesses on `Strategy` mirror the pre-existing `_create_template` pattern in `tests/test_strategies.py`)
- [x] `uv run pytest -q` — 3256 passed, 9 skipped
- [x] `FRAISIER_INTEGRATION=1 uv run pytest tests/integration/test_rebuild_stamp_integration.py` — 2 passed against real Postgres (seeded-row + empty-table sub-tests)

## Upgrade notes
Templates created by earlier fraisier versions are unstamped. Consumers strictly rejecting unstamped templates will refuse reseeds until the next rebuild. See CHANGELOG for cutover guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)