### PR TITLE
release: v0.18.0 — webhook self-upgrade on pyproject pin (#162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Webhook self-upgrade when deployed pyproject pins a newer fraisier** ([#162](https://github.com/fraiseql/fraisier/issues/162)). After every successful deploy the webhook inspects the deployed `pyproject.toml`. If `[project].dependencies` (or any `[project.optional-dependencies.*]` group) contains an exact `fraisier==X.Y.Z` pin newer than the running webhook, fraisier detaches a worker that runs `uv tool install --force --refresh-package fraisier fraisier==X.Y.Z` against the webhook user's own uv tool directory, then asks the systemctl-helper socket to restart the webhook unit. The current deploy is unaffected — the upgrade applies to the next deploy. Range-pinned (`>=`, `~=`, `!=`) and unpinned dependencies are intentionally skipped. Complements the bootstrap-side restart already shipped in [#156](https://github.com/fraiseql/fraisier/issues/156) by covering the deploy-driven path (the operator-driven path was already covered).
+- **`fraisier-{project}-webhook.service` in the systemctl-helper allowlist**. The self-upgrade above restarts the webhook via the existing root-privileged `fraisier-systemctl-helper.service` socket — the webhook process is not root, so it cannot `systemctl restart` itself directly. The helper rejects any service not in its compile-time allowlist; the webhook unit is now included by `_collect_allowed_services` in `fraisier/scaffold/renderer.py`.
+- **`webhook.self_upgrade` config knob**. Default: `true`. Set `webhook: { self_upgrade: false }` in `fraises.yaml` to opt out per webhook.
+
+### Upgrade notes
+
+- Existing installations must re-scaffold and re-run `install.sh` to add the webhook unit to the systemctl-helper allowlist. Until they do, the install side of the self-upgrade succeeds but the restart RPC is rejected (logged at `error` level, deploy is not affected).
+- Self-upgrade logs land in `/var/lib/fraisier/self-upgrade/{project}-{ts}.log` (one file per upgrade attempt). Inspect there when a self-upgrade does not seem to have taken effect.
+
 ## [0.17.0] - 2026-05-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.18.0] - 2026-05-21
 
 ### Added
 

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -287,3 +287,19 @@ branch_mapping:
   #     environment: production
   #   - fraise: worker
   #     environment: production
+
+# ============================================================
+# WEBHOOK BEHAVIOUR
+# ============================================================
+# webhook:
+#   # When true (default), after every successful deploy the webhook
+#   # checks whether the deployed pyproject.toml pins a newer fraisier
+#   # version than the webhook is running. If so, it detaches an
+#   # `uv tool install --force fraisier==<pinned>` and asks the
+#   # systemctl-helper socket to restart the webhook unit. See #162.
+#   #
+#   # Prerequisite: the webhook unit must appear in the systemctl-helper
+#   # allowlist. Re-scaffold and re-run install.sh after upgrading to
+#   # v0.18.0+ to pick it up. Until then the install succeeds but the
+#   # restart RPC fails (and is logged).
+#   self_upgrade: true

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -186,8 +186,10 @@ def _collect_allowed_services(
     """Collect all systemd service names from fraises and environments.
 
     Returns fully-qualified service names (e.g., 'project_fraise_env.service').
+    The webhook's own service unit is included so the #162 self-upgrade path
+    can restart the webhook via the systemctl-helper socket.
     """
-    services = []
+    services = [f"fraisier-{project_name}-webhook.service"]
     for fraise in fraises_list:
         fraise_name = fraise.get("name", "")
         if not fraise_name:

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -20,9 +20,7 @@ APP_VERSION_RE = re.compile(r"^[A-Za-z0-9._+\-]+$")
 
 # Matches "fraisier" or "fraisier[extras]" as the dependency name,
 # followed by an exact == pin and a semver-shaped version.
-_FRAISIER_PIN_RE = re.compile(
-    r"^\s*fraisier(?:\[[^\]]*\])?\s*==\s*(\d+\.\d+\.\d+)\s*$"
-)
+_FRAISIER_PIN_RE = re.compile(r"^\s*fraisier(?:\[[^\]]*\])?\s*==\s*(\d+\.\d+\.\d+)\s*$")
 
 
 def _validate_app_version(version: str, *, source: str) -> tuple[str, str] | None:

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -7,6 +7,7 @@ and database version derivation.
 import json
 import logging
 import re
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,12 @@ log = logging.getLogger(__name__)
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 
 APP_VERSION_RE = re.compile(r"^[A-Za-z0-9._+\-]+$")
+
+# Matches "fraisier" or "fraisier[extras]" as the dependency name,
+# followed by an exact == pin and a semver-shaped version.
+_FRAISIER_PIN_RE = re.compile(
+    r"^\s*fraisier(?:\[[^\]]*\])?\s*==\s*(\d+\.\d+\.\d+)\s*$"
+)
 
 
 def _validate_app_version(version: str, *, source: str) -> tuple[str, str] | None:
@@ -349,6 +356,37 @@ def read_pyproject_version(pyproject_path: Path) -> str:
     if not m:
         raise ValueError(f"No version field found in {pyproject_path}")
     return m.group(2)
+
+
+def detect_required_fraisier_version(app_path: Path) -> str | None:
+    """Return the exact fraisier version pinned in ``app_path/pyproject.toml``.
+
+    Walks ``[project].dependencies`` and every ``[project.optional-dependencies.*]``
+    group, returning the first ``X.Y.Z`` that follows a ``fraisier==`` (or
+    ``fraisier[extra]==``) exact pin. Returns ``None`` if fraisier is absent,
+    range-pinned (``>=``, ``~=``, ``!=``, etc.), or unpinned — the caller treats
+    ``None`` as "no upgrade decision can be made".
+    """
+    pyproject = app_path / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    project = data.get("project", {})
+    candidates: list[str] = list(project.get("dependencies") or [])
+    optional = project.get("optional-dependencies") or {}
+    for group in optional.values():
+        if isinstance(group, list):
+            candidates.extend(group)
+    for dep in candidates:
+        if not isinstance(dep, str):
+            continue
+        match = _FRAISIER_PIN_RE.match(dep)
+        if match:
+            return match.group(1)
+    return None
 
 
 def generate_version_json(

--- a/fraisier/webhook.py
+++ b/fraisier/webhook.py
@@ -26,6 +26,7 @@ from .git import GitProvider, WebhookEvent, get_provider
 from .locking import deployment_lock, is_deployment_locked
 from .status import read_status
 from .webhook_rate_limit import check_rate_limit
+from .webhook_self_upgrade import maybe_self_upgrade
 
 # Configure logging
 logging.basicConfig(
@@ -246,6 +247,14 @@ async def _run_deployment(
                 f"Deployment successful: {fraise_name}/{environment} "
                 f"({result.old_version} -> {result.new_version})"
             )
+            app_path = fraise_config.get("app_path")
+            if app_path:
+                webhook_cfg = config.webhook
+                maybe_self_upgrade(
+                    Path(app_path),
+                    project_name=config.project_name,
+                    enabled=bool(webhook_cfg.get("self_upgrade", True)),
+                )
         else:
             logger.error(
                 f"Deployment failed: {fraise_name}/{environment} "

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -1,0 +1,181 @@
+"""Webhook-driven self-upgrade for fraisier (issue #162).
+
+When a deployed pyproject.toml pins a newer fraisier than the webhook is
+running, ``maybe_self_upgrade`` detaches a worker subprocess that:
+
+1. runs ``uv tool install --force --refresh-package fraisier fraisier=={X}``
+   against the webhook user's own uv tool dir, then
+2. on success, sends a ``restart`` RPC to the systemctl-helper socket
+   (``FRAISIER_SYSTEMCTL_SOCKET``) for the webhook's own service unit.
+
+The worker is spawned with ``start_new_session=True`` so it survives the
+webhook restart that follows step 2. The webhook's own service unit must
+appear in the systemctl-helper allowlist (added in Phase 3); without it
+the restart RPC is rejected with ``service not allowed``.
+
+Mirrors the operator-driven path in :mod:`fraisier.bootstrap` (commit
+``590e31a``), which covers the workstation-side upgrade.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as importlib_metadata
+import logging
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fraisier.service_managers.systemd import _call_via_socket
+from fraisier.versioning import detect_required_fraisier_version
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Callable
+
+log = logging.getLogger(__name__)
+
+# Webhook units run with ProtectSystem=strict and have /var/lib/fraisier in
+# ReadWritePaths, so a sibling directory is writable by the deploy user.
+_LOG_DIR = Path("/var/lib/fraisier/self-upgrade")
+
+
+def _build_install_cmd(required: str) -> list[str]:
+    """Return the argv for ``uv tool install`` matching bootstrap's form."""
+    return [
+        "uv",
+        "tool",
+        "install",
+        "--force",
+        "--refresh-package",
+        "fraisier",
+        f"fraisier=={required}",
+    ]
+
+
+def _parse_semver(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"not semver: {version!r}")
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def maybe_self_upgrade(
+    app_path: Path,
+    *,
+    project_name: str,
+    enabled: bool,
+    spawn: Callable[[str, str], None] | None = None,
+) -> None:
+    """Best-effort: detect a newer pinned fraisier and spawn a detached upgrade.
+
+    Never raises — a failure here must not break a successful deploy. The
+    *spawn* parameter is a test seam; production code leaves it at None and
+    uses :func:`_spawn_upgrade`.
+    """
+    if not enabled:
+        return
+    try:
+        required = detect_required_fraisier_version(app_path)
+        if required is None:
+            return
+        installed = importlib_metadata.version("fraisier")
+        try:
+            if _parse_semver(required) <= _parse_semver(installed):
+                return
+        except ValueError:
+            log.warning(
+                "self-upgrade: skipping — non-semver version comparison "
+                "(required=%s installed=%s)",
+                required,
+                installed,
+            )
+            return
+        log.info(
+            "self-upgrade: required=%s installed=%s — spawning upgrade for %s",
+            required,
+            installed,
+            project_name,
+        )
+        (spawn or _spawn_upgrade)(required, project_name)
+    except Exception:
+        log.exception("self-upgrade: skipped due to unexpected error")
+
+
+def _open_log_fd(project_name: str):
+    """Open a log file under :data:`_LOG_DIR`. Fall back to DEVNULL on failure."""
+    try:
+        _LOG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+        return (_LOG_DIR / f"{project_name}-{ts}.log").open("ab")
+    except OSError as exc:
+        log.warning("self-upgrade: could not open log file (%s); using DEVNULL", exc)
+        return subprocess.DEVNULL
+
+
+def _spawn_upgrade(required: str, project_name: str) -> None:
+    """Spawn the detached worker that runs install + restart-RPC."""
+    socket_path = os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", "")
+    service = f"fraisier-{project_name}-webhook.service"
+    cmd = [
+        sys.executable,
+        "-m",
+        "fraisier.webhook_self_upgrade",
+        "--required",
+        required,
+        "--service",
+        service,
+        "--socket",
+        socket_path,
+    ]
+    stdout = _open_log_fd(project_name)
+    subprocess.Popen(
+        cmd,
+        start_new_session=True,
+        stdin=subprocess.DEVNULL,
+        stdout=stdout,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _run_upgrade(required: str, service: str, socket_path: str) -> int:
+    """Synchronous worker — runs install, then restart RPC on success."""
+    cmd = _build_install_cmd(required)
+    log.info("self-upgrade: running %s", " ".join(cmd))
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        log.error(
+            "self-upgrade: install failed rc=%s stderr=%s",
+            result.returncode,
+            result.stderr,
+        )
+        return result.returncode
+    log.info("self-upgrade: install succeeded; requesting restart of %s", service)
+    if not socket_path:
+        log.warning(
+            "self-upgrade: FRAISIER_SYSTEMCTL_SOCKET not set; "
+            "skipping restart of %s",
+            service,
+        )
+        return 0
+    try:
+        _call_via_socket(socket_path, "restart", service)
+    except (ConnectionRefusedError, subprocess.CalledProcessError) as exc:
+        log.error("self-upgrade: restart RPC failed: %s", exc)
+        return 1
+    return 0
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(prog="fraisier.webhook_self_upgrade")
+    parser.add_argument("--required", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--socket", default="")
+    args = parser.parse_args()
+    sys.exit(_run_upgrade(args.required, args.service, args.socket))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _main()

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -155,8 +155,7 @@ def _run_upgrade(required: str, service: str, socket_path: str) -> int:
     log.info("self-upgrade: install succeeded; requesting restart of %s", service)
     if not socket_path:
         log.warning(
-            "self-upgrade: FRAISIER_SYSTEMCTL_SOCKET not set; "
-            "skipping restart of %s",
+            "self-upgrade: FRAISIER_SYSTEMCTL_SOCKET not set; skipping restart of %s",
             service,
         )
         return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.17.0"
+version = "0.18.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -2371,6 +2371,40 @@ fraises:
         assert "myproj_my_api_production.service" in wrapper_content
         assert "myproj_my_api_development.service" in wrapper_content
 
+    def test_allowed_services_includes_webhook_unit(self, tmp_path):
+        """Helper allowlist must include the webhook unit so #162 self-upgrade
+        can restart the webhook via the systemctl-helper socket."""
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        p = tmp_path / "fraises.yaml"
+        p.write_text(
+            f"""
+name: myproj
+scaffold:
+  deploy_user: deployer
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/prod
+"""
+        )
+        config = FraisierConfig(p)
+        renderer = ScaffoldRenderer(config)
+        renderer.render()
+
+        helper_svc = (
+            tmp_path / "output" / "systemd" / "fraisier-myproj-systemctl-helper.service"
+        )
+        helper_content = helper_svc.read_text()
+        assert "fraisier-myproj-webhook.service" in helper_content
+
+        # And the legacy wrapper carries it too, so rollbacks keep working.
+        wrapper_content = (tmp_path / "output" / "systemctl-wrapper.sh").read_text()
+        assert "fraisier-myproj-webhook.service" in wrapper_content
+
     def test_sudoers_no_db_admin_for_migrate_strategy(self, tmp_path):
         """Sudoers omits DB admin commands for migrate/apply strategies (#41)."""
         from fraisier.scaffold.renderer import ScaffoldRenderer

--- a/tests/test_systemctl_helper.py
+++ b/tests/test_systemctl_helper.py
@@ -168,6 +168,37 @@ class TestHandleConnection:
         assert result["ok"] is True
         assert result["returncode"] == 0
 
+    def test_restart_allowed_for_webhook_unit(self):
+        """Contract for #162: when the webhook unit is in the allowlist, the
+        helper accepts restart for it. Locks the wire-up that the self-upgrade
+        runner depends on."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        webhook = "fraisier-myproj-webhook.service"
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = self._call(
+                {"action": "restart", "service": webhook},
+                frozenset({webhook}),
+            )
+
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args == ["/usr/bin/systemctl", "restart", webhook]
+        assert result["ok"] is True
+
+    def test_restart_rejected_for_webhook_when_not_in_allowlist(self):
+        """Regression guard: without #162's allowlist addition, a restart RPC
+        for the webhook unit must be rejected (not silently allowed)."""
+        result = self._call(
+            {"action": "restart", "service": "fraisier-myproj-webhook.service"},
+            frozenset({"some_other.service"}),
+        )
+        assert result["ok"] is False
+        assert "service not allowed" in result["error"]
+
     def test_systemctl_failure_returns_ok_false(self):
         mock_result = MagicMock()
         mock_result.returncode = 5

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -535,19 +535,19 @@ class TestDetectRequiredFraisierVersion:
 
     def test_returns_pinned_version_from_pep621_deps(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
-            'dependencies = [\n'
+            "dependencies = [\n"
             '  "fraisier==0.16.5",\n'
             '  "fastapi>=0.100",\n'
-            ']\n'
+            "]\n"
         )
         assert detect_required_fraisier_version(tmp_path) == "0.16.5"
 
     def test_returns_none_when_fraisier_absent(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'dependencies = ["fastapi>=0.100"]\n'
@@ -556,7 +556,7 @@ class TestDetectRequiredFraisierVersion:
 
     def test_returns_none_for_range_pin(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'dependencies = ["fraisier>=0.16,<0.17"]\n'
@@ -565,7 +565,7 @@ class TestDetectRequiredFraisierVersion:
 
     def test_returns_none_for_unpinned(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'dependencies = ["fraisier"]\n'
@@ -574,12 +574,12 @@ class TestDetectRequiredFraisierVersion:
 
     def test_handles_optional_dependencies_group(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
-            'dependencies = []\n'
-            '\n'
-            '[project.optional-dependencies]\n'
+            "dependencies = []\n"
+            "\n"
+            "[project.optional-dependencies]\n"
             'deploy = ["fraisier==0.17.0"]\n'
         )
         assert detect_required_fraisier_version(tmp_path) == "0.17.0"
@@ -590,7 +590,7 @@ class TestDetectRequiredFraisierVersion:
     def test_extras_marker_does_not_trip_match(self, tmp_path):
         """An entry like fraisier[extra]==X.Y.Z still extracts the pin."""
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'dependencies = ["fraisier[full]==0.16.6"]\n'
@@ -600,7 +600,7 @@ class TestDetectRequiredFraisierVersion:
     def test_does_not_match_substring_packages(self, tmp_path):
         """A package named 'fraisier-plugin' must not be treated as fraisier."""
         (tmp_path / "pyproject.toml").write_text(
-            '[project]\n'
+            "[project]\n"
             'name = "myapp"\n'
             'version = "1.0.0"\n'
             'dependencies = ["fraisier-plugin==1.0.0"]\n'

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -18,6 +18,7 @@ from fraisier.versioning import (
     VersionSyncTarget,
     bump_version,
     derive_database_version,
+    detect_required_fraisier_version,
     generate_version_json,
     has_version_changed,
     is_valid_semver,
@@ -527,3 +528,81 @@ class TestResolveAppVersion:
             '[project]\nname = "x"\nversion = "0.0.1"\n'
         )
         assert resolve_app_version(tmp_path) == ("0.0.1", "pyproject.toml")
+
+
+class TestDetectRequiredFraisierVersion:
+    """Tests for detect_required_fraisier_version — used by the webhook self-upgrade path."""
+
+    def test_returns_pinned_version_from_pep621_deps(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = [\n'
+            '  "fraisier==0.16.5",\n'
+            '  "fastapi>=0.100",\n'
+            ']\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) == "0.16.5"
+
+    def test_returns_none_when_fraisier_absent(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = ["fastapi>=0.100"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) is None
+
+    def test_returns_none_for_range_pin(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = ["fraisier>=0.16,<0.17"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) is None
+
+    def test_returns_none_for_unpinned(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = ["fraisier"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) is None
+
+    def test_handles_optional_dependencies_group(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = []\n'
+            '\n'
+            '[project.optional-dependencies]\n'
+            'deploy = ["fraisier==0.17.0"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) == "0.17.0"
+
+    def test_returns_none_when_pyproject_missing(self, tmp_path):
+        assert detect_required_fraisier_version(tmp_path) is None
+
+    def test_extras_marker_does_not_trip_match(self, tmp_path):
+        """An entry like fraisier[extra]==X.Y.Z still extracts the pin."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = ["fraisier[full]==0.16.6"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) == "0.16.6"
+
+    def test_does_not_match_substring_packages(self, tmp_path):
+        """A package named 'fraisier-plugin' must not be treated as fraisier."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\n'
+            'name = "myapp"\n'
+            'version = "1.0.0"\n'
+            'dependencies = ["fraisier-plugin==1.0.0"]\n'
+        )
+        assert detect_required_fraisier_version(tmp_path) is None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -455,6 +455,195 @@ class TestRunDeploymentErrorRecording:
         assert "Unexpected" in caplog.text
 
 
+class TestSelfUpgradeWireUp:
+    """`_run_deployment` invokes `maybe_self_upgrade` after a successful deploy
+    (issue #162). Default is enabled; opt-out via `webhook.self_upgrade: false`."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_lock(self, tmp_path):
+        @contextmanager
+        def tmp_lock(fraise_name):
+            from fraisier.locking import file_deployment_lock as real_lock
+
+            with real_lock(fraise_name, lock_dir=tmp_path) as path:
+                yield path
+
+        with patch("fraisier.webhook.deployment_lock", side_effect=tmp_lock):
+            yield
+
+    def _make_config(self, webhook_cfg: dict | None = None, project: str = "myproj"):
+        cfg = MagicMock()
+        cfg._config = {"git": {}}
+        cfg.webhook = webhook_cfg if webhook_cfg is not None else {}
+        cfg.project_name = project
+        cfg.get_deploy_user.return_value = "deployer"
+        return cfg
+
+    def _success_result(self):
+        return MagicMock(
+            success=True,
+            new_version="2.0.0",
+            old_version="1.0.0",
+            error_message=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_invoked_on_successful_deploy_with_app_path(self, test_db):
+        fraise_config = {
+            "type": "api",
+            "app_path": "/srv/app",
+            "systemd_service": "test-api.service",
+        }
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = self._success_result()
+
+        with (
+            patch("fraisier.webhook.get_config", return_value=self._make_config()),
+            patch(
+                "fraisier.deployers.api.APIDeployer",
+                return_value=mock_deployer,
+            ),
+            patch("fraisier.webhook.maybe_self_upgrade") as mock_upgrade,
+        ):
+            await execute_deployment(
+                fraise_name="my_api",
+                environment="production",
+                fraise_config=fraise_config,
+                git_branch="main",
+            )
+
+        mock_upgrade.assert_called_once()
+        kwargs = mock_upgrade.call_args.kwargs
+        # First positional is app_path
+        from pathlib import Path as _Path
+
+        assert mock_upgrade.call_args.args[0] == _Path("/srv/app")
+        assert kwargs["project_name"] == "myproj"
+        assert kwargs["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_invoked_on_failed_deploy(self, test_db):
+        fraise_config = {
+            "type": "api",
+            "app_path": "/srv/app",
+            "systemd_service": "test-api.service",
+        }
+        failed = MagicMock(
+            success=False,
+            new_version=None,
+            old_version="1.0.0",
+            error_message="boom",
+        )
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = failed
+
+        with (
+            patch("fraisier.webhook.get_config", return_value=self._make_config()),
+            patch(
+                "fraisier.deployers.api.APIDeployer",
+                return_value=mock_deployer,
+            ),
+            patch("fraisier.webhook.maybe_self_upgrade") as mock_upgrade,
+        ):
+            await execute_deployment(
+                fraise_name="my_api",
+                environment="production",
+                fraise_config=fraise_config,
+                git_branch="main",
+            )
+
+        mock_upgrade.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_via_webhook_self_upgrade_false(self, test_db):
+        fraise_config = {
+            "type": "api",
+            "app_path": "/srv/app",
+            "systemd_service": "test-api.service",
+        }
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = self._success_result()
+
+        with (
+            patch(
+                "fraisier.webhook.get_config",
+                return_value=self._make_config(webhook_cfg={"self_upgrade": False}),
+            ),
+            patch(
+                "fraisier.deployers.api.APIDeployer",
+                return_value=mock_deployer,
+            ),
+            patch("fraisier.webhook.maybe_self_upgrade") as mock_upgrade,
+        ):
+            await execute_deployment(
+                fraise_name="my_api",
+                environment="production",
+                fraise_config=fraise_config,
+                git_branch="main",
+            )
+
+        mock_upgrade.assert_called_once()
+        assert mock_upgrade.call_args.kwargs["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_exception_in_upgrade_does_not_break_deploy(self, test_db, caplog):
+        fraise_config = {
+            "type": "api",
+            "app_path": "/srv/app",
+            "systemd_service": "test-api.service",
+        }
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = self._success_result()
+
+        with (
+            patch("fraisier.webhook.get_config", return_value=self._make_config()),
+            patch(
+                "fraisier.deployers.api.APIDeployer",
+                return_value=mock_deployer,
+            ),
+            patch(
+                "fraisier.webhook.maybe_self_upgrade",
+                side_effect=RuntimeError("nope"),
+            ),
+        ):
+            # Must complete without raising.
+            await execute_deployment(
+                fraise_name="my_api",
+                environment="production",
+                fraise_config=fraise_config,
+                git_branch="main",
+            )
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_no_app_path(self, test_db):
+        """ETL/docker_compose fraises without an app_path can't self-upgrade —
+        the call must be skipped, not raise on a None path."""
+        fraise_config = {
+            "type": "etl",
+            "script_path": "scripts/pipeline.py",
+            # no app_path
+        }
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = self._success_result()
+
+        with (
+            patch("fraisier.webhook.get_config", return_value=self._make_config()),
+            patch(
+                "fraisier.deployers.etl.ETLDeployer",
+                return_value=mock_deployer,
+            ),
+            patch("fraisier.webhook.maybe_self_upgrade") as mock_upgrade,
+        ):
+            await execute_deployment(
+                fraise_name="data_pipeline",
+                environment="production",
+                fraise_config=fraise_config,
+                git_branch="main",
+            )
+
+        mock_upgrade.assert_not_called()
+
+
 class TestProcessWebhookEvent:
     """Tests for process_webhook_event function."""
 

--- a/tests/test_webhook_self_upgrade.py
+++ b/tests/test_webhook_self_upgrade.py
@@ -43,17 +43,13 @@ class TestMaybeSelfUpgrade:
     def test_no_spawn_when_disabled(self, tmp_path):
         _write_pyproject(tmp_path, "99.0.0")
         spawn = MagicMock()
-        maybe_self_upgrade(
-            tmp_path, project_name="foo", enabled=False, spawn=spawn
-        )
+        maybe_self_upgrade(tmp_path, project_name="foo", enabled=False, spawn=spawn)
         spawn.assert_not_called()
 
     def test_no_spawn_when_required_is_none(self, tmp_path):
         # No pyproject.toml at all → detect returns None.
         spawn = MagicMock()
-        maybe_self_upgrade(
-            tmp_path, project_name="foo", enabled=True, spawn=spawn
-        )
+        maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         spawn.assert_not_called()
 
     def test_no_spawn_when_required_equals_installed(self, tmp_path):
@@ -63,9 +59,7 @@ class TestMaybeSelfUpgrade:
             "fraisier.webhook_self_upgrade.importlib_metadata.version",
             return_value="1.2.3",
         ):
-            maybe_self_upgrade(
-                tmp_path, project_name="foo", enabled=True, spawn=spawn
-            )
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         spawn.assert_not_called()
 
     def test_no_spawn_when_required_older(self, tmp_path):
@@ -75,9 +69,7 @@ class TestMaybeSelfUpgrade:
             "fraisier.webhook_self_upgrade.importlib_metadata.version",
             return_value="1.2.3",
         ):
-            maybe_self_upgrade(
-                tmp_path, project_name="foo", enabled=True, spawn=spawn
-            )
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         spawn.assert_not_called()
 
     def test_spawn_when_required_newer(self, tmp_path):
@@ -87,9 +79,7 @@ class TestMaybeSelfUpgrade:
             "fraisier.webhook_self_upgrade.importlib_metadata.version",
             return_value="1.2.3",
         ):
-            maybe_self_upgrade(
-                tmp_path, project_name="foo", enabled=True, spawn=spawn
-            )
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         spawn.assert_called_once_with("2.0.0", "foo")
 
     def test_never_raises_on_internal_error(self, tmp_path):
@@ -100,9 +90,7 @@ class TestMaybeSelfUpgrade:
             "fraisier.webhook_self_upgrade.importlib_metadata.version",
             return_value="1.2.3",
         ):
-            maybe_self_upgrade(
-                tmp_path, project_name="foo", enabled=True, spawn=spawn
-            )
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
 
     def test_never_raises_on_malformed_installed_version(self, tmp_path):
         _write_pyproject(tmp_path, "1.2.3")
@@ -111,22 +99,16 @@ class TestMaybeSelfUpgrade:
             "fraisier.webhook_self_upgrade.importlib_metadata.version",
             return_value="not-a-version",
         ):
-            maybe_self_upgrade(
-                tmp_path, project_name="foo", enabled=True, spawn=spawn
-            )
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         # Conservative: skip when we can't compare.
         spawn.assert_not_called()
 
 
 class TestSpawnUpgrade:
     def test_spawn_uses_detached_kwargs(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            "fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs"
-        )
+        monkeypatch.setattr("fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs")
         monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.Popen"
-        ) as mock_popen:
+        with patch("fraisier.webhook_self_upgrade.subprocess.Popen") as mock_popen:
             _spawn_upgrade("0.17.0", "myproj")
         mock_popen.assert_called_once()
         args, kwargs = mock_popen.call_args
@@ -153,9 +135,7 @@ class TestSpawnUpgrade:
             "fraisier.webhook_self_upgrade._LOG_DIR", Path("/dev/null/no")
         )
         monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.Popen"
-        ) as mock_popen:
+        with patch("fraisier.webhook_self_upgrade.subprocess.Popen") as mock_popen:
             _spawn_upgrade("0.17.0", "myproj")
         mock_popen.assert_called_once()
         _, kwargs = mock_popen.call_args
@@ -163,13 +143,9 @@ class TestSpawnUpgrade:
         assert kwargs["stdout"] is subprocess.DEVNULL
 
     def test_spawn_with_no_socket_env(self, monkeypatch, tmp_path):
-        monkeypatch.setattr(
-            "fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs"
-        )
+        monkeypatch.setattr("fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs")
         monkeypatch.delenv("FRAISIER_SYSTEMCTL_SOCKET", raising=False)
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.Popen"
-        ) as mock_popen:
+        with patch("fraisier.webhook_self_upgrade.subprocess.Popen") as mock_popen:
             _spawn_upgrade("0.17.0", "myproj")
         args, _ = mock_popen.call_args
         cmd = args[0]
@@ -180,17 +156,12 @@ class TestSpawnUpgrade:
 
 class TestRunUpgrade:
     def test_install_success_triggers_restart_rpc(self):
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.run"
-        ) as mock_run, patch(
-            "fraisier.webhook_self_upgrade._call_via_socket"
-        ) as mock_socket:
-            mock_run.return_value = SimpleNamespace(
-                returncode=0, stdout="", stderr=""
-            )
-            rc = _run_upgrade(
-                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
-            )
+        with (
+            patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
+            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+        ):
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            rc = _run_upgrade("0.17.0", "fraisier-foo-webhook.service", "/run/x.sock")
         assert rc == 0
         assert mock_run.call_args[0][0] == _build_install_cmd("0.17.0")
         mock_socket.assert_called_once_with(
@@ -198,53 +169,41 @@ class TestRunUpgrade:
         )
 
     def test_install_failure_skips_restart(self):
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.run"
-        ) as mock_run, patch(
-            "fraisier.webhook_self_upgrade._call_via_socket"
-        ) as mock_socket:
+        with (
+            patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
+            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+        ):
             mock_run.return_value = SimpleNamespace(
                 returncode=1, stdout="", stderr="oops"
             )
