### PR TITLE
release: v0.17.0 — parallel pg_dump + backup OnFailure hooks (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-21
+
+### Added
+
+- **Parallel `pg_dump` via `backup.jobs`** ([#202](https://github.com/fraiseql/fraisier/issues/202)). Set `backup.jobs: N` in `fraises.yaml` or pass `--jobs N` to `fraisier db backup` to run pg_dump with N parallel workers. When `jobs == 1` (default), behaviour is byte-identical to today — a single-stream `pg_dump -Fc` producing one `.dump` file. When `jobs > 1`, fraisier switches to directory format (`pg_dump -Fd -j N`) producing a `<db>_<mode>_<ts>_<algo>.dump/` directory containing `toc.dat` plus per-table `*.dat` blobs. Parallelism comes from concurrent table COPYs.
+- **`find_latest_backup` discovers directory-format dumps**. All restore consumers (the CLI restore path, `RestoreMigrateStrategy`) now transparently locate either form. `Path.glob` matched both already; the change is in behaviour lock-in and tests. `pg_restore` auto-detects `-Fd` from the positional directory path, so no caller needed adjusting.
+- **`OnFailure=` hook on scaffolded backup units** ([#202](https://github.com/fraiseql/fraisier/issues/202) Phase 4). Closes the alerting gap that hid the original prod incident — when a backup exits non-zero (pg_dump SIGTERM, disk full, TOC verification rejection, size-sanity rejection), systemd now triggers `fraisier-<project>-backup-alert@%n.service`. The default alert is passive — pipes one line through `systemd-cat` into the journal. Operators who want real alerting can override the template with `systemctl edit fraisier-<project>-backup-alert@.service` or replace the file. fraisier ships no notifier choice to avoid lock-in.
+
+### Changed
+
+- **Size sanity check for directory dumps** uses recursive content size, not the directory inode's bare `stat().st_size` (~4096 bytes). Extracted as `_dump_size(path)` in `fraisier/dbops/backup.py`. Without this, a directory dump would falsely trigger the size check whenever a prior file dump existed.
+- **`cleanup_old_backups` removes both file and directory dumps** via `shutil.rmtree` for directories, guarded by a resolved-path containment check against `backup_dir` so a glob result cannot escape via a symlinked entry.
+
+### Upgrade notes
+
+- Existing single-file `.dump` backups remain readable; nothing in the v0.16.x line is invalidated.
+- Existing installations must re-run `install.sh` to pick up the new `fraisier-<project>-backup-alert@.service` unit and the `OnFailure=` line on the existing backup unit.
+- Setting `backup.jobs > 1` requires that the database disk, the backup target disk, and the network between them can sustain N parallel reads/writes; higher `jobs` does not always mean faster. Tune to your hardware.
+- The pre-deploy `BackupHook` (the `pg_dump | gzip > *.sql.gz` path in `fraisier/hooks/backup.py`) is intentionally unchanged — that code path is separate from `run_backup()` and does not benefit from parallelism in its current form.
+
 ## [0.16.6] - 2026-05-21
 
 ### Fixed

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -686,14 +686,26 @@ def db_restore(
     type=click.Choice(["full", "slim"]),
     help="Backup mode",
 )
+@click.option(
+    "--jobs",
+    type=int,
+    default=None,
+    help=(
+        "Number of parallel pg_dump workers (overrides config backup.jobs). "
+        "Values >1 switch to directory-format dumps."
+    ),
+)
 @click.pass_context
-def backup_cmd(ctx: click.Context, fraise: str, env: str, mode: str) -> None:
+def backup_cmd(
+    ctx: click.Context, fraise: str, env: str, mode: str, jobs: int | None
+) -> None:
     """Run database backup for a fraise.
 
     \b
     Examples:
         fraisier backup management -e production
         fraisier backup management -e production --mode slim
+        fraisier backup management -e production --jobs 4
     """
     from fraisier.dbops.backup import check_disk_space, run_backup
     from fraisier.dbops.guard import is_external_db
@@ -744,6 +756,8 @@ def backup_cmd(ctx: click.Context, fraise: str, env: str, mode: str) -> None:
         slim_cfg = backup_cfg.get("slim", {})
         excluded_tables = slim_cfg.get("excluded_tables", [])
 
+    effective_jobs = jobs if jobs is not None else int(backup_cfg.get("jobs", 1))
+
     result = run_backup(
         db_name=db_name,
         output_dir=output_dir,
@@ -751,6 +765,7 @@ def backup_cmd(ctx: click.Context, fraise: str, env: str, mode: str) -> None:
         compression=compression,
         mode=mode,
         excluded_tables=excluded_tables,
+        jobs=effective_jobs,
     )
 
     if result.success:

--- a/fraisier/dbops/backup.py
+++ b/fraisier/dbops/backup.py
@@ -52,6 +52,21 @@ def _verify_backup_toc(
     return True, ""
 
 
+def _dump_size(path: Path) -> int:
+    """Return the on-disk byte total of a dump file or directory dump.
+
+    For a regular file dump (``pg_dump -Fc``), returns the file size.
+    For a directory dump (``pg_dump -Fd``), returns the recursive sum of
+    every contained file (``toc.dat`` plus every ``*.dat`` blob). Using
+    the directory's own ``stat().st_size`` would return the inode's
+    metadata size (typically 4096 bytes), which makes the size sanity
+    check meaningless for ``-Fd`` dumps.
+    """
+    if path.is_dir():
+        return sum(p.stat().st_size for p in path.rglob("*") if p.is_file())
+    return path.stat().st_size
+
+
 def _previous_same_mode_backup(
     output_dir: Path,
     *,
@@ -90,6 +105,7 @@ def run_backup(
     compression: str = "zstd:9",
     mode: str = "full",
     excluded_tables: list[str] | None = None,
+    jobs: int = 1,
 ) -> BackupResult:
     """Run pg_dump with custom-format compression.
 
@@ -102,7 +118,16 @@ def run_backup(
         compression: Compression spec (e.g. "zstd:9").
         mode: "full" or "slim" (slim excludes tables).
         excluded_tables: Tables to exclude in slim mode.
+        jobs: Number of parallel pg_dump workers. When ``1`` (default),
+            uses the single-stream custom format (``-Fc``) writing one
+            ``.dump`` file. When ``>1``, switches to directory format
+            (``-Fd -j N``) writing a ``.dump/`` directory containing
+            ``toc.dat`` plus per-table ``*.dat`` blobs. Parallelism comes
+            from concurrent table COPYs.
     """
+    if not isinstance(jobs, int) or isinstance(jobs, bool) or jobs < 1:
+        msg = f"jobs must be a positive integer, got {jobs!r}"
+        raise ValueError(msg)
     validate_pg_identifier(db_name, "database name")
     _validate_compression(compression)
     validate_file_path(output_dir)
@@ -113,13 +138,13 @@ def run_backup(
     filename = f"{db_name}_{mode}_{timestamp}{suffix}.dump"
     backup_path = f"{output_dir}/{filename}"
 
-    cmd: list[str] = [
-        "pg_dump",
-        "-Fc",
-        f"--compress={compression}",
-        "-f",
-        backup_path,
-    ]
+    # pg_dump itself creates the directory for -Fd and refuses if it already exists.
+    cmd: list[str] = ["pg_dump"]
+    if jobs > 1:
+        cmd.extend(["-Fd", "-j", str(jobs)])
+    else:
+        cmd.append("-Fc")
+    cmd.extend([f"--compress={compression}", "-f", backup_path])
 
     if mode == "slim" and excluded_tables:
         for table in excluded_tables:
@@ -149,8 +174,8 @@ def run_backup(
         Path(output_dir), db_name=db_name, mode=mode, current_path=backup_path
     )
     if prev is not None:
-        prev_size = prev.stat().st_size
-        cur_size = Path(backup_path).stat().st_size
+        prev_size = _dump_size(prev)
+        cur_size = _dump_size(Path(backup_path))
         if prev_size > 0 and cur_size < prev_size * _SIZE_SANITY_RATIO:
             return BackupResult(
                 success=False,
@@ -177,17 +202,31 @@ def cleanup_old_backups(
     *,
     retention_hours: int,
 ) -> list[str]:
-    """Remove backup files older than *retention_hours*.
+    """Remove backup files and directory dumps older than *retention_hours*.
 
-    Returns list of removed file paths.
+    Handles both ``-Fc`` file dumps (one ``.dump`` file) and ``-Fd``
+    directory dumps (one ``.dump/`` directory tree). For each match,
+    ``rmtree`` is guarded by a resolved-path containment check against
+    ``backup_dir`` to ensure a glob result can't escape via a symlinked
+    entry.
+
+    Returns the list of removed paths (as strings).
     """
     cutoff = time.time() - retention_hours * 3600
+    resolved_root = backup_dir.resolve()
     removed: list[str] = []
 
     for f in backup_dir.glob("*.dump"):
-        if f.stat().st_mtime < cutoff:
+        if f.stat().st_mtime >= cutoff:
+            continue
+        resolved = f.resolve()
+        if not resolved.is_relative_to(resolved_root):
+            continue
+        if f.is_dir():
+            shutil.rmtree(f)
+        else:
             f.unlink()
-            removed.append(str(f))
+        removed.append(str(f))
 
     return removed
 

--- a/fraisier/dbops/restore.py
+++ b/fraisier/dbops/restore.py
@@ -108,11 +108,20 @@ def find_latest_backup(
     pattern: str = "*.dump",
     preferred_compression: str | None = None,
 ) -> Path | None:
-    """Find the most recent backup file matching *pattern* in *backup_dir*.
+    """Find the most recent backup file or directory matching *pattern* in *backup_dir*.
+
+    Discovers both ``pg_dump -Fc`` file dumps (``*.dump``) and parallel
+    ``pg_dump -Fd`` directory dumps (``*.dump/`` containing ``toc.dat``
+    plus per-table ``*.dat`` blobs). The producer side names both forms
+    with the same ``<db>_<mode>_<ts>_<algo>.dump`` convention so a single
+    glob covers both; ordering is by mtime, with the directory's own
+    mtime reflecting the moment ``pg_dump`` finished writing the last
+    ``*.dat`` block.
 
     When *preferred_compression* is set (e.g. ``"lz4"``), tries to find
-    the newest dump whose filename contains ``_{algo}.dump`` first.
-    Falls back to the regular newest-dump selection if none match.
+    the newest dump whose filename contains ``_{algo}.dump`` first
+    (matching either form). Falls back to the regular newest-dump
+    selection if none match.
     """
     if preferred_compression:
         pref_pattern = f"*_{preferred_compression}.dump"

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -670,10 +670,15 @@ class ScaffoldRenderer:
         rendered_files.extend(self._collect_per_env_nginx(dry_run))
 
         # Systemd timer and backup service templates
+        project_name = self.context.get("project_name", "fraisier")
         for timer_tpl, timer_out in [
             ("core/deploy-checker.timer.j2", "systemd/deploy-checker.timer"),
             ("core/backup.timer.j2", "systemd/backup.timer"),
             ("core/backup.service.j2", "systemd/backup.service"),
+            (
+                "core/backup-alert@.service.j2",
+                f"systemd/fraisier-{project_name}-backup-alert@.service",
+            ),
         ]:
             rendered_files.append(timer_out)
             if not dry_run:

--- a/fraisier/scaffold/templates/core/backup-alert@.service.j2
+++ b/fraisier/scaffold/templates/core/backup-alert@.service.j2
@@ -1,0 +1,7 @@
+[Unit]
+Description=Backup failure alert for {{ project_name }} (%i)
+Documentation=https://fraisier.readthedocs.io/
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "echo 'fraisier-{{ project_name }} backup failed: %i' | systemd-cat -t fraisier-backup-alert -p err"

--- a/fraisier/scaffold/templates/core/backup.service.j2
+++ b/fraisier/scaffold/templates/core/backup.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=Database backup for {{ project_name }}
+OnFailure=fraisier-{{ project_name }}-backup-alert@%n.service
 
 [Service]
 Type=oneshot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.16.6"
+version = "0.17.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_cli_db.py
+++ b/tests/test_cli_db.py
@@ -232,6 +232,7 @@ class TestBackup:
             compression="zstd:9",
             mode="full",
             excluded_tables=[],
+            jobs=1,
         )
 
     def test_backup_insufficient_disk_space_exits_1(self, runner, mock_config):
@@ -285,7 +286,42 @@ class TestBackup:
             compression="zstd:9",
             mode="slim",
             excluded_tables=["logs", "events"],
+            jobs=1,
         )
+
+    def test_backup_passes_jobs_from_config(self, runner, mock_config):
+        """backup reads backup.jobs from config and forwards to run_backup (#202)."""
+        mock_config._config = {"backup": {"jobs": 4}}
+        result_mock = MagicMock(success=True, backup_path="/backup/mydb.dump")
+        with (
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch("fraisier.dbops.backup.check_disk_space", return_value=True),
+            patch(
+                "fraisier.dbops.backup.run_backup", return_value=result_mock
+            ) as mock_backup,
+        ):
+            result = runner.invoke(main, ["backup", "my_api", "-e", "production"])
+
+        assert result.exit_code == 0
+        assert mock_backup.call_args.kwargs["jobs"] == 4
+
+    def test_backup_jobs_flag_overrides_config(self, runner, mock_config):
+        """--jobs takes precedence over backup.jobs from config (#202)."""
+        mock_config._config = {"backup": {"jobs": 2}}
+        result_mock = MagicMock(success=True, backup_path="/backup/mydb.dump")
+        with (
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch("fraisier.dbops.backup.check_disk_space", return_value=True),
+            patch(
+                "fraisier.dbops.backup.run_backup", return_value=result_mock
+            ) as mock_backup,
+        ):
+            result = runner.invoke(
+                main, ["backup", "my_api", "-e", "production", "--jobs", "8"]
+            )
+
+        assert result.exit_code == 0
+        assert mock_backup.call_args.kwargs["jobs"] == 8
 
 
 class TestDbRestore:

--- a/tests/test_dbops_backup.py
+++ b/tests/test_dbops_backup.py
@@ -257,6 +257,160 @@ class TestRunBackup:
         assert result.error == ""
 
 
+class TestRunBackupJobs:
+    """Test run_backup parallel/directory-format mode (#202 Phase 3)."""
+
+    def test_jobs_1_uses_Fc_format_and_file_output(self, tmp_path: Path):
+        """jobs=1 (default) preserves the single-stream -Fc behaviour byte-for-byte."""
+        captured: dict = {}
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "pg_dump":
+                captured["cmd"] = list(cmd)
+                out = cmd[cmd.index("-f") + 1]
+                Path(out).write_bytes(b"x" * 1000)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = run_backup(
+                db_name="proddb",
+                output_dir=str(tmp_path),
+                database_url=_TEST_URL,
+                jobs=1,
+            )
+
+        assert result.success is True
+        cmd = captured["cmd"]
+        assert "-Fc" in cmd
+        assert "-Fd" not in cmd
+        assert "-j" not in cmd
+        assert Path(result.backup_path).is_file()
+        assert not Path(result.backup_path).is_dir()
+
+    def test_jobs_default_matches_jobs_1(self, tmp_path: Path):
+        """Omitting jobs keeps the file-format behaviour."""
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "pg_dump":
+                out = cmd[cmd.index("-f") + 1]
+                Path(out).write_bytes(b"x" * 1000)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = run_backup(
+                db_name="proddb",
+                output_dir=str(tmp_path),
+                database_url=_TEST_URL,
+            )
+
+        assert result.success is True
+        assert Path(result.backup_path).is_file()
+
+    def test_jobs_greater_than_1_uses_Fd_format_and_directory_output(
+        self, tmp_path: Path
+    ):
+        """jobs=4 switches to pg_dump -Fd -j 4 writing a directory dump."""
+        captured: dict = {}
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "pg_dump":
+                captured["cmd"] = list(cmd)
+                out = cmd[cmd.index("-f") + 1]
+                # pg_dump -Fd creates the directory and writes toc.dat + per-table blobs.
+                Path(out).mkdir(parents=False, exist_ok=False)
+                (Path(out) / "toc.dat").write_bytes(b"toc" * 100)
+                (Path(out) / "1.dat").write_bytes(b"data" * 250)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = run_backup(
+                db_name="proddb",
+                output_dir=str(tmp_path),
+                database_url=_TEST_URL,
+                jobs=4,
+            )
+
+        assert result.success is True, result.error
+        cmd = captured["cmd"]
+        assert "-Fd" in cmd
+        assert "-Fc" not in cmd
+        assert "-j" in cmd
+        assert cmd[cmd.index("-j") + 1] == "4"
+        path = Path(result.backup_path)
+        assert path.is_dir()
+        assert path.name.endswith(".dump")
+        assert (path / "toc.dat").exists()
+
+    def test_size_check_uses_directory_total_for_directory_dumps(self, tmp_path: Path):
+        """Size sanity check sums directory contents recursively (#202 Phase 3).
+
+        Without recursive sizing, a directory dump's bare inode size
+        (~4096 bytes) would falsely trigger the size sanity check
+        whenever a prior file dump existed of any meaningful size.
+        """
+        # Prior file dump: 10_000 bytes
+        prev = tmp_path / "proddb_full_20260520_1200_zstd.dump"
+        prev.write_bytes(b"x" * 10_000)
+        os.utime(prev, (1_000_000, 1_000_000))
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "pg_dump":
+                out = cmd[cmd.index("-f") + 1]
+                Path(out).mkdir(parents=False, exist_ok=False)
+                # New directory dump: 8_000 bytes total — 80% of prior, well above threshold.
+                (Path(out) / "toc.dat").write_bytes(b"t" * 2_000)
+                (Path(out) / "1.dat").write_bytes(b"d" * 6_000)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = run_backup(
+                db_name="proddb",
+                output_dir=str(tmp_path),
+                database_url=_TEST_URL,
+                jobs=4,
+            )
+
+        assert result.success is True, result.error
+        assert Path(result.backup_path).is_dir()
+
+    def test_size_check_fails_when_directory_dump_undersized(self, tmp_path: Path):
+        """A directory dump under 50% of the prior total is rejected."""
+        prev = tmp_path / "proddb_full_20260520_1200_zstd.dump"
+        prev.write_bytes(b"x" * 10_000)
+        os.utime(prev, (1_000_000, 1_000_000))
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "pg_dump":
+                out = cmd[cmd.index("-f") + 1]
+                Path(out).mkdir(parents=False, exist_ok=False)
+                # New directory dump: only 1_000 bytes — 10% of prior.
+                (Path(out) / "toc.dat").write_bytes(b"t" * 500)
+                (Path(out) / "1.dat").write_bytes(b"d" * 500)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = run_backup(
+                db_name="proddb",
+                output_dir=str(tmp_path),
+                database_url=_TEST_URL,
+                jobs=4,
+            )
+
+        assert result.success is False
+        assert "size sanity" in result.error
+
+    def test_jobs_rejects_zero_and_negative(self, tmp_path: Path):
+        """jobs must be a positive integer; 0 and negatives raise ValueError."""
+        for bad in (0, -1, -10):
+            with pytest.raises(ValueError, match="jobs"):
+                run_backup(
+                    db_name="proddb",
+                    output_dir=str(tmp_path),
+                    database_url=_TEST_URL,
+                    jobs=bad,
+                )
+
+
 class TestVerifyBackupToc:
     """Test _verify_backup_toc helper."""
 
@@ -367,3 +521,46 @@ class TestCleanupOldBackups:
         assert recent_file.exists()
         assert non_dump.exists()
         assert len(removed) == 1
+
+    def test_cleanup_removes_old_directory_dumps(self, tmp_path: Path):
+        """Old directory-format dumps (#202 Phase 3) are removed via rmtree."""
+        old_dir = tmp_path / "proddb_full_20250101_0000_zstd.dump"
+        old_dir.mkdir()
+        (old_dir / "toc.dat").write_text("toc")
+        (old_dir / "1.dat").write_text("data")
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_dir, (old_mtime, old_mtime))
+
+        recent_dir = tmp_path / "proddb_full_20250320_1200_zstd.dump"
+        recent_dir.mkdir()
+        (recent_dir / "toc.dat").write_text("toc")
+
+        removed = cleanup_old_backups(tmp_path, retention_hours=24)
+
+        assert str(old_dir) in removed
+        assert not old_dir.exists()
+        assert recent_dir.exists()
+        assert (recent_dir / "toc.dat").exists()
+
+    def test_cleanup_mixed_files_and_directories(self, tmp_path: Path):
+        """Mixed file + directory dumps are both eligible for removal."""
+        old_mtime = time.time() - 48 * 3600
+
+        old_file = tmp_path / "proddb_full_20250101_0000.dump"
+        old_file.write_text("old file")
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        old_dir = tmp_path / "proddb_full_20250101_0100_zstd.dump"
+        old_dir.mkdir()
+        (old_dir / "toc.dat").write_text("toc")
+        os.utime(old_dir, (old_mtime, old_mtime))
+
+        new_file = tmp_path / "proddb_full_20250320_1200.dump"
+        new_file.write_text("new file")
+
+        removed = cleanup_old_backups(tmp_path, retention_hours=24)
+
+        assert sorted(removed) == sorted([str(old_file), str(old_dir)])
+        assert not old_file.exists()
+        assert not old_dir.exists()
+        assert new_file.exists()

--- a/tests/test_dbops_restore.py
+++ b/tests/test_dbops_restore.py
@@ -55,6 +55,34 @@ class TestRestoreBackup:
         assert result.success is False
         assert "pg_restore: error" in result.error
 
+    def test_restore_backup_accepts_directory_dump_path(self, tmp_path: Path):
+        """restore_backup forwards a directory-format dump path to pg_restore unchanged.
+
+        pg_restore auto-detects ``-Fd`` from the positional path being a
+        directory. Lock-in for #202 Phase 3 — once parallel pg_dump
+        starts producing directory dumps, every existing restore caller
+        must work without further changes.
+        """
+        dir_dump = tmp_path / "mydb_full_20260520_1200_zstd.dump"
+        dir_dump.mkdir()
+        (dir_dump / "toc.dat").write_text("stub toc")
+
+        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
+            mock_cmd.return_value = (0, "", "")
+            result = restore_backup(
+                backup_path=str(dir_dump),
+                db_name="staging",
+                connection_url=_TEST_URL,
+            )
+
+        assert result.success is True
+        cmd = mock_cmd.call_args[0][0]
+        assert cmd[0] == "pg_restore"
+        assert str(dir_dump) in cmd
+        assert not any(arg.startswith("-F") for arg in cmd), (
+            "pg_restore must auto-detect dump format; no -F flag override"
+        )
+
     def test_restore_with_owner_fix(self):
         with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
             mock_cmd.return_value = (0, "", "")
@@ -265,3 +293,79 @@ class TestFindLatestBackup:
 
         result = find_latest_backup(tmp_path)
         assert result == zstd
+
+    def test_find_latest_backup_returns_directory_dump(self, tmp_path: Path):
+        """find_latest_backup discovers pg_dump -Fd directory dumps (#202 Phase 2).
+
+        Parallel pg_dump produces a directory containing toc.dat + per-table
+        .dat files. Path.glob matches both files and directories, so the
+        function should locate it without special-casing.
+        """
+        import os
+
+        dir_dump = tmp_path / "mydb_full_20260520_1200_zstd.dump"
+        dir_dump.mkdir()
+        (dir_dump / "toc.dat").write_text("stub toc")
+        os.utime(dir_dump, (2000, 2000))
+
+        result = find_latest_backup(tmp_path)
+        assert result == dir_dump
+        assert result is not None and result.is_dir()
+
+    def test_find_latest_backup_picks_newer_directory_over_older_file(
+        self, tmp_path: Path
+    ):
+        """When a directory dump is newer than the latest file dump, it wins."""
+        import os
+
+        file_dump = tmp_path / "mydb_full_20260519_1200_zstd.dump"
+        file_dump.write_text("file dump bytes")
+        os.utime(file_dump, (1000, 1000))
+
+        dir_dump = tmp_path / "mydb_full_20260520_1200_zstd.dump"
+        dir_dump.mkdir()
+        (dir_dump / "toc.dat").write_text("stub toc")
+        os.utime(dir_dump, (2000, 2000))
+
+        result = find_latest_backup(tmp_path)
+        assert result == dir_dump
+
+    def test_find_latest_backup_picks_newer_file_over_older_directory(
+        self, tmp_path: Path
+    ):
+        """Symmetric case: newer file dump wins over older directory dump."""
+        import os
+
+        dir_dump = tmp_path / "mydb_full_20260519_1200_zstd.dump"
+        dir_dump.mkdir()
+        (dir_dump / "toc.dat").write_text("stub toc")
+        os.utime(dir_dump, (1000, 1000))
+
+        file_dump = tmp_path / "mydb_full_20260520_1200_zstd.dump"
+        file_dump.write_text("file dump bytes")
+        os.utime(file_dump, (2000, 2000))
+
+        result = find_latest_backup(tmp_path)
+        assert result == file_dump
+
+    def test_find_latest_backup_preferred_compression_matches_directory(
+        self, tmp_path: Path
+    ):
+        """preferred_compression matches directory dumps by filename suffix.
+
+        The producer (Phase 3) names directory dumps `<db>_<mode>_<ts>_<algo>.dump/`,
+        so the filename-suffix match used by file dumps works unchanged.
+        """
+        import os
+
+        zstd_file = tmp_path / "mydb_full_20260520_1300_zstd.dump"
+        zstd_file.write_text("zstd file dump")
+        os.utime(zstd_file, (2000, 2000))  # newer
+
+        lz4_dir = tmp_path / "mydb_full_20260520_1200_lz4.dump"
+        lz4_dir.mkdir()
+        (lz4_dir / "toc.dat").write_text("stub toc")
+        os.utime(lz4_dir, (1000, 1000))  # older
+
+        result = find_latest_backup(tmp_path, preferred_compression="lz4")
+        assert result == lz4_dir

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -708,6 +708,66 @@ scaffold:
             assert directive in content, f"Missing directive: {directive}"
         assert "ReadWritePaths=/var/backups/" in content
 
+    def test_backup_service_has_on_failure_alert_hook(self, tmp_path):
+        """backup.service emits OnFailure= so operators see backup failures (#202 Phase 4)."""
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = self._make_config(
+            tmp_path,
+            """
+name: tp
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        worker_count: 2
+scaffold:
+  output_dir: {output}
+""".format(output=str(tmp_path / "output")),
+        )
+        renderer = ScaffoldRenderer(config)
+        renderer.render()
+
+        svc_path = tmp_path / "output" / "systemd" / "backup.service"
+        content = svc_path.read_text()
+
+        assert "OnFailure=fraisier-tp-backup-alert@%n.service" in content
+
+    def test_backup_alert_unit_is_scaffolded(self, tmp_path):
+        """backup-alert@.service template renders with a systemd-cat default (#202 Phase 4)."""
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = self._make_config(
+            tmp_path,
+            """
+name: tp
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        worker_count: 2
+scaffold:
+  output_dir: {output}
+""".format(output=str(tmp_path / "output")),
+        )
+        renderer = ScaffoldRenderer(config)
+        renderer.render()
+
+        alert_path = (
+            tmp_path / "output" / "systemd" / "fraisier-tp-backup-alert@.service"
+        )
+        assert alert_path.exists(), "backup-alert@.service must be scaffolded"
+        content = alert_path.read_text()
+
+        # Default action is passive — log to journal via systemd-cat.
+        assert "systemd-cat" in content
+        assert "fraisier-backup-alert" in content
+        # %i identifies the failing unit; OnFailure= passes the failing
+        # unit's name via %n which becomes the template instance.
+        assert "%i" in content
+
 
 class TestNginxTemplate:
     """Nginx reverse proxy template with SSL, CORS, security headers."""

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.16.6"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Minor release closing #202. Three new capabilities, all on the backup/restore pipeline:

- **Parallel `pg_dump`** via `backup.jobs: N` config / `--jobs N` CLI. When `jobs > 1`, fraisier switches to directory format (`pg_dump -Fd -j N`) writing a `<db>_<mode>_<ts>_<algo>.dump/` tree of `toc.dat` + per-table `*.dat` blobs. Parallelism comes from concurrent table COPYs. `jobs = 1` (default) is byte-identical to v0.16.x.
- **Directory-dump discovery** on the restore side. `find_latest_backup` and `restore_backup` transparently handle either form — `Path.glob` matched both already; this PR locks in the contract with tests and updates docstrings. `pg_restore` auto-detects `-Fd` from the positional directory path so no caller needed adjusting.
- **`OnFailure=` alerting hook** on every scaffolded backup unit. Closes the alerting gap that hid the original prod incident — pg_dump SIGTERM, disk full, TOC verification rejection (#202 Phase 1), and the new size-sanity rejection all now trigger `fraisier-<project>-backup-alert@%n.service`. The default action is passive (one line through `systemd-cat` into the journal); operators replace the template with whatever notifier they prefer.

## Per-commit breakdown

| Commit | What |
|---|---|
| `feat(restore): find_latest_backup discovers directory-format dumps (#202)` | Phase 2 — consumer-side. 5 new tests, docstring update; zero functional change to `find_latest_backup`. |
| `feat(backup): parallel pg_dump -Fd -j N for large databases (#202)` | Phase 3 — producer-side. New `jobs` kwarg on `run_backup`, `_dump_size(path)` helper for the size sanity check, directory-aware `cleanup_old_backups` with a resolved-path containment guard. CLI `--jobs` flag plus `backup.jobs` config plumbing. 8 new tests. |
| `feat(scaffold): OnFailure= alerting hook for backup units (#202)` | Phase 4 — scaffold. New `backup-alert@.service.j2` template + `OnFailure=` line on `backup.service.j2` + renderer wiring. 2 new tests. |
| `release: v0.17.0` | Version bump + CHANGELOG. |

## Out of scope (per Phase 3 plan)

- **`fraisier/hooks/backup.py` (pre-deploy `BackupHook`)** is unchanged. That code path is `pg_dump | gzip > *.sql.gz` — a self-contained pre-deploy snapshot mechanism that does not call `run_backup()`. Unifying is a separate ticket.

## Test plan

- [x] `uv run pytest` — full suite passes locally
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [ ] CI: Python 3.11 / 3.12 / 3.13 matrix
- [ ] CI: lint + type-check + security
- [ ] CI: publish workflow tag-triggered after merge + tag push
- [ ] Manual staging E2E: scaffold a fraise with `backup.jobs: 4`, run `fraisier db backup`, confirm a `*.dump/` directory + `toc.dat` appear, then `fraisier db restore` against it.
- [ ] Manual staging E2E: force a backup to fail (point at non-existent DB), `journalctl -t fraisier-backup-alert` shows the alert.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)