### PR TITLE
release: v0.20.0 — post-migration SQL hook (#204 PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-05-22
+
+### Added
+
+- **Post-migration SQL hooks** ([#204](https://github.com/fraiseql/fraisier/issues/204)). New `database.post_migrate:` list runs configurable SQL files between `confiture migrate up` and the service restart — typically the project's idempotent `db/7_grant/*.sql` sweep, but any cross-script reconciliation (post-migration ACL fixups, default-value sync) fits the slot. Each entry takes exactly one of `sql_dir` (runs all `*.sql` lexicographically) or `sql_file` (single file), plus an `on_error` knob (`halt`, default — raises `DeploymentError` and aborts before the service restart, so no rollback is needed; or `warn` — logs and continues). Closes the gap that lets a new table without grants slip past unauthenticated `/health` and fail under authenticated traffic.
+- **`fraisier/post_migrate.py`** — `PostMigrateStep`, `load_post_migrate_steps(database_config, *, app_path)`, `run_post_migrate_steps(steps, *, database_url, runner)`. psql shellout uses `["psql", database_url, "-v", "ON_ERROR_STOP=1", "-f", str(sql_file)]`.
+
+### Upgrade notes
+
+- Opt-in: a fraise without a `database.post_migrate` block is unchanged.
+- The hook runs **before** the service restart. A `halt` failure aborts the deploy with `status=failed` and leaves the previous service version serving — there is nothing to roll back because nothing was restarted yet.
+- The SQL files run under the `database.database_url` role (the same role confiture uses for the migration). This is intentional: drift from a non-owner `CREATE OR REPLACE` is the specific bug the hook closes.
+- See `fraises.example.yaml` for the config block shape.
+
 ## [0.19.1] - 2026-05-22
 
 ### Added

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -111,6 +111,15 @@ fraises:
           name: myapp_production
           strategy: apply  # safe migrations only, never drop
           backup_before_deploy: true
+          # Optional post-migration SQL hooks (#204). Each entry has
+          # exactly one of `sql_dir` or `sql_file`; on_error is `halt`
+          # (default — abort before restart) or `warn` (log + continue).
+          # Runs after confiture finishes and before the service restart.
+          # post_migrate:
+          #   - sql_dir: db/7_grant/   # idempotent grant sweep
+          #     on_error: halt
+          #   - sql_file: db/post_migrate.sql
+          #     on_error: warn
         health_check:
           url: https://api.myapp.io/health
           timeout: 30

--- a/fraisier/config/_validation.py
+++ b/fraisier/config/_validation.py
@@ -433,9 +433,7 @@ def _validate_post_migrate(fraise_name: str, db: dict) -> list[str]:
                 "or sql_file, not both"
             )
         elif not sql_dir and not sql_file:
-            errors.append(
-                f"{fraise_name}: {location} must specify sql_dir or sql_file"
-            )
+            errors.append(f"{fraise_name}: {location} must specify sql_dir or sql_file")
 
         on_error = entry.get("on_error", "halt")
         if on_error not in _VALID_POST_MIGRATE_ON_ERROR:

--- a/fraisier/config/_validation.py
+++ b/fraisier/config/_validation.py
@@ -7,7 +7,7 @@ Free functions that validate sections of the raw config dict loaded by
 """
 
 import re
-from typing import Any
+from typing import Any, cast
 
 from fraisier.config.schema import _UNIT_NAME_RE, _VALID_STRATEGIES
 from fraisier.dbops._strategies import ADMIN_STRATEGIES
@@ -243,6 +243,10 @@ def _validate_environment(fraise_name: str, env: dict) -> None:
     if isinstance(db, dict) and db.get("preflight"):
         errors.extend(_validate_preflight(fraise_name, db))
 
+    # post_migrate hook validation (#204)
+    if isinstance(db, dict) and db.get("post_migrate") is not None:
+        errors.extend(_validate_post_migrate(fraise_name, db))
+
     # ZFS configuration validation
     zfs_config = env.get("zfs")
     if zfs_config is not None:
@@ -393,6 +397,52 @@ def _validate_preflight(fraise_name: str, db: dict) -> list[str]:
             f"{fraise_name}: database.preflight.timeout_seconds must be "
             f"a positive integer, got {timeout!r}"
         )
+
+    return errors
+
+
+_VALID_POST_MIGRATE_ON_ERROR = frozenset({"halt", "warn"})
+
+
+def _validate_post_migrate(fraise_name: str, db: dict) -> list[str]:
+    """Return validation errors for a database.post_migrate config block."""
+    errors: list[str] = []
+    entries: Any = db.get("post_migrate")
+    if not isinstance(entries, list):
+        errors.append(
+            f"{fraise_name}: database.post_migrate must be a list, "
+            f"got {type(entries).__name__}"
+        )
+        return errors
+
+    for index, raw_entry in enumerate(entries):
+        location = f"database.post_migrate[{index}]"
+        if not isinstance(raw_entry, dict):
+            errors.append(
+                f"{fraise_name}: {location} must be a mapping, "
+                f"got {type(raw_entry).__name__}"
+            )
+            continue
+
+        entry = cast("dict[str, Any]", raw_entry)
+        sql_dir = entry.get("sql_dir")
+        sql_file = entry.get("sql_file")
+        if sql_dir and sql_file:
+            errors.append(
+                f"{fraise_name}: {location} must specify either sql_dir "
+                "or sql_file, not both"
+            )
+        elif not sql_dir and not sql_file:
+            errors.append(
+                f"{fraise_name}: {location} must specify sql_dir or sql_file"
+            )
+
+        on_error = entry.get("on_error", "halt")
+        if on_error not in _VALID_POST_MIGRATE_ON_ERROR:
+            errors.append(
+                f"{fraise_name}: {location}.on_error must be 'halt' or "
+                f"'warn', got {on_error!r}"
+            )
 
     return errors
 

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -206,6 +206,33 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         logger.info("Running database migrations")
         self._run_strategy()
 
+    def _run_post_migrate(self) -> None:
+        """Run database.post_migrate SQL hooks (#204).
+
+        Best-effort scoping: a ``halt`` step raises ``DeploymentError``
+        and aborts the deploy before the service is restarted (nothing
+        is yet serving the new code, so no rollback is needed). A
+        ``warn`` step logs and continues. Skipped silently when the
+        ``post_migrate`` list is empty or ``database_url`` is missing —
+        no app DB to connect to.
+        """
+        database_url = self.database_config.get("database_url")
+        if not database_url:
+            return
+        from fraisier import post_migrate
+
+        steps = post_migrate.load_post_migrate_steps(
+            self.database_config,
+            app_path=Path(self.app_path) if self.app_path else Path(),
+        )
+        if not steps:
+            return
+        post_migrate.run_post_migrate_steps(
+            steps,
+            database_url=database_url,
+            runner=self.runner,
+        )
+
     def _check_health_or_rollback(
         self,
         start_time: float,
@@ -288,6 +315,7 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
                 # Step 3: Run database migrations via strategy if configured
                 if self.database_config:
                     self._run_database_migrations()
+                    self._run_post_migrate()
 
                 # Step 4: Restart service (unless strategy handles it)
                 if self.systemd_service and not self._is_restore_migrate_strategy():

--- a/fraisier/post_migrate.py
+++ b/fraisier/post_migrate.py
@@ -1,0 +1,132 @@
+"""Post-migration SQL hook (#204 PR A).
+
+Runs a configurable list of SQL files (typically the project's idempotent
+``db/7_grant/*.sql``) between ``confiture migrate up`` and the service
+restart. Closes a class of regressions where a freshly-applied migration
+introduces a new table that the app role has no grants on, or where a
+``CREATE OR REPLACE VIEW`` applied by a non-owner role causes silent ACL
+drift — both of which slip through unauthenticated ``/health`` but fail
+the moment authenticated traffic hits.
+
+Each step has an ``on_error`` knob:
+- ``halt`` (default) — psql nonzero exit raises ``DeploymentError``
+  immediately. No further entries run. Deploy aborts before the service
+  is restarted, so there is nothing to roll back.
+- ``warn`` — psql nonzero exit is logged at WARNING and iteration
+  continues. The deploy still completes successfully.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from fraisier.errors import DeploymentError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterable
+
+    from fraisier.runners import CommandRunner
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PostMigrateStep:
+    """One entry in the ``database.post_migrate`` list."""
+
+    sql_dir: Path | None
+    sql_file: Path | None
+    on_error: Literal["halt", "warn"]
+
+
+def _resolve(path: str, app_path: Path) -> Path:
+    p = Path(path)
+    if p.is_absolute():
+        return p
+    return app_path / p
+
+
+def load_post_migrate_steps(
+    database_config: dict,
+    *,
+    app_path: Path,
+) -> list[PostMigrateStep]:
+    """Parse ``database.post_migrate`` into a list of ``PostMigrateStep``.
+
+    Returns an empty list if the section is missing or empty. Path
+    fields are resolved relative to *app_path*. Validation of the
+    overall shape (sql_dir XOR sql_file, on_error in {halt, warn}) is
+    performed at config-load time by ``fraisier.config._validation``.
+    """
+    raw = database_config.get("post_migrate") or []
+    steps: list[PostMigrateStep] = []
+    for entry in raw:
+        sql_dir_raw = entry.get("sql_dir")
+        sql_file_raw = entry.get("sql_file")
+        on_error: Literal["halt", "warn"] = entry.get("on_error", "halt")
+        steps.append(
+            PostMigrateStep(
+                sql_dir=_resolve(sql_dir_raw, app_path) if sql_dir_raw else None,
+                sql_file=_resolve(sql_file_raw, app_path) if sql_file_raw else None,
+                on_error=on_error,
+            )
+        )
+    return steps
+
+
+def _expand_step(step: PostMigrateStep) -> Iterable[Path]:
+    if step.sql_file is not None:
+        yield step.sql_file
+        return
+    if step.sql_dir is not None:
+        yield from sorted(step.sql_dir.glob("*.sql"))
+
+
+def _run_one(
+    sql_file: Path,
+    *,
+    database_url: str,
+    runner: CommandRunner,
+) -> None:
+    cmd = [
+        "psql",
+        database_url,
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-f",
+        str(sql_file),
+    ]
+    runner.run(cmd)
+
+
+def run_post_migrate_steps(
+    steps: list[PostMigrateStep],
+    *,
+    database_url: str,
+    runner: CommandRunner,
+) -> None:
+    """Execute each step in order.
+
+    A ``halt`` step that fails raises ``DeploymentError`` immediately
+    and no further steps run. A ``warn`` step that fails is logged and
+    iteration continues.
+    """
+    for step in steps:
+        for sql_file in _expand_step(step):
+            try:
+                _run_one(sql_file, database_url=database_url, runner=runner)
+            except subprocess.CalledProcessError as exc:
+                if step.on_error == "halt":
+                    raise DeploymentError(
+                        f"post_migrate step failed (halt): {sql_file} "
+                        f"(exit {exc.returncode}): {exc.stderr or ''}"
+                    ) from exc
+                logger.warning(
+                    "post_migrate step %s failed (warn, continuing): %s",
+                    sql_file,
+                    exc.stderr or exc,
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.19.1"
+version = "0.20.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_api_deploy_post_migrate.py
+++ b/tests/test_api_deploy_post_migrate.py
@@ -1,0 +1,187 @@
+"""Tests for the post-migrate SQL hook wired into the API deploy pipeline (#204).
+
+The runner is invoked after ``_run_database_migrations`` succeeds and
+before ``_restart_service``. A ``halt`` failure raises ``DeploymentError``
+which aborts the deploy prior to the service restart; no rollback is
+needed because no new code is yet serving. A ``warn`` failure logs and
+the pipeline continues normally.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fraisier.deployers.api import APIDeployer
+
+
+def _make_deployer(post_migrate=None, **overrides):
+    database = {
+        "name": "mydb",
+        "strategy": "migrate",
+        "database_url": "postgresql:///mydb?host=/var/run/postgresql",
+    }
+    if post_migrate is not None:
+        database["post_migrate"] = post_migrate
+    config = {
+        "fraise_name": "myapi",
+        "environment": "production",
+        "app_path": "/srv/myapi",
+        "clone_url": "git@github.com:org/myapi.git",
+        "branch": "main",
+        "systemd_service": "myapi.service",
+        "health_check": {"url": "http://localhost:8000/health", "timeout": 5},
+        "repos_base": "/tmp/repos",
+        "database": database,
+    }
+    config.update(overrides)
+    return APIDeployer(config)
+
+
+class TestPostMigrateOrdering:
+    def test_runs_post_migrate_between_migrations_and_restart(self):
+        call_order = []
+        deployer = _make_deployer(
+            post_migrate=[{"sql_file": "db/grant.sql"}],
+        )
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(
+                deployer,
+                "_run_database_migrations",
+                side_effect=lambda: call_order.append("migrate"),
+            ),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+                side_effect=lambda *_a, **_kw: call_order.append("post_migrate"),
+            ),
+            patch.object(
+                deployer,
+                "_restart_service",
+                side_effect=lambda: call_order.append("restart"),
+            ),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+        ):
+            result = deployer.execute()
+
+        assert result.success is True
+        assert call_order == ["migrate", "post_migrate", "restart"]
+
+    def test_no_section_is_noop(self):
+        # database has no post_migrate key — runner must not fire.
+        deployer = _make_deployer()
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_run_database_migrations"),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+            ) as mock_run,
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+        ):
+            deployer.execute()
+
+        mock_run.assert_not_called()
+
+
+class TestPostMigrateFailureSemantics:
+    def test_halt_failure_aborts_before_service_restart(self):
+        from fraisier.errors import DeploymentError
+
+        deployer = _make_deployer(
+            post_migrate=[{"sql_file": "db/grant.sql", "on_error": "halt"}],
+        )
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_run_database_migrations"),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+                side_effect=DeploymentError("grant.sql failed"),
+            ),
+            patch.object(deployer, "_restart_service") as mock_restart,
+            patch.object(deployer, "_wait_for_health", return_value=True),
+        ):
+            result = deployer.execute()
+
+        # The deploy fails because the halt fired.
+        assert result.success is False
+        # And it did NOT restart the service — by design, the service is
+        # left serving the previous version.
+        mock_restart.assert_not_called()
+
+    def test_warn_failure_proceeds_to_service_restart(self):
+        # When the runner uses on_error=warn it does not raise; the
+        # deploy continues normally. We assert by mocking the runner to
+        # return None (no exception) and confirming restart happens.
+        deployer = _make_deployer(
+            post_migrate=[{"sql_file": "db/grant.sql", "on_error": "warn"}],
+        )
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_run_database_migrations"),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+                return_value=None,
+            ) as mock_run,
+            patch.object(deployer, "_restart_service") as mock_restart,
+            patch.object(deployer, "_wait_for_health", return_value=True),
+        ):
+            result = deployer.execute()
+
+        assert result.success is True
+        mock_run.assert_called_once()
+        mock_restart.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "missing_field", ["database_url"],
+)
+class TestPostMigrateGuards:
+    def test_skips_when_database_url_missing(self, missing_field):
+        # post_migrate is defined but database_url is missing — the
+        # runner cannot connect to anything, so it must not fire.
+        deployer = _make_deployer(post_migrate=[{"sql_file": "db/grant.sql"}])
+        # Remove the database_url key.
+        deployer.database_config = {
+            k: v
+            for k, v in deployer.database_config.items()
+            if k != missing_field
+        }
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_run_database_migrations"),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+            ) as mock_run,
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+        ):
+            deployer.execute()
+
+        mock_run.assert_not_called()

--- a/tests/test_api_deploy_post_migrate.py
+++ b/tests/test_api_deploy_post_migrate.py
@@ -155,7 +155,8 @@ class TestPostMigrateFailureSemantics:
 
 
 @pytest.mark.parametrize(
-    "missing_field", ["database_url"],
+    "missing_field",
+    ["database_url"],
 )
 class TestPostMigrateGuards:
     def test_skips_when_database_url_missing(self, missing_field):
@@ -164,9 +165,7 @@ class TestPostMigrateGuards:
         deployer = _make_deployer(post_migrate=[{"sql_file": "db/grant.sql"}])
         # Remove the database_url key.
         deployer.database_config = {
-            k: v
-            for k, v in deployer.database_config.items()
-            if k != missing_field
+            k: v for k, v in deployer.database_config.items() if k != missing_field
         }
 
         with (

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -484,9 +484,7 @@ fraises:
 """
 
     def _write(self, tmp_path, entries: str):
-        return _write_config(
-            tmp_path, self._BASE_CONFIG.format(entries=entries)
-        )
+        return _write_config(tmp_path, self._BASE_CONFIG.format(entries=entries))
 
     def test_accepts_entry_with_sql_dir_only(self, tmp_path):
         config_file = self._write(tmp_path, "[{sql_dir: db/7_grant/}]")
@@ -520,10 +518,6 @@ fraises:
         FraisierConfig(config_file)
 
     def test_on_error_rejects_unknown_value(self, tmp_path):
-        config_file = self._write(
-            tmp_path, "[{sql_dir: db/7_grant/, on_error: panic}]"
-        )
-        with pytest.raises(
-            ValidationError, match=r"on_error.*'halt'.*'warn'"
-        ):
+        config_file = self._write(tmp_path, "[{sql_dir: db/7_grant/, on_error: panic}]")
+        with pytest.raises(ValidationError, match=r"on_error.*'halt'.*'warn'"):
             FraisierConfig(config_file)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -464,3 +464,66 @@ fraises:
         )
         with pytest.raises(ValidationError, match=r"preferred_compression"):
             FraisierConfig(config_file)
+
+
+class TestPostMigrateValidation:
+    """`database.post_migrate` schema validation (#204 PR A)."""
+
+    _BASE_CONFIG = """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        database:
+          name: mydb
+          strategy: migrate
+          database_url: "postgresql:///mydb?host=/var/run/postgresql"
+          post_migrate: {entries}
+"""
+
+    def _write(self, tmp_path, entries: str):
+        return _write_config(
+            tmp_path, self._BASE_CONFIG.format(entries=entries)
+        )
+
+    def test_accepts_entry_with_sql_dir_only(self, tmp_path):
+        config_file = self._write(tmp_path, "[{sql_dir: db/7_grant/}]")
+        FraisierConfig(config_file)  # must not raise
+
+    def test_accepts_entry_with_sql_file_only(self, tmp_path):
+        config_file = self._write(tmp_path, "[{sql_file: db/post_migrate.sql}]")
+        FraisierConfig(config_file)
+
+    def test_rejects_entry_with_both_sql_dir_and_sql_file(self, tmp_path):
+        config_file = self._write(
+            tmp_path,
+            "[{sql_dir: db/7_grant/, sql_file: db/post_migrate.sql}]",
+        )
+        with pytest.raises(
+            ValidationError, match=r"post_migrate.*either.*sql_dir.*or.*sql_file"
+        ):
+            FraisierConfig(config_file)
+
+    def test_rejects_entry_with_neither_sql_dir_nor_sql_file(self, tmp_path):
+        config_file = self._write(tmp_path, "[{on_error: warn}]")
+        with pytest.raises(
+            ValidationError, match=r"post_migrate.*sql_dir.*or.*sql_file"
+        ):
+            FraisierConfig(config_file)
+
+    def test_on_error_defaults_to_halt(self, tmp_path):
+        # No on_error key in the YAML — loader assigns "halt" at parse time.
+        # Validation passes; default behaviour is checked in test_post_migrate.py.
+        config_file = self._write(tmp_path, "[{sql_dir: db/7_grant/}]")
+        FraisierConfig(config_file)
+
+    def test_on_error_rejects_unknown_value(self, tmp_path):
+        config_file = self._write(
+            tmp_path, "[{sql_dir: db/7_grant/, on_error: panic}]"
+        )
+        with pytest.raises(
+            ValidationError, match=r"on_error.*'halt'.*'warn'"
+        ):
+            FraisierConfig(config_file)

--- a/tests/test_post_migrate.py
+++ b/tests/test_post_migrate.py
@@ -209,9 +209,7 @@ class TestRunPostMigrateStepsOnError:
             subprocess.CalledProcessError(
                 returncode=1, cmd=["psql"], stderr="WARNING-ish failure"
             ),
-            subprocess.CompletedProcess(
-                args=[], returncode=0, stdout="", stderr=""
-            ),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
 
         with caplog.at_level(logging.WARNING, logger="fraisier.post_migrate"):

--- a/tests/test_post_migrate.py
+++ b/tests/test_post_migrate.py
@@ -1,0 +1,226 @@
+"""Tests for post-migrate SQL hook (#204 PR A).
+
+The post-migrate hook runs a configurable list of SQL files (typically
+``db/7_grant/*.sql``) between ``confiture migrate up`` and the service
+restart so cross-script reconciliation (idempotent grant sweeps,
+post-migration fixups) lives outside confiture's per-migration scope.
+
+Two on_error modes:
+- ``halt`` (default): psql nonzero exit raises ``DeploymentError``
+  immediately; no further entries run; the deploy aborts before the
+  service is restarted.
+- ``warn``: psql nonzero exit is logged at WARNING and iteration
+  continues to the next entry. The deploy still ends in ``success``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from fraisier.errors import DeploymentError
+from fraisier.post_migrate import (
+    PostMigrateStep,
+    load_post_migrate_steps,
+    run_post_migrate_steps,
+)
+
+# ---------------------------------------------------------------------------
+# Loader / path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLoadPostMigrateSteps:
+    def test_missing_post_migrate_key_is_noop(self):
+        # The `database:` block has no `post_migrate:` entry — no steps.
+        steps = load_post_migrate_steps(
+            {"strategy": "rebuild"}, app_path=Path("/srv/api")
+        )
+        assert steps == []
+
+    def test_empty_post_migrate_section_is_noop(self):
+        steps = load_post_migrate_steps(
+            {"strategy": "rebuild", "post_migrate": []},
+            app_path=Path("/srv/api"),
+        )
+        assert steps == []
+
+    def test_path_resolution_is_relative_to_app_path(self):
+        steps = load_post_migrate_steps(
+            {
+                "post_migrate": [
+                    {"sql_dir": "db/7_grant/"},
+                    {"sql_file": "db/post_migrate.sql"},
+                ]
+            },
+            app_path=Path("/srv/api"),
+        )
+        assert len(steps) == 2
+        assert steps[0].sql_dir == Path("/srv/api/db/7_grant/")
+        assert steps[0].sql_file is None
+        assert steps[1].sql_file == Path("/srv/api/db/post_migrate.sql")
+        assert steps[1].sql_dir is None
+
+    def test_on_error_defaults_to_halt(self):
+        steps = load_post_migrate_steps(
+            {"post_migrate": [{"sql_file": "db/x.sql"}]},
+            app_path=Path("/srv/api"),
+        )
+        assert steps[0].on_error == "halt"
+
+    def test_absolute_paths_are_preserved(self):
+        steps = load_post_migrate_steps(
+            {"post_migrate": [{"sql_file": "/etc/extra/grant.sql"}]},
+            app_path=Path("/srv/api"),
+        )
+        assert steps[0].sql_file == Path("/etc/extra/grant.sql")
+
+
+# ---------------------------------------------------------------------------
+# Runner — single-file
+# ---------------------------------------------------------------------------
+
+
+def _runner_ok() -> MagicMock:
+    runner = MagicMock()
+    runner.run.return_value = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="", stderr=""
+    )
+    return runner
+
+
+class TestRunPostMigrateStepsSingleFile:
+    def test_runs_single_sql_file_via_psql(self, tmp_path):
+        sql = tmp_path / "grant.sql"
+        sql.write_text("GRANT SELECT ON tb_foo TO app;")
+        steps = [PostMigrateStep(sql_dir=None, sql_file=sql, on_error="halt")]
+        runner = _runner_ok()
+
+        run_post_migrate_steps(
+            steps,
+            database_url="postgresql://u@h/db",
+            runner=runner,
+        )
+
+        runner.run.assert_called_once()
+        cmd = runner.run.call_args.args[0]
+        assert cmd == [
+            "psql",
+            "postgresql://u@h/db",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-f",
+            str(sql),
+        ]
+
+
+class TestRunPostMigrateStepsDirectory:
+    def test_runs_all_files_in_dir_lexicographically(self, tmp_path):
+        sql_dir = tmp_path / "grants"
+        sql_dir.mkdir()
+        (sql_dir / "20_grants.sql").write_text("-- second")
+        (sql_dir / "10_revoke.sql").write_text("-- first")
+        # Non-.sql files must be ignored.
+        (sql_dir / "README.md").write_text("docs")
+
+        steps = [PostMigrateStep(sql_dir=sql_dir, sql_file=None, on_error="halt")]
+        runner = _runner_ok()
+
+        run_post_migrate_steps(
+            steps,
+            database_url="postgresql://u@h/db",
+            runner=runner,
+        )
+
+        called_paths = [call.args[0][-1] for call in runner.run.call_args_list]
+        assert called_paths == [
+            str(sql_dir / "10_revoke.sql"),
+            str(sql_dir / "20_grants.sql"),
+        ]
+
+    def test_empty_dir_is_a_noop(self, tmp_path):
+        sql_dir = tmp_path / "grants"
+        sql_dir.mkdir()
+        steps = [PostMigrateStep(sql_dir=sql_dir, sql_file=None, on_error="halt")]
+        runner = _runner_ok()
+        run_post_migrate_steps(
+            steps,
+            database_url="postgresql://u@h/db",
+            runner=runner,
+        )
+        runner.run.assert_not_called()
+
+
+class TestRunPostMigrateStepsOnError:
+    def test_halt_raises_deployment_error_on_psql_failure(self, tmp_path):
+        sql = tmp_path / "fail.sql"
+        sql.write_text("SELECT 1/0;")
+        steps = [PostMigrateStep(sql_dir=None, sql_file=sql, on_error="halt")]
+        runner = MagicMock()
+        runner.run.side_effect = subprocess.CalledProcessError(
+            returncode=3, cmd=["psql"], stderr="ERROR: syntax error"
+        )
+
+        with pytest.raises(DeploymentError, match=r"fail\.sql"):
+            run_post_migrate_steps(
+                steps,
+                database_url="postgresql://u@h/db",
+                runner=runner,
+            )
+
+    def test_halt_stops_after_first_failure(self, tmp_path):
+        bad = tmp_path / "10_bad.sql"
+        bad.write_text("bad")
+        never_run = tmp_path / "20_never.sql"
+        never_run.write_text("good")
+        steps = [
+            PostMigrateStep(sql_dir=None, sql_file=bad, on_error="halt"),
+            PostMigrateStep(sql_dir=None, sql_file=never_run, on_error="halt"),
+        ]
+        runner = MagicMock()
+        runner.run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["psql"], stderr="boom"
+        )
+        with pytest.raises(DeploymentError):
+            run_post_migrate_steps(
+                steps,
+                database_url="postgresql://u@h/db",
+                runner=runner,
+            )
+        # Only the first file ran.
+        assert runner.run.call_count == 1
+
+    def test_warn_logs_and_continues(self, tmp_path, caplog):
+        bad = tmp_path / "10_bad.sql"
+        bad.write_text("bad")
+        good = tmp_path / "20_good.sql"
+        good.write_text("good")
+        steps = [
+            PostMigrateStep(sql_dir=None, sql_file=bad, on_error="warn"),
+            PostMigrateStep(sql_dir=None, sql_file=good, on_error="warn"),
+        ]
+        runner = MagicMock()
+        # First call fails, second call succeeds.
+        runner.run.side_effect = [
+            subprocess.CalledProcessError(
+                returncode=1, cmd=["psql"], stderr="WARNING-ish failure"
+            ),
+            subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            ),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="fraisier.post_migrate"):
+            run_post_migrate_steps(
+                steps,
+                database_url="postgresql://u@h/db",
+                runner=runner,
+            )
+
+        assert runner.run.call_count == 2
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("10_bad.sql" in r.getMessage() for r in warnings)

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

PR A of the two-PR `#204` plan. Adds an optional `database.post_migrate:` list that runs configurable SQL files between `confiture migrate up` and the service restart. Typical use is the project's idempotent `db/7_grant/*.sql` sweep — closes the gap that lets a new table without grants slip past unauthenticated `/health` and only fail under authenticated traffic.

Each entry takes exactly one of `sql_dir` (runs all `*.sql` lexicographically) or `sql_file`, plus an `on_error` knob:
- `halt` (default) — psql nonzero exit raises `DeploymentError` immediately. No further entries run. The service is **not** restarted; deploy aborts with `status=failed`. Rollback path is not triggered (no new code is yet serving).
- `warn` — psql nonzero exit is logged at WARNING. Iteration continues. Deploy still ends in `status=success`.

PR B (authenticated smoke test) lands on top of this — it inherits the per-env-extension config shape PR A establishes.

## Test plan

- [x] `uv run pytest tests/test_post_migrate.py tests/test_config_validation.py tests/test_api_deploy_post_migrate.py` — 22 new tests pass.
- [x] `uv run pytest` (full suite) — 3355 passed. The one pre-existing test-ordering flake in `test_install_helper.py` is unrelated and fails on `main` too; deselected from the sweep.
- [x] `uv run ruff check` + `uv run ty check` — clean.
- [ ] Manual happy path: `db/7_grant/00_app.sql` with `GRANT SELECT ON tb_foo TO app_role;`. Deploy. Revoke the grant manually; redeploy; confirm the grant is restored.
- [ ] Manual halt: introduce a syntax error in a `.sql`. Deploy; expect `DeploymentError` before restart and the git tree remains on the old commit.
- [ ] Manual warn: same syntax error with `on_error: warn`; expect a WARNING log line, restart proceeds, deploy succeeds.

Refs #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)