### PR TITLE
release: v0.16.6 — fix scaffold + sync XS bundle (#152, #161, #164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.6] - 2026-05-21
+
+### Fixed
+
+- **Scaffolded deploy service unit silently dropped `StrictHostKeyChecking`** ([#152](https://github.com/fraiseql/fraisier/issues/152)). The `Environment="GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new"` line was tokenised by systemd before quote handling, so `-o` was rejected with `Invalid environment assignment, ignoring: -o` and the option silently dropped — first-time `git fetch` then failed with SSH exit 255 (the symptom #116 had originally tried to address). The template now uses the equivalent no-space form `-oStrictHostKeyChecking=accept-new`; existing installations need to re-scaffold to pick up the fix.
+- **Generated sudoers fragment ended with a double newline** ([#161](https://github.com/fraiseql/fraisier/issues/161)). `pre-commit-hooks/end-of-file-fixer` flagged the file on every commit. The blank-line separator between rules is now suppressed on the final iteration via `{% if not loop.last %}`, preserving readability between rules without trailing whitespace.
+- **`fraisier sync` aborted with "nothing to commit" when conflicts auto-resolved back to source HEAD** ([#164](https://github.com/fraiseql/fraisier/issues/164)). The clean-merge path already guarded its pre-merge commit with `git diff --cached --quiet`; the conflict-resolution path did not. When every conflicted file was a fraisier-owned file that resolved to source HEAD (which was already the sync branch's tip), the staged index ended byte-identical to HEAD and `git commit --no-edit` exited non-zero. Both paths now route through a single `_commit_if_staged(message)` helper.
+
 ## [0.16.5] - 2026-05-21
 
 ### Fixed

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -127,6 +127,18 @@ def _capture(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
+def _commit_if_staged(message: str) -> None:
+    """Commit the staged index with ``message`` only if there is something staged.
+
+    Git refuses an empty commit, so callers that may have staged no net change
+    (clean merges with no diverging tracked content, or conflict resolutions
+    that resolve back to HEAD) need a guard before invoking ``git commit``.
+    """
+    staged = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+    if staged.returncode != 0:
+        _run(["git", "commit", "--no-edit", "--no-verify", "-m", message])
+
+
 def _print_dry_run_plan(source: str, tgt: str, sync_branch: str) -> None:
     """Print the shell commands that sync would execute, without running them."""
     auto_owned = ", ".join(_AUTO_RESOLVED)
@@ -339,30 +351,11 @@ def sync_cmd(
                 )
                 raise SystemExit(1)
 
-            _run(
-                [
-                    "git",
-                    "commit",
-                    "--no-edit",
-                    "--no-verify",
-                    "-m",
-                    f"Pre-merge {tgt} into sync branch (auto-resolved fraisier files)",
-                ]
+            _commit_if_staged(
+                f"Pre-merge {tgt} into sync branch (auto-resolved fraisier files)"
             )
         else:
-            # Clean merge — commit only if something was staged.
-            staged = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
-            if staged.returncode != 0:
-                _run(
-                    [
-                        "git",
-                        "commit",
-                        "--no-edit",
-                        "--no-verify",
-                        "-m",
-                        f"Pre-merge {tgt} into sync branch",
-                    ]
-                )
+            _commit_if_staged(f"Pre-merge {tgt} into sync branch")
 
         console.print(f"  Pushing [bold]{sync_branch}[/bold]")
         _run(["git", "push", "origin", sync_branch])

--- a/fraisier/scaffold/templates/core/deploy-service.j2
+++ b/fraisier/scaffold/templates/core/deploy-service.j2
@@ -15,7 +15,7 @@ StandardError=journal
 Environment=PYTHONDONTWRITEBYTECODE=1
 Environment=FRAISIER_CONFIG={{ scaffold.config_path }}
 # Allow git fetch to succeed on first run without known_hosts pre-seeded.
-Environment="GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new"
+Environment="GIT_SSH_COMMAND=ssh -oStrictHostKeyChecking=accept-new"
 {% if allowed_services %}
 Environment=FRAISIER_SYSTEMCTL_SOCKET=/run/fraisier/systemctl-{{ project_name }}.sock
 {% endif %}

--- a/fraisier/scaffold/templates/core/sudoers.j2
+++ b/fraisier/scaffold/templates/core/sudoers.j2
@@ -8,6 +8,8 @@
 # {{ rule.description }}
 # Environments: {{ rule.environments | join(', ') }}
 {{ rule.from_user }} ALL=({{ rule.as_user }}) NOPASSWD: {{ rule.cmd }} *
+{% if not loop.last %}
 
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.16.5"
+version = "0.16.6"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_deploy_service_manifest.py
+++ b/tests/test_deploy_service_manifest.py
@@ -208,6 +208,60 @@ fraises:
         # config_dir should be in ReadWritePaths
         assert "/opt/fraisier" in content
 
+    def test_deploy_service_emits_compact_ssh_option(self, tmp_path):
+        """GIT_SSH_COMMAND uses -oKey=Value form so systemd parses it as one value.
+
+        Regression test for #152: the space-separated `-o StrictHostKeyChecking=...`
+        form is tokenised by systemd before quote handling, so `-o` is rejected
+        with `Invalid environment assignment, ignoring: -o` and the option is
+        silently dropped — first-time host key acceptance never applied.
+        """
+        config = self._make_config(
+            tmp_path,
+            """
+name: myapp
+scaffold:
+  output_dir: scripts/generated
+  deploy_user: fraisier
+  config_path: /opt/fraisier/fraises.yaml
+
+fraises:
+  api:
+    type: api
+    environments:
+      dev:
+        app_path: /var/www/api
+        git_repo: /var/repos/api.git
+""",
+        )
+        renderer = ScaffoldRenderer(config)
+        renderer._validate_names()
+
+        context = dict(renderer.context)
+        context["fraise_name"] = "api"
+        context["env_name"] = "dev"
+
+        fraise = config.get_fraise("api")
+        env_config = fraise.get("environments", {}).get("dev", {})
+        context["env_config"] = env_config
+
+        from fraisier.naming import deploy_socket_name
+
+        socket_unit = deploy_socket_name(env_config, "dev", "api")
+        socket_stem = socket_unit.removesuffix(".socket")
+        context["socket_stem"] = socket_stem
+        context["socket_unit_name"] = socket_unit
+
+        template = renderer.env.get_template("core/deploy-service.j2")
+        content = template.render(**context)
+
+        assert 'GIT_SSH_COMMAND=ssh -oStrictHostKeyChecking=accept-new"' in content, (
+            "expected compact -oKey=Value ssh option form"
+        )
+        assert (
+            "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new" not in content
+        ), "space-separated -o form is tokenised by systemd and silently dropped"
+
     def test_deploy_service_no_hardcoded_readwrite_conditionals(self, tmp_path):
         """deploy-service.j2 has no hardcoded conditional ReadWritePaths blocks."""
         config = self._make_config(

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -4082,12 +4082,13 @@ scaffold:
 
         Bootstrap creates the deploy user's SSH keypair but does not populate
         ~/.ssh/known_hosts. Without StrictHostKeyChecking=accept-new the first
-        git fetch fails with SSH exit 255 (issue #116).
+        git fetch fails with SSH exit 255 (issue #116). The compact -oKey=Value
+        form is used so systemd parses it as one Environment= value (#152).
         """
         out = self._render(tmp_path)
         service = (out / "systemd" / "fraisier-api-production@.service").read_text()
         ssh_env = (
-            'Environment="GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new"'
+            'Environment="GIT_SSH_COMMAND=ssh -oStrictHostKeyChecking=accept-new"'
         )
         assert ssh_env in service
 

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -2721,6 +2721,81 @@ fraises:
         assert "FRAISIER_PG_WRAPPER" not in content
         assert "pgadmin-myproj" not in content
 
+    def test_sudoers_ends_with_exactly_one_trailing_newline(self, tmp_path):
+        """Generated sudoers file ends with one \\n, not two.
+
+        Regression test for #161: the previous template emitted a blank line
+        after every rule including the last, leaving the file ending in
+        ``\\n\\n``. pre-commit's end-of-file-fixer flagged it on every run.
+        """
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = _make_full_config(tmp_path)
+        renderer = ScaffoldRenderer(config)
+
+        rules = [
+            {
+                "from_user": "deployer",
+                "as_user": "root",
+                "cmd": "/usr/bin/apt-get install",
+                "environments": ["development", "production"],
+                "description": "Dependency install",
+            },
+            {
+                "from_user": "deployer",
+                "as_user": "postgres",
+                "cmd": "/usr/bin/createdb",
+                "environments": ["development"],
+                "description": "Dependency install",
+            },
+        ]
+
+        template = renderer.env.get_template("core/sudoers.j2")
+        content = template.render(
+            project_name="testproj",
+            sudoers_rules=rules,
+        )
+
+        assert content.endswith("\n"), "sudoers must end with a newline"
+        assert not content.endswith("\n\n"), (
+            "sudoers must not end with a blank line (pre-commit end-of-file-fixer flags it)"
+        )
+
+        body = content.split("# Dependency install rules (deduplicated)\n", 1)[1]
+        rule_blocks = [b for b in body.split("/usr/bin/") if b]
+        assert len(rule_blocks) >= 2, "expected both rules to render"
+        between = body.split("/usr/bin/apt-get install *", 1)[1]
+        between = between.split("# Dependency install", 1)[0]
+        assert "\n\n" in between, (
+            "blank line between rules should be preserved for human-readability"
+        )
+
+    def test_sudoers_single_rule_no_trailing_blank(self, tmp_path):
+        """Single-rule sudoers also ends cleanly with one \\n."""
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = _make_full_config(tmp_path)
+        renderer = ScaffoldRenderer(config)
+
+        rules = [
+            {
+                "from_user": "deployer",
+                "as_user": "root",
+                "cmd": "/usr/bin/apt-get install",
+                "environments": ["production"],
+                "description": "Dependency install",
+            },
+        ]
+
+        template = renderer.env.get_template("core/sudoers.j2")
+        content = template.render(
+            project_name="testproj",
+            sudoers_rules=rules,
+        )
+
+        assert content.endswith("\n")
+        assert not content.endswith("\n\n")
+
 
 class TestWebhookServerFiltering:
     """Webhook service filters ReadWritePaths by server (#62)."""

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -4087,9 +4087,7 @@ scaffold:
         """
         out = self._render(tmp_path)
         service = (out / "systemd" / "fraisier-api-production@.service").read_text()
-        ssh_env = (
-            'Environment="GIT_SSH_COMMAND=ssh -oStrictHostKeyChecking=accept-new"'
-        )
+        ssh_env = 'Environment="GIT_SSH_COMMAND=ssh -oStrictHostKeyChecking=accept-new"'
         assert ssh_env in service
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -509,6 +509,7 @@ class TestSyncConflicts:
                 _mk(),  # checkout origin/dev -- version.json
                 _mk(),  # git add version.json
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
+                _mk(returncode=1),  # git diff --cached --quiet → something staged
                 _mk(),  # git commit
                 _mk(),  # git push
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -519,6 +520,52 @@ class TestSyncConflicts:
         commit_calls = [c[0][0] for c in m.call_args_list if "commit" in c[0][0]]
         assert commit_calls, "expected at least one commit call"
         assert all("--no-verify" in call for call in commit_calls)
+
+    def test_pre_merge_skips_commit_when_resolution_yields_no_diff(self, tmp_path):
+        """Conflict-resolution path skips pre-merge commit when nothing is staged.
+
+        Regression test for #164. When every conflicted file auto-resolves
+        back to source HEAD (the sync branch's tip), the index after
+        `git add` is byte-identical to HEAD. Git refused the empty commit
+        and sync aborted. The fix mirrors the clean-merge path's existing
+        `git diff --cached --quiet` guard.
+        """
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                _mk(stdout="main\n"),
+                _mk(),
+                _mk(stdout=self.SHA + "\n"),
+                _mk(stdout=self.MERGE_BASE + "\n"),
+                _mk(returncode=0, stdout='{"version": "1.1.0"}'),
+                _mk(returncode=0, stdout='{"version": "1.0.0"}'),
+                _mk(),  # git checkout -b
+                _mk(returncode=1),  # git merge (conflict)
+                _mk(stdout="pyproject.toml\n"),  # diff --filter=U
+                _mk(returncode=0),  # cat-file origin/dev:pyproject.toml (exists)
+                _mk(),  # checkout origin/dev -- pyproject.toml
+                _mk(),  # git add pyproject.toml
+                _mk(stdout=""),  # diff --filter=U (remaining: clean)
+                _mk(returncode=0),  # git diff --cached --quiet → nothing staged
+                _mk(),  # git push
+                _mk(stdout=self.PR_URL + "\n"),  # gh pr create
+                _mk(),  # gh pr merge
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        commands = [c[0][0] for c in m.call_args_list]
+        commit_calls = [c for c in commands if "commit" in c]
+        assert commit_calls == [], (
+            "no commit should be issued when conflict resolution staged no diff"
+        )
+        staged_checks = [
+            c for c in commands if c == ["git", "diff", "--cached", "--quiet"]
+        ]
+        assert len(staged_checks) == 1, (
+            "conflict-resolution path must guard the pre-merge commit"
+        )
 
     def test_source_deletion_auto_resolved(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.16.5"
+version = "0.16.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.16.4"
+version = "0.16.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Three independent fixes that all surface as visible noise on every deploy or sync cycle. Each is XS by itself; bundled into v0.16.6 to avoid forcing consumers through two re-scaffold cycles in quick succession.

### Fixes

- **#152** — `deploy.service` `Environment=` for `GIT_SSH_COMMAND` was tokenised by systemd before quote handling, so `-o` was rejected with `Invalid environment assignment, ignoring: -o` on every activation and `StrictHostKeyChecking=accept-new` was silently dropped. The deploy unit logs the warning on every restart and the first `git fetch` against an unknown host fails with SSH exit 255 — the exact symptom #116 had originally tried to address. Switched to the equivalent no-space form `-oStrictHostKeyChecking=accept-new` (documented as equivalent in `ssh_config(5)`).
- **#161** — `scripts/generated/sudoers` ended with `\n\n` because the Jinja `{% for %}` body included a literal blank-line separator after every rule including the last. `pre-commit-hooks/end-of-file-fixer` flagged it on every commit. Guarded the separator with `{% if not loop.last %}` so the blank line still appears between rules (kept for human-readability during audits) but not after the final rule.
- **#164** — `fraisier sync` conflict-resolution path unconditionally ran `git commit --no-edit`. When every conflicted file auto-resolved back to source HEAD (the sync branch's tip), the staged index was byte-identical to HEAD and git refused the empty commit, aborting the sync. The clean-merge path already had a `git diff --cached --quiet` guard; this PR extracts both into a shared `_commit_if_staged(message)` helper so the symmetry is visible and the paths can't drift apart again.

### Per-commit breakdown

| Commit | What |
|---|---|
| `chore(deps): sync uv.lock to v0.16.5` | Catches the lockfile up after v0.16.5's pyproject bump (the release PR missed it). |
| `fix(scaffold): use compact -oKey=Value form for GIT_SSH_COMMAND (#152)` | Template + new regression test in `test_deploy_service_manifest.py`. |
| `fix(scaffold): drop trailing blank line in generated sudoers (#161)` | Template + two new regression tests in `test_scaffold.py` (multi-rule + single-rule). |
| `test(scaffold): align legacy GIT_SSH_COMMAND assertion with #152` | Updates the existing `test_deploy_service_has_git_ssh_command` to assert the new form. |
| `fix(sync): guard conflict-path pre-merge commit against empty index (#164)` | New `_commit_if_staged()` helper used by both merge paths; new regression test in `test_sync.py`. |
| `release: v0.16.6` | Version bump + CHANGELOG. |

## Test plan

- [x] `uv run pytest` — 3281 passed, 9 skipped locally
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [ ] CI: Python 3.11 / 3.12 / 3.13 matrix
- [ ] CI: lint + type-check + security
- [ ] CI: publish workflow tag-triggered after merge + tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)