### PR TITLE
release: v0.19.0 — deployment duration estimates (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-05-21
+
+### Added
+
+- **Deployment duration estimates in webhook responses** ([#201](https://github.com/fraiseql/fraisier/issues/201)). Webhook dispatch responses now carry `estimated_duration_s`, `estimated_ready_at` (UTC), and `estimate_confidence` (`"history"` or `"fallback"`) for each triggered deployment that has a `database.strategy`. Agentic and human callers can use these to size their `sleep`/poll loops at trigger time instead of guessing.
+- **`tb_deployment.strategy` + `tb_deployment.db_size_mb` columns**. Recorded per successful deploy via `complete_deployment(..., strategy=..., db_size_mb=...)`. Legacy installs are migrated in place via idempotent `ALTER TABLE ... ADD COLUMN`. ETL and docker_compose fraises (no database section) record `strategy=NULL` and are excluded from the estimator.
+- **`FraisierDB.get_successful_deploy_durations(*, fraise, environment, strategy, limit)`**. New repository method consumed by the estimator; returns the most recent successful deploy durations filtered by the trinity, excluding NULL durations and non-success rows.
+- **`fraisier/duration_estimate.py`** — `estimate_duration(db, *, fraise, environment, strategy, db_size_mb)` returns an `EstimateResult(seconds, confidence, samples_used)`. Uses the median of the most recent up-to-5 successful runs (with a 1.20 buffer) when ≥3 samples exist, otherwise falls back to a per-strategy seconds-per-MB rate clamped to a per-strategy floor (180s rebuild, 120s restore_migrate, 30s migrate, 60s for unknown strategies). Wrapped in `try/except` so a flaky history store cannot block a deploy.
+
+### Upgrade notes
+
+- Schema additions are additive; no migration required beyond starting the upgraded fraisier process (which runs the `ALTER TABLE` step on first connect).
+- The CLI surface (`fraisier trigger-deploy` printing `Estimated completion: ~Nm`) is deferred to a follow-up PR — the webhook surface is the higher-value one for agentic callers and the CLI version can land independently once this lands.
+- `db_size_mb` is reserved for future use; values are recorded as NULL today. Plumbing it through requires a `pg_database_size()` query before each deploy.
+
 ## [0.18.0] - 2026-05-21
 
 ### Added

--- a/fraisier/database.py
+++ b/fraisier/database.py
@@ -339,10 +339,18 @@ class FraisierDB:
         new_version: str | None = None,
         error_message: str | None = None,
         details: str | None = None,
+        strategy: str | None = None,
+        db_size_mb: int | None = None,
     ) -> None:
         """Record completion of a deployment."""
         self._history.complete_deployment(
-            deployment_id, success, new_version, error_message, details
+            deployment_id,
+            success,
+            new_version,
+            error_message,
+            details,
+            strategy,
+            db_size_mb,
         )
 
     def mark_deployment_rolled_back(self, deployment_id: int) -> None:

--- a/fraisier/database.py
+++ b/fraisier/database.py
@@ -88,6 +88,8 @@ def _tables_sql() -> str:
             git_branch TEXT,
             error_message TEXT,
             details TEXT,
+            strategy TEXT,
+            db_size_mb INTEGER,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
@@ -237,10 +239,25 @@ def _indexes_sql() -> str:
     """
 
 
+def _ensure_deployment_columns(conn: sqlite3.Connection) -> None:
+    """Add nullable columns introduced after the initial schema.
+
+    SQLite's ``CREATE TABLE IF NOT EXISTS`` does not retro-add columns to
+    pre-existing tables, so legacy installs need explicit ``ADD COLUMN``
+    statements. Each addition is idempotent and column-scoped.
+    """
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tb_deployment)")}
+    if "strategy" not in cols:
+        conn.execute("ALTER TABLE tb_deployment ADD COLUMN strategy TEXT")
+    if "db_size_mb" not in cols:
+        conn.execute("ALTER TABLE tb_deployment ADD COLUMN db_size_mb INTEGER")
+
+
 def init_database() -> None:
     """Initialize database schema following trinity pattern."""
     with get_connection() as conn:
         conn.executescript(_tables_sql())
+        _ensure_deployment_columns(conn)
         conn.executescript(_views_sql())
         conn.executescript(_indexes_sql())
         conn.commit()

--- a/fraisier/database.py
+++ b/fraisier/database.py
@@ -361,6 +361,22 @@ class FraisierDB:
         """Get a specific deployment record."""
         return self._history.get_deployment(deployment_id)
 
+    def get_successful_deploy_durations(
+        self,
+        *,
+        fraise: str,
+        environment: str,
+        strategy: str,
+        limit: int = 5,
+    ) -> list[float]:
+        """Return the most recent successful deploy durations (seconds)."""
+        return self._history.get_successful_deploy_durations(
+            fraise=fraise,
+            environment=environment,
+            strategy=strategy,
+            limit=limit,
+        )
+
     def get_recent_deployments(
         self,
         limit: int = 20,

--- a/fraisier/db/history.py
+++ b/fraisier/db/history.py
@@ -257,6 +257,33 @@ class DeploymentHistoryManager:
             rows = conn.execute(query, params).fetchall()
             return [self._normalize_deployment_dict(dict(row)) for row in rows]
 
+    def get_successful_deploy_durations(
+        self,
+        *,
+        fraise: str,
+        environment: str,
+        strategy: str,
+        limit: int = 5,
+    ) -> list[float]:
+        """Return the *limit* most recent successful deploy durations (seconds).
+
+        Filtered by (fraise, environment, strategy). Rows with NULL
+        ``duration_seconds`` are excluded. Used by the duration estimator
+        (#201) to compute a per-strategy median.
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT duration_seconds FROM tb_deployment
+                WHERE fraise_name=? AND environment_name=? AND strategy=?
+                  AND status='success' AND duration_seconds IS NOT NULL
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                (fraise, environment, strategy, limit),
+            ).fetchall()
+            return [float(row["duration_seconds"]) for row in rows]
+
     def get_deployment_stats(
         self, fraise: str | None = None, days: int = 30
     ) -> dict[str, Any]:

--- a/fraisier/db/history.py
+++ b/fraisier/db/history.py
@@ -134,6 +134,8 @@ class DeploymentHistoryManager:
         new_version: str | None = None,
         error_message: str | None = None,
         details: str | None = None,
+        strategy: str | None = None,
+        db_size_mb: int | None = None,
     ) -> None:
         """Record completion of a deployment (pk_deployment).
 
@@ -143,6 +145,9 @@ class DeploymentHistoryManager:
             new_version: New deployed version
             error_message: Error message if failed
             details: JSON details of deployment
+            strategy: Deploy strategy name (rebuild, restore_migrate, migrate),
+                      consumed by the duration estimator (#201).
+            db_size_mb: Database size at deploy time in megabytes (optional).
         """
         now = datetime.now().isoformat()
         status = "success" if success else "failed"
@@ -163,7 +168,8 @@ class DeploymentHistoryManager:
                 """
                 UPDATE tb_deployment
                 SET completed_at=?, status=?, new_version=?, duration_seconds=?,
-                    error_message=?, details=?, updated_at=?
+                    error_message=?, details=?, strategy=?, db_size_mb=?,
+                    updated_at=?
                 WHERE pk_deployment=?
                 """,
                 (
@@ -173,6 +179,8 @@ class DeploymentHistoryManager:
                     duration,
                     error_message,
                     details,
+                    strategy,
+                    db_size_mb,
                     now,
                     deployment_id,
                 ),

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -398,11 +398,14 @@ class GitDeployMixin:
             from fraisier.database import get_db
 
             db = get_db()
+            database_config = getattr(self, "database_config", None) or {}
+            strategy = database_config.get("strategy")
             db.complete_deployment(
                 deployment_id=deployment_pk,
                 success=result.success,
                 new_version=result.new_version,
                 error_message=result.error_message,
+                strategy=strategy,
             )
             if result.status.value == "rolled_back":
                 db.mark_deployment_rolled_back(deployment_pk)

--- a/fraisier/duration_estimate.py
+++ b/fraisier/duration_estimate.py
@@ -1,0 +1,121 @@
+"""Deployment duration estimator (issue #201).
+
+Looks up the most recent successful deploys for
+``(fraise, environment, strategy)`` and returns a median-based estimate.
+Falls back to a strategy-specific per-MB rate (or a per-strategy floor when
+the database size is unknown) when fewer than three samples are available.
+
+Used by the webhook response and the CLI deploy commands to give human and
+agentic callers a "wait ~Nm" signal at trigger time.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:  # pragma: no cover
+    from fraisier.database import FraisierDB
+
+log = logging.getLogger(__name__)
+
+# Median-buffer factor applied to history-based estimates.
+_HISTORY_BUFFER = 1.20
+
+# Minimum number of historical samples required to trust the median.
+_MIN_HISTORY_SAMPLES = 3
+
+# History lookback size.
+_HISTORY_LIMIT = 5
+
+# Per-strategy seconds-per-MB used for the fallback estimator. Approximate
+# orders of magnitude; the estimator clamps to STRATEGY_FLOOR_SECONDS so a
+# small database does not produce an unrealistically short estimate.
+STRATEGY_FALLBACK_SECONDS_PER_MB: dict[str, float] = {
+    "rebuild": 0.0025,  # ~400 MB/s rebuild
+    "restore_migrate": 0.05,  # ~20 MB/s pg_restore
+    "migrate": 5.0,  # roughly per-migration; db_size ignored downstream
+}
+
+# Per-strategy floor when db_size is unknown or scaling lands below it.
+STRATEGY_FLOOR_SECONDS: dict[str, int] = {
+    "rebuild": 180,
+    "restore_migrate": 120,
+    "migrate": 30,
+}
+
+# Generic floor when the strategy is unknown.
+_UNKNOWN_STRATEGY_FLOOR = 60
+
+
+@dataclass(frozen=True)
+class EstimateResult:
+    """Result of a duration estimate."""
+
+    seconds: int
+    confidence: Literal["history", "fallback"]
+    samples_used: int
+
+
+def _fallback_seconds(strategy: str, db_size_mb: int | None) -> int:
+    """Return the fallback estimate in seconds for *strategy* and *db_size_mb*."""
+    floor = STRATEGY_FLOOR_SECONDS.get(strategy, _UNKNOWN_STRATEGY_FLOOR)
+    rate = STRATEGY_FALLBACK_SECONDS_PER_MB.get(strategy)
+    if db_size_mb is None or rate is None:
+        return floor
+    scaled = int(db_size_mb * rate)
+    return max(scaled, floor)
+
+
+def estimate_duration(
+    db: FraisierDB,
+    *,
+    fraise: str,
+    environment: str,
+    strategy: str,
+    db_size_mb: int | None,
+) -> EstimateResult:
+    """Return an estimate for the next ``(fraise, environment, strategy)`` deploy.
+
+    Returns the median of the most recent up to ``_HISTORY_LIMIT`` successful
+    durations, multiplied by ``_HISTORY_BUFFER`` (default 1.20), when at least
+    ``_MIN_HISTORY_SAMPLES`` (default 3) samples are available. Otherwise falls
+    back to ``STRATEGY_FALLBACK_SECONDS_PER_MB[strategy] * db_size_mb``, clamped
+    to ``STRATEGY_FLOOR_SECONDS[strategy]``. Never raises — a DB error returns
+    the fallback estimate so a flaky history store cannot block a deploy.
+    """
+    try:
+        durations = db.get_successful_deploy_durations(
+            fraise=fraise,
+            environment=environment,
+            strategy=strategy,
+            limit=_HISTORY_LIMIT,
+        )
+    except Exception:
+        log.exception(
+            "estimate_duration: history lookup failed for %s/%s/%s — using fallback",
+            fraise,
+            environment,
+            strategy,
+        )
+        return EstimateResult(
+            seconds=_fallback_seconds(strategy, db_size_mb),
+            confidence="fallback",
+            samples_used=0,
+        )
+
+    sample_count = len(durations)
+    if sample_count >= _MIN_HISTORY_SAMPLES:
+        median = statistics.median(durations)
+        return EstimateResult(
+            seconds=int(median * _HISTORY_BUFFER),
+            confidence="history",
+            samples_used=sample_count,
+        )
+    return EstimateResult(
+        seconds=_fallback_seconds(strategy, db_size_mb),
+        confidence="fallback",
+        samples_used=sample_count,
+    )

--- a/fraisier/webhook.py
+++ b/fraisier/webhook.py
@@ -21,6 +21,7 @@ from .config import get_config
 if TYPE_CHECKING:
     from .config.loader import FraisierConfig
     from .database import FraisierDB
+from .duration_estimate import estimate_duration
 from .errors import ConfigurationError, DeploymentError, DeploymentLockError
 from .git import GitProvider, WebhookEvent, get_provider
 from .locking import deployment_lock, is_deployment_locked
@@ -287,6 +288,47 @@ def _get_lock_dir(config: "FraisierConfig") -> Path | None:
         return None
 
 
+# Maps the user-facing `database.strategy` value to the estimator's key.
+_STRATEGY_ALIASES: dict[str, str] = {"apply": "migrate"}
+
+
+def _build_estimate(
+    fraise_config: dict[str, Any], fraise_name: str, environment: str
+) -> dict[str, Any] | None:
+    """Return ``{estimated_duration_s, estimated_ready_at, estimate_confidence}``
+    or None if the fraise has no database section or the lookup fails."""
+    database_config = fraise_config.get("database") or {}
+    strategy = database_config.get("strategy")
+    if not strategy:
+        return None
+    strategy = _STRATEGY_ALIASES.get(strategy, strategy)
+    try:
+        from datetime import UTC, datetime, timedelta
+
+        from .database import get_db
+
+        result = estimate_duration(
+            get_db(),
+            fraise=fraise_name,
+            environment=environment,
+            strategy=strategy,
+            db_size_mb=None,
+        )
+        eta = datetime.now(tz=UTC) + timedelta(seconds=result.seconds)
+        return {
+            "estimated_duration_s": result.seconds,
+            "estimated_ready_at": eta.isoformat().replace("+00:00", "Z"),
+            "estimate_confidence": result.confidence,
+        }
+    except Exception:
+        logger.exception(
+            "estimate_duration: failed to build estimate for %s/%s",
+            fraise_name,
+            environment,
+        )
+        return None
+
+
 def _dispatch_deployment(
     event: WebhookEvent,
     background_tasks: BackgroundTasks,
@@ -339,13 +381,15 @@ def _dispatch_deployment(
             git_branch=event.branch,
             git_commit=event.commit_sha,
         )
-        deployments.append(
-            {
-                "status": "deployment_triggered",
-                "fraise": fraise_name,
-                "environment": environment,
-            }
-        )
+        deployment: dict[str, Any] = {
+            "status": "deployment_triggered",
+            "fraise": fraise_name,
+            "environment": environment,
+        }
+        estimate = _build_estimate(fraise_config, fraise_name, environment)
+        if estimate is not None:
+            deployment.update(estimate)
+        deployments.append(deployment)
 
     # Single-fraise backward compatibility: return flat response
     if len(fraise_configs) == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.18.0"
+version = "0.19.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -217,6 +217,44 @@ class TestFraisierDB:
         assert deployment["duration_seconds"] is not None
         assert deployment["error_message"] is None
 
+    def test_complete_deployment_persists_strategy_and_db_size(self, test_db):
+        """#201: complete_deployment writes strategy + db_size_mb to tb_deployment."""
+        deployment_id = test_db.start_deployment(
+            fraise="my_api", environment="production"
+        )
+        test_db.complete_deployment(
+            deployment_id=deployment_id,
+            success=True,
+            new_version="v2",
+            strategy="rebuild",
+            db_size_mb=512,
+        )
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT strategy, db_size_mb FROM tb_deployment "
+                "WHERE pk_deployment=?",
+                (deployment_id,),
+            ).fetchone()
+        assert row["strategy"] == "rebuild"
+        assert row["db_size_mb"] == 512
+
+    def test_complete_deployment_strategy_optional(self, test_db):
+        """Omitting strategy/db_size_mb leaves them NULL — legacy callers unaffected."""
+        deployment_id = test_db.start_deployment(
+            fraise="my_api", environment="production"
+        )
+        test_db.complete_deployment(
+            deployment_id=deployment_id, success=True, new_version="v2"
+        )
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT strategy, db_size_mb FROM tb_deployment "
+                "WHERE pk_deployment=?",
+                (deployment_id,),
+            ).fetchone()
+        assert row["strategy"] is None
+        assert row["db_size_mb"] is None
+
     def test_complete_deployment_failure(self, test_db):
         """Test completing a failed deployment."""
         deployment_id = test_db.start_deployment(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -43,8 +43,7 @@ class TestFraisierDB:
         _db = FraisierDB()
         with get_connection() as conn:
             cols = {
-                row["name"]
-                for row in conn.execute("PRAGMA table_info(tb_deployment)")
+                row["name"] for row in conn.execute("PRAGMA table_info(tb_deployment)")
             }
         assert "strategy" in cols
         assert "db_size_mb" in cols
@@ -231,8 +230,7 @@ class TestFraisierDB:
         )
         with get_connection() as conn:
             row = conn.execute(
-                "SELECT strategy, db_size_mb FROM tb_deployment "
-                "WHERE pk_deployment=?",
+                "SELECT strategy, db_size_mb FROM tb_deployment WHERE pk_deployment=?",
                 (deployment_id,),
             ).fetchone()
         assert row["strategy"] == "rebuild"