-            rc = _run_upgrade(
-                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
-            )
+            rc = _run_upgrade("0.17.0", "fraisier-foo-webhook.service", "/run/x.sock")
         assert rc == 1
         mock_socket.assert_not_called()
 
     def test_install_success_no_socket_logs_and_returns_ok(self, caplog):
         import logging
 
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.run"
-        ) as mock_run, patch(
-            "fraisier.webhook_self_upgrade._call_via_socket"
-        ) as mock_socket, caplog.at_level(
-            logging.WARNING, logger="fraisier.webhook_self_upgrade"
+        with (
+            patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
+            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            caplog.at_level(logging.WARNING, logger="fraisier.webhook_self_upgrade"),
         ):
-            mock_run.return_value = SimpleNamespace(
-                returncode=0, stdout="", stderr=""
-            )
-            rc = _run_upgrade(
-                "0.17.0", "fraisier-foo-webhook.service", ""
-            )
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            rc = _run_upgrade("0.17.0", "fraisier-foo-webhook.service", "")
         assert rc == 0
         mock_socket.assert_not_called()
         assert "FRAISIER_SYSTEMCTL_SOCKET" in caplog.text
 
     def test_restart_rpc_failure_returns_nonzero(self):
-        with patch(
-            "fraisier.webhook_self_upgrade.subprocess.run"
-        ) as mock_run, patch(
-            "fraisier.webhook_self_upgrade._call_via_socket",
-            side_effect=ConnectionRefusedError("nope"),
+        with (
+            patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
+            patch(
+                "fraisier.webhook_self_upgrade._call_via_socket",
+                side_effect=ConnectionRefusedError("nope"),
+            ),
         ):
-            mock_run.return_value = SimpleNamespace(
-                returncode=0, stdout="", stderr=""
-            )
-            rc = _run_upgrade(
-                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
-            )
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            rc = _run_upgrade("0.17.0", "fraisier-foo-webhook.service", "/run/x.sock")
         assert rc != 0
 
 

--- a/tests/test_webhook_self_upgrade.py
+++ b/tests/test_webhook_self_upgrade.py
@@ -1,0 +1,280 @@
+"""Tests for webhook self-upgrade runner (issue #162)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fraisier.webhook_self_upgrade import (
+    _build_install_cmd,
+    _run_upgrade,
+    _spawn_upgrade,
+    maybe_self_upgrade,
+)
+
+
+def _write_pyproject(tmp_path: Path, fraisier_pin: str | None) -> None:
+    deps = "[]" if fraisier_pin is None else f'["fraisier=={fraisier_pin}"]'
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "myapp"\nversion = "1.0.0"\ndependencies = {deps}\n'
+    )
+
+
+class TestBuildInstallCmd:
+    def test_matches_bootstrap_form(self):
+        """The install command must mirror fraisier/bootstrap.py:221-222 exactly."""
+        assert _build_install_cmd("0.16.6") == [
+            "uv",
+            "tool",
+            "install",
+            "--force",
+            "--refresh-package",
+            "fraisier",
+            "fraisier==0.16.6",
+        ]
+
+
+class TestMaybeSelfUpgrade:
+    def test_no_spawn_when_disabled(self, tmp_path):
+        _write_pyproject(tmp_path, "99.0.0")
+        spawn = MagicMock()
+        maybe_self_upgrade(
+            tmp_path, project_name="foo", enabled=False, spawn=spawn
+        )
+        spawn.assert_not_called()
+
+    def test_no_spawn_when_required_is_none(self, tmp_path):
+        # No pyproject.toml at all → detect returns None.
+        spawn = MagicMock()
+        maybe_self_upgrade(
+            tmp_path, project_name="foo", enabled=True, spawn=spawn
+        )
+        spawn.assert_not_called()
+
+    def test_no_spawn_when_required_equals_installed(self, tmp_path):
+        _write_pyproject(tmp_path, "1.2.3")
+        spawn = MagicMock()
+        with patch(
+            "fraisier.webhook_self_upgrade.importlib_metadata.version",
+            return_value="1.2.3",
+        ):
+            maybe_self_upgrade(
+                tmp_path, project_name="foo", enabled=True, spawn=spawn
+            )
+        spawn.assert_not_called()
+
+    def test_no_spawn_when_required_older(self, tmp_path):
+        _write_pyproject(tmp_path, "1.0.0")
+        spawn = MagicMock()
+        with patch(
+            "fraisier.webhook_self_upgrade.importlib_metadata.version",
+            return_value="1.2.3",
+        ):
+            maybe_self_upgrade(
+                tmp_path, project_name="foo", enabled=True, spawn=spawn
+            )
+        spawn.assert_not_called()
+
+    def test_spawn_when_required_newer(self, tmp_path):
+        _write_pyproject(tmp_path, "2.0.0")
+        spawn = MagicMock()
+        with patch(
+            "fraisier.webhook_self_upgrade.importlib_metadata.version",
+            return_value="1.2.3",
+        ):
+            maybe_self_upgrade(
+                tmp_path, project_name="foo", enabled=True, spawn=spawn
+            )
+        spawn.assert_called_once_with("2.0.0", "foo")
+
+    def test_never_raises_on_internal_error(self, tmp_path):
+        spawn = MagicMock(side_effect=RuntimeError("boom"))
+        _write_pyproject(tmp_path, "99.0.0")
+        # Must not raise even though spawn blows up.
+        with patch(
+            "fraisier.webhook_self_upgrade.importlib_metadata.version",
+            return_value="1.2.3",
+        ):
+            maybe_self_upgrade(
+                tmp_path, project_name="foo", enabled=True, spawn=spawn
+            )
+
+    def test_never_raises_on_malformed_installed_version(self, tmp_path):
+        _write_pyproject(tmp_path, "1.2.3")
+        spawn = MagicMock()
+        with patch(
+            "fraisier.webhook_self_upgrade.importlib_metadata.version",
+            return_value="not-a-version",
+        ):
+            maybe_self_upgrade(
+                tmp_path, project_name="foo", enabled=True, spawn=spawn
+            )
+        # Conservative: skip when we can't compare.
+        spawn.assert_not_called()
+
+
+class TestSpawnUpgrade:
+    def test_spawn_uses_detached_kwargs(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs"
+        )
+        monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.Popen"
+        ) as mock_popen:
+            _spawn_upgrade("0.17.0", "myproj")
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        cmd = args[0]
+        assert cmd[0] == sys.executable
+        assert "fraisier.webhook_self_upgrade" in cmd
+        assert "--required" in cmd
+        assert "0.17.0" in cmd
+        assert "--service" in cmd
+        assert "fraisier-myproj-webhook.service" in cmd
+        assert "--socket" in cmd
+        assert "/run/x.sock" in cmd
+        assert kwargs["start_new_session"] is True
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["stderr"] is subprocess.STDOUT
+        # stdout should be a writable file handle, not None.
+        assert kwargs["stdout"] is not None
+        # Log directory was created on demand.
+        assert (tmp_path / "logs").is_dir()
+
+    def test_spawn_works_when_log_dir_uncreatable(self, monkeypatch):
+        # Pointing _LOG_DIR at an unwritable path should not crash the spawn.
+        monkeypatch.setattr(
+            "fraisier.webhook_self_upgrade._LOG_DIR", Path("/dev/null/no")
+        )
+        monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.Popen"
+        ) as mock_popen:
+            _spawn_upgrade("0.17.0", "myproj")
+        mock_popen.assert_called_once()
+        _, kwargs = mock_popen.call_args
+        # Falls back to DEVNULL when log file can't be opened.
+        assert kwargs["stdout"] is subprocess.DEVNULL
+
+    def test_spawn_with_no_socket_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "fraisier.webhook_self_upgrade._LOG_DIR", tmp_path / "logs"
+        )
+        monkeypatch.delenv("FRAISIER_SYSTEMCTL_SOCKET", raising=False)
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.Popen"
+        ) as mock_popen:
+            _spawn_upgrade("0.17.0", "myproj")
+        args, _ = mock_popen.call_args
+        cmd = args[0]
+        # --socket is still passed (empty string) so the child can choose to skip.
+        idx = cmd.index("--socket")
+        assert cmd[idx + 1] == ""
+
+
+class TestRunUpgrade:
+    def test_install_success_triggers_restart_rpc(self):
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.run"
+        ) as mock_run, patch(
+            "fraisier.webhook_self_upgrade._call_via_socket"
+        ) as mock_socket:
+            mock_run.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            rc = _run_upgrade(
+                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
+            )
+        assert rc == 0
+        assert mock_run.call_args[0][0] == _build_install_cmd("0.17.0")
+        mock_socket.assert_called_once_with(
+            "/run/x.sock", "restart", "fraisier-foo-webhook.service"
+        )
+
+    def test_install_failure_skips_restart(self):
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.run"
+        ) as mock_run, patch(
+            "fraisier.webhook_self_upgrade._call_via_socket"
+        ) as mock_socket:
+            mock_run.return_value = SimpleNamespace(
+                returncode=1, stdout="", stderr="oops"
+            )
+            rc = _run_upgrade(
+                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
+            )
+        assert rc == 1
+        mock_socket.assert_not_called()
+
+    def test_install_success_no_socket_logs_and_returns_ok(self, caplog):
+        import logging
+
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.run"
+        ) as mock_run, patch(
+            "fraisier.webhook_self_upgrade._call_via_socket"
+        ) as mock_socket, caplog.at_level(
+            logging.WARNING, logger="fraisier.webhook_self_upgrade"
+        ):
+            mock_run.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            rc = _run_upgrade(
+                "0.17.0", "fraisier-foo-webhook.service", ""
+            )
+        assert rc == 0
+        mock_socket.assert_not_called()
+        assert "FRAISIER_SYSTEMCTL_SOCKET" in caplog.text
+
+    def test_restart_rpc_failure_returns_nonzero(self):
+        with patch(
+            "fraisier.webhook_self_upgrade.subprocess.run"
+        ) as mock_run, patch(
+            "fraisier.webhook_self_upgrade._call_via_socket",
+            side_effect=ConnectionRefusedError("nope"),
+        ):
+            mock_run.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            rc = _run_upgrade(
+                "0.17.0", "fraisier-foo-webhook.service", "/run/x.sock"
+            )
+        assert rc != 0
+
+
+@pytest.mark.parametrize("argv_socket", ["/run/x.sock", ""])
+def test_main_entrypoint_invokes_run_upgrade(monkeypatch, argv_socket):
+    """`python -m fraisier.webhook_self_upgrade` wires argv → _run_upgrade."""
+    from fraisier import webhook_self_upgrade as mod
+
+    captured = {}
+
+    def fake_run(required, service, socket_path):
+        captured["args"] = (required, service, socket_path)
+        return 0
+
+    monkeypatch.setattr(mod, "_run_upgrade", fake_run)
+    argv = [
+        "webhook_self_upgrade",
+        "--required",
+        "0.17.0",
+        "--service",
+        "fraisier-foo-webhook.service",
+        "--socket",
+        argv_socket,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as excinfo:
+        mod._main()
+    assert excinfo.value.code == 0
+    assert captured["args"] == (
+        "0.17.0",
+        "fraisier-foo-webhook.service",
+        argv_socket,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #162. When a deployed `pyproject.toml` pins a newer fraisier than the webhook is running, the webhook now detaches a worker that `uv tool install --force fraisier==<pinned>` and asks the systemctl-helper socket to restart its own unit.

- Detection (`detect_required_fraisier_version`) is conservative: only exact `==X.Y.Z` pins trigger an upgrade. Range pins and unpinned deps are ignored.
- The upgrade is fully detached and never blocks or fails the current deploy — `maybe_self_upgrade` is best-effort and swallows all exceptions.
- Install runs against the webhook user's own uv tool dir (no privilege elevation). Restart goes through the existing root-privileged systemctl-helper socket, which has the webhook unit added to its allowlist in this PR.
- Default-on, opt-out via `webhook: { self_upgrade: false }` in `fraises.yaml`.

Complements #156 (operator-driven bootstrap restart, already shipped) — together they cover both upgrade paths.

## Commits

| Phase | Commit | What |
|---|---|---|
| 1 | `31ec1ba` | `detect_required_fraisier_version` + 8 tests |
| 2 | `aa742fe` | `webhook_self_upgrade.py` module (4 functions, 17 tests) |
| 3 | `fa50f85` | scaffold allowlist + systemctl-helper contract tests |
| 4 | `c289da3` | wire `maybe_self_upgrade` into `_run_deployment` (5 tests) |
| 5 | `6cef6e0` | docs: `fraises.example.yaml` + CHANGELOG |
| 6 | `0fc69f7` | release: v0.18.0 |

## Upgrade note (also in CHANGELOG)

Existing installations must re-scaffold and re-run `install.sh` to add the webhook unit to the systemctl-helper allowlist. Until they do, the install side of the self-upgrade succeeds but the restart RPC is rejected (logged at error level; deploy is not affected).

## Test plan

- [x] `uv run pytest` → 3331 passed, 9 skipped
- [x] `uv run ruff check` → clean
- [x] `uv run ruff format --check` → clean
- [x] `uv run ty check` for touched files → clean (one pre-existing diagnostic in `scaffold/renderer.py` at line 148 unrelated to this PR)
- [ ] Manual end-to-end on a staging host (per the issue plan §Verification, requires a real install — out of scope for this PR review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)