@@ -248,8 +246,7 @@ class TestFraisierDB:
         )
         with get_connection() as conn:
             row = conn.execute(
-                "SELECT strategy, db_size_mb FROM tb_deployment "
-                "WHERE pk_deployment=?",
+                "SELECT strategy, db_size_mb FROM tb_deployment WHERE pk_deployment=?",
                 (deployment_id,),
             ).fetchone()
         assert row["strategy"] is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -38,6 +38,82 @@ class TestFraisierDB:
             assert "tb_deployment" in tables
             assert "tb_webhook_event" in tables
 
+    def test_deployment_table_has_strategy_and_db_size_columns(self):
+        """`tb_deployment` carries `strategy` and `db_size_mb` for #201 history."""
+        _db = FraisierDB()
+        with get_connection() as conn:
+            cols = {
+                row["name"]
+                for row in conn.execute("PRAGMA table_info(tb_deployment)")
+            }
+        assert "strategy" in cols
+        assert "db_size_mb" in cols
+
+    def test_deployment_table_columns_added_on_legacy_install(self, tmp_path):
+        """On a pre-#201 database, init_database adds the missing columns
+        without re-creating the table or losing data."""
+        import fraisier.database as dbmod
+
+        legacy_path = tmp_path / "legacy.db"
+        # Build the table without the new columns.
+        import sqlite3
+
+        with sqlite3.connect(legacy_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE tb_deployment (
+                    id TEXT NOT NULL UNIQUE,
+                    identifier TEXT NOT NULL UNIQUE,
+                    pk_deployment INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fk_fraise_state INTEGER,
+                    fraise_name TEXT NOT NULL,
+                    environment_name TEXT NOT NULL,
+                    job_name TEXT,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT,
+                    duration_seconds REAL,
+                    old_version TEXT,
+                    new_version TEXT,
+                    status TEXT NOT NULL,
+                    triggered_by TEXT,
+                    triggered_by_user TEXT,
+                    git_commit TEXT,
+                    git_branch TEXT,
+                    error_message TEXT,
+                    details TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                """
+            )
+            conn.execute(
+                "INSERT INTO tb_deployment "
+                "(id, identifier, fraise_name, environment_name, started_at, "
+                "status, created_at, updated_at) "
+                "VALUES ('u1', 'i1', 'f', 'e', 'now', 'success', 'now', 'now')"
+            )
+            conn.commit()
+
+        # Re-init through fraisier; should ADD COLUMN, not DROP+CREATE.
+        original = dbmod.get_db_path
+        try:
+            dbmod.get_db_path = lambda: legacy_path
+            dbmod.init_database()
+            with dbmod.get_connection() as conn:
+                cols = {
+                    row["name"]
+                    for row in conn.execute("PRAGMA table_info(tb_deployment)")
+                }
+                assert "strategy" in cols
+                assert "db_size_mb" in cols
+                # Legacy row preserved.
+                row = conn.execute(
+                    "SELECT id FROM tb_deployment WHERE id='u1'"
+                ).fetchone()
+                assert row is not None
+        finally:
+            dbmod.get_db_path = original
+
     def test_update_fraise_state_new(self, test_db):
         """Test updating fraise state for new fraise."""
         test_db.update_fraise_state(

--- a/tests/test_duration_estimate.py
+++ b/tests/test_duration_estimate.py
@@ -1,0 +1,198 @@
+"""Tests for deployment duration estimator (issue #201)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from fraisier.duration_estimate import (
+    STRATEGY_FALLBACK_SECONDS_PER_MB,
+    STRATEGY_FLOOR_SECONDS,
+    EstimateResult,
+    estimate_duration,
+)
+
+
+def _db_with_durations(durations: list[float]) -> MagicMock:
+    db = MagicMock()
+    db.get_successful_deploy_durations.return_value = durations
+    return db
+
+
+class TestEstimateDurationHistory:
+    def test_returns_history_median_with_buffer_when_three_or_more_samples(self):
+        db = _db_with_durations([100.0, 120.0, 140.0])  # median 120 → +20% = 144
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="rebuild", db_size_mb=500
+        )
+        assert isinstance(result, EstimateResult)
+        assert result.confidence == "history"
+        assert result.samples_used == 3
+        assert result.seconds == 144
+
+    def test_uses_only_history_when_five_samples_present(self):
+        db = _db_with_durations([90.0, 100.0, 110.0, 120.0, 130.0])
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="rebuild", db_size_mb=500
+        )
+        assert result.confidence == "history"
+        # median = 110, +20% = 132
+        assert result.seconds == 132
+        assert result.samples_used == 5
+
+    def test_query_filters_by_fraise_env_and_strategy(self):
+        db = _db_with_durations([100.0, 100.0, 100.0])
+        estimate_duration(
+            db,
+            fraise="api",
+            environment="staging",
+            strategy="restore_migrate",
+            db_size_mb=200,
+        )
+        db.get_successful_deploy_durations.assert_called_once_with(
+            fraise="api", environment="staging", strategy="restore_migrate", limit=5
+        )
+
+
+class TestEstimateDurationFallback:
+    def test_returns_fallback_when_no_samples(self):
+        db = _db_with_durations([])
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="rebuild", db_size_mb=400
+        )
+        assert result.confidence == "fallback"
+        assert result.samples_used == 0
+        # 400 MB * 0.0025 s/MB = 1.0s; should be clamped to floor 180s.
+        assert result.seconds == STRATEGY_FLOOR_SECONDS["rebuild"]
+
+    def test_fallback_scales_with_db_size_when_above_floor(self):
+        db = _db_with_durations([])
+        # 200_000 MB * 0.05 = 10_000s for restore_migrate
+        result = estimate_duration(
+            db,
+            fraise="api",
+            environment="prod",
+            strategy="restore_migrate",
+            db_size_mb=200_000,
+        )
+        assert result.confidence == "fallback"
+        assert result.seconds == int(
+            200_000 * STRATEGY_FALLBACK_SECONDS_PER_MB["restore_migrate"]
+        )
+
+    def test_fallback_uses_strategy_floor_when_db_size_unknown(self):
+        db = _db_with_durations([])
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="migrate", db_size_mb=None
+        )
+        assert result.confidence == "fallback"
+        assert result.seconds == STRATEGY_FLOOR_SECONDS["migrate"]
+
+    def test_fallback_only_two_samples_still_falls_back(self):
+        """Plan: <3 samples → fallback. Two samples isn't enough signal."""
+        db = _db_with_durations([100.0, 200.0])
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="rebuild", db_size_mb=None
+        )
+        assert result.confidence == "fallback"
+        assert result.samples_used == 2
+
+    def test_fallback_for_unknown_strategy_uses_generic_floor(self):
+        db = _db_with_durations([])
+        result = estimate_duration(
+            db,
+            fraise="api",
+            environment="prod",
+            strategy="custom_xyz",
+            db_size_mb=None,
+        )
+        assert result.confidence == "fallback"
+        # Unknown strategy gets a non-zero generic floor (60s by convention).
+        assert result.seconds >= 60
+
+
+class TestEstimateDurationErrors:
+    def test_swallows_db_error_and_falls_back(self):
+        """A failing DB query must never break the estimator — return fallback."""
+        db = MagicMock()
+        db.get_successful_deploy_durations.side_effect = RuntimeError("db down")
+        result = estimate_duration(
+            db, fraise="api", environment="prod", strategy="rebuild", db_size_mb=500
+        )
+        assert result.confidence == "fallback"
+        assert result.samples_used == 0
+
+
+class TestGetSuccessfulDeployDurations:
+    """The repository method consumed by the estimator."""
+
+    def test_returns_durations_for_matching_fraise_env_strategy(self, test_db):
+        from fraisier.database import get_connection
+
+        # Three successful rebuild deploys for api/prod.
+        for dur in (100.0, 110.0, 120.0):
+            pk = test_db.start_deployment(fraise="api", environment="prod")
+            test_db.complete_deployment(
+                deployment_id=pk,
+                success=True,
+                new_version="v2",
+                strategy="rebuild",
+            )
+            # Patch duration in place since timing is fast in tests.
+            with get_connection() as conn:
+                conn.execute(
+                    "UPDATE tb_deployment SET duration_seconds=? WHERE pk_deployment=?",
+                    (dur, pk),
+                )
+                conn.commit()
+        # One failure that must NOT be returned.
+        pk = test_db.start_deployment(fraise="api", environment="prod")
+        test_db.complete_deployment(deployment_id=pk, success=False, strategy="rebuild")
+
+        result = test_db.get_successful_deploy_durations(
+            fraise="api", environment="prod", strategy="rebuild", limit=10
+        )
+        assert sorted(result) == [100.0, 110.0, 120.0]
+
+    def test_filters_by_strategy(self, test_db):
+        pk_rebuild = test_db.start_deployment(fraise="api", environment="prod")
+        test_db.complete_deployment(
+            deployment_id=pk_rebuild,
+            success=True,
+            new_version="v",
+            strategy="rebuild",
+        )
+        pk_migrate = test_db.start_deployment(fraise="api", environment="prod")
+        test_db.complete_deployment(
+            deployment_id=pk_migrate,
+            success=True,
+            new_version="v",
+            strategy="migrate",
+        )
+
+        rebuild = test_db.get_successful_deploy_durations(
+            fraise="api", environment="prod", strategy="rebuild", limit=10
+        )
+        migrate = test_db.get_successful_deploy_durations(
+            fraise="api", environment="prod", strategy="migrate", limit=10
+        )
+        assert len(rebuild) == 1
+        assert len(migrate) == 1
+
+    def test_limit_honoured(self, test_db):
+        for _ in range(10):
+            pk = test_db.start_deployment(fraise="api", environment="prod")
+            test_db.complete_deployment(
+                deployment_id=pk, success=True, new_version="v", strategy="rebuild"
+            )
+        result = test_db.get_successful_deploy_durations(
+            fraise="api", environment="prod", strategy="rebuild", limit=5
+        )
+        assert len(result) == 5
+
+    def test_returns_empty_for_no_matches(self, test_db):
+        result = test_db.get_successful_deploy_durations(
+            fraise="ghost", environment="prod", strategy="rebuild", limit=10
+        )
+        assert result == []

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -683,6 +683,111 @@ class TestProcessWebhookEvent:
             assert result["branch"] == "main"
             assert result["provider"] == "github"
 
+    def test_dispatch_response_includes_estimate_for_fraise_with_database(self, test_db):
+        """#201: dispatch response carries estimated_duration_s + estimated_ready_at
+        when the fraise has a `database` section with a strategy."""
+        event = WebhookEvent(
+            provider="github",
+            event_type="push",
+            branch="main",
+            commit_sha="abc123",
+            sender="dev",
+            is_push=True,
+            is_ping=False,
+        )
+        with patch("fraisier.webhook.get_config") as mock_config:
+            mock_config_obj = MagicMock()
+            mock_config_obj.get_fraises_for_branch.return_value = [
+                {
+                    "fraise_name": "my_api",
+                    "environment": "production",
+                    "type": "api",
+                    "app_path": "/tmp/api",
+                    "database": {"strategy": "rebuild"},
+                }
+            ]
+            mock_config.return_value = mock_config_obj
+
+            from fastapi import BackgroundTasks
+
+            result = process_webhook_event(event, BackgroundTasks(), webhook_id=1)
+
+        assert result["status"] == "deployment_triggered"
+        assert "estimated_duration_s" in result
+        assert isinstance(result["estimated_duration_s"], int)
+        assert result["estimated_duration_s"] > 0
+        assert "estimated_ready_at" in result
+        assert result["estimated_ready_at"].endswith("Z")
+        assert result["estimate_confidence"] in {"history", "fallback"}
+
+    def test_dispatch_omits_estimate_for_fraise_without_database(self, test_db):
+        """ETL/docker_compose fraises (no database section) don't get an estimate."""
+        event = WebhookEvent(
+            provider="github",
+            event_type="push",
+            branch="main",
+            commit_sha="abc123",
+            sender="dev",
+            is_push=True,
+            is_ping=False,
+        )
+        with patch("fraisier.webhook.get_config") as mock_config:
+            mock_config_obj = MagicMock()
+            mock_config_obj.get_fraises_for_branch.return_value = [
+                {
+                    "fraise_name": "etl_pipeline",
+                    "environment": "production",
+                    "type": "etl",
+                    "script_path": "scripts/pipeline.py",
+                }
+            ]
+            mock_config.return_value = mock_config_obj
+
+            from fastapi import BackgroundTasks
+
+            result = process_webhook_event(event, BackgroundTasks(), webhook_id=1)
+
+        assert result["status"] == "deployment_triggered"
+        assert "estimated_duration_s" not in result
+        assert "estimated_ready_at" not in result
+
+    def test_dispatch_estimate_failure_does_not_break_response(self, test_db):
+        """An estimator exception is swallowed; the deployment is still triggered."""
+        event = WebhookEvent(
+            provider="github",
+            event_type="push",
+            branch="main",
+            commit_sha="abc123",
+            sender="dev",
+            is_push=True,
+            is_ping=False,
+        )
+        with (
+            patch("fraisier.webhook.get_config") as mock_config,
+            patch(
+                "fraisier.webhook.estimate_duration",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            mock_config_obj = MagicMock()
+            mock_config_obj.get_fraises_for_branch.return_value = [
+                {
+                    "fraise_name": "my_api",
+                    "environment": "production",
+                    "type": "api",
+                    "app_path": "/tmp/api",
+                    "database": {"strategy": "rebuild"},
+                }
+            ]
+            mock_config.return_value = mock_config_obj
+
+            from fastapi import BackgroundTasks
+
+            result = process_webhook_event(event, BackgroundTasks(), webhook_id=1)
+
+        assert result["status"] == "deployment_triggered"
+        assert "estimated_duration_s" not in result
+
     def test_process_push_returns_skipped_when_deploy_locked(self, test_db):
         """Webhook returns 'skipped' when a deploy is already running."""
         event = WebhookEvent(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -683,7 +683,9 @@ class TestProcessWebhookEvent:
             assert result["branch"] == "main"
             assert result["provider"] == "github"
 
-    def test_dispatch_response_includes_estimate_for_fraise_with_database(self, test_db):
+    def test_dispatch_response_includes_estimate_for_fraise_with_database(
+        self, test_db
+    ):
         """#201: dispatch response carries estimated_duration_s + estimated_ready_at
         when the fraise has a `database` section with a strategy."""
         event = WebhookEvent(

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #201 (webhook surface). Webhook dispatch responses now carry `estimated_duration_s`, `estimated_ready_at` (UTC), and `estimate_confidence` for each triggered deployment that has a `database.strategy`. Agentic and human callers can size their `sleep`/poll loops at trigger time instead of guessing.

- Median of the most recent up-to-5 successful runs (with a 1.20 buffer) when ≥3 samples exist.
- Strategy-floor fallback otherwise (180s rebuild, 120s restore_migrate, 30s migrate, 60s unknown).
- `tb_deployment` gets `strategy` + `db_size_mb` columns; legacy installs migrate in place.
- All boundary code (estimator, dispatch helper) wraps the lookup in `try/except` — a flaky history store cannot block a deploy.

## Commits

| Phase | Commit | What |
|---|---|---|
| 1.1 | `745d4f4` | schema: add `strategy` + `db_size_mb` columns |
| 1.2 | `fa8a99e` | recorder: `complete_deployment` persists them |
| 2 | `f1d414b` | `duration_estimate.py` + `get_successful_deploy_durations` |
| 3.1 | `35e47ce` | webhook dispatch response carries the estimate |
| 4 | `7585614` | release v0.19.0 |

## Deferred to a follow-up PR

- **CLI display (Phase 3.2)**: `fraisier trigger-deploy` printing `Estimated completion: ~Nm`. The webhook surface is the higher-value one for agentic callers (and is what #201 explicitly calls out); the CLI side can land independently. Keeping it separate keeps this PR's diff focused on the agentic/server-side surface.
- **`db_size_mb` plumbing**: column exists and is honoured by the estimator, but currently recorded as NULL. Wiring it requires a `pg_database_size()` query before each deploy. Reserved for a future enhancement.

## Test plan

- [x] `uv run pytest` → 3334 passed, 26 skipped
- [x] `uv run ruff check` → clean
- [x] `uv run ruff format --check` → clean
- [x] `uv run ty check fraisier/duration_estimate.py fraisier/database.py fraisier/db/history.py fraisier/webhook.py` → clean
- [ ] Manual end-to-end on a staging host: trigger three rebuild deploys, then post a webhook and confirm the response carries `estimate_confidence: "history"` and a sensible `estimated_duration_s`. (Requires a real install — out of scope for this PR review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)