### PR TITLE
release: v0.21.0 — authenticated smoke tests (#204 PR B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2026-05-22
+
+### Added
+
+- **Authenticated smoke tests** ([#204](https://github.com/fraiseql/fraisier/issues/204) PR B). New `smoke_tests:` list runs configured HTTP requests with bearer credentials and JSONPath assertions immediately after the unauthenticated `/health` poll succeeds. Closes the class of regressions where a new table or `CREATE OR REPLACE VIEW` slips past unauthenticated `/health` and only fails when authenticated traffic hits. Each test takes `method`, `url` (absolute, or relative — joined onto `health_check.url`), `timeout`, `headers`, optional `body`, an `on_failure` policy (`rollback` default, `halt`, or `warn`), and a list of `assert` entries. JSONPath is the minimal `$.dotted.path` subset — no `$..foo` recursion, no array indexing, no wildcards (rejected at config-load time with a clear "use $.dotted.path only" message).
+- **`fraisier/smoke_tests.py`** — `Assertion`, `SmokeTest`, `SmokeTestError`, `_walk_json_path`, `load_smoke_tests`, `run_smoke_tests`. HTTP via `httpx.Client`. `Authorization`, `Cookie`, and `X-API-Key` header values are redacted in log output.
+- **`!envvar` YAML tag** in `fraises.yaml`. Values like `Authorization: !envvar SMOKE_TEST_JWT` are resolved from `os.environ` at config-load time; missing variables raise `ConfigurationError` immediately. Implemented as a `yaml.SafeLoader` subclass so safety guarantees are preserved.
+
+### Upgrade notes
+
+- Opt-in: a fraise without a `smoke_tests:` block is unchanged.
+- `rollback` is the default `on_failure`: an authenticated probe that fails after `/health` passes is by definition a regression the unauthenticated probe missed — the safest default is to restore the previous version.
+- `halt` is for cases where rolling back would be more disruptive than serving a partially-broken version (rare; typically only useful when the failure points to *external* state).
+- Smoke tests run before the success result is constructed, so a rollback or halt failure is recorded as `status=failed` in `tb_deployment` with the smoke-test error message.
+- See `fraises.example.yaml` for the config block shape.
+
 ## [0.20.0] - 2026-05-22
 
 ### Added

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -43,7 +43,7 @@ name: myapp
 git:
   provider: github
   github:
-    webhook_secret: ${FRAISIER_WEBHOOK_SECRET}
+    webhook_secret: !envvar FRAISIER_WEBHOOK_SECRET
 
 scaffold:
   deploy_user: fraisier       # system user that runs deployments
@@ -84,14 +84,20 @@ branch_mapping:
 
 ### How secrets work
 
-Use `${ENV_VAR}` syntax in `fraises.yaml`. Fraisier resolves these at runtime. Never commit
-actual secrets. A typical environment file at `/etc/myapp/prod.env`:
+Use the `!envvar VAR_NAME` YAML tag in `fraises.yaml`. The tag resolves to the contents of
+`os.environ['VAR_NAME']` when the config file is parsed; missing variables raise
+`ConfigurationError` immediately. Never commit actual secrets. A typical environment file at
+`/etc/myapp/prod.env`:
 
 ```bash
 FRAISIER_WEBHOOK_SECRET=<min 32 chars, random>
 DATABASE_URL=postgresql://myapp:pass@localhost/myapp_production
 DATABASE_ADMIN_URL=postgresql://postgres@/postgres?host=/var/run/postgresql
 ```
+
+`${VAR}` shell-style substitution is supported **only** inside the `notifications:` and
+`hooks:` blocks (expanded at fire time by their dispatchers). Use `!envvar` for everything
+else — most consumers read the YAML value literally and will not expand `${VAR}`.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -127,4 +127,6 @@ This avoids granting the deploy user OS-level sudo access to the postgres accoun
 - **Host compromise**: If an attacker has shell access to the deployment server, fraisier cannot protect against them.
 - **Network MitM**: Fraisier does not manage TLS. Use a reverse proxy (nginx, Caddy) with TLS termination.
 - **Config file tampering**: If an attacker can write to `fraises.yaml`, command validation reduces but does not eliminate risk. Protect the config file with filesystem permissions.
-- **Secrets in config**: Fraisier does not encrypt secrets at rest. Use environment variables for sensitive values (`${VAR}` syntax in YAML).
+- **Secrets in config**: Fraisier does not encrypt secrets at rest. Source secrets from environment variables instead of embedding them in `fraises.yaml`:
+  - **`!envvar VAR_NAME`** (load-time, recommended): a custom YAML tag that resolves to `os.environ['VAR_NAME']` when `fraises.yaml` is parsed. Missing variables raise `ConfigurationError` immediately. Works anywhere in `fraises.yaml`, including `git.<provider>.webhook_secret`, `smoke_tests.headers`, and `database.database_url`.
+  - **`${VAR_NAME}`** (runtime): scoped to the `notifications:` and `hooks:` blocks only. Expanded by the dispatcher at fire time. Do not use elsewhere — most consumers read the YAML value literally and will not expand it.

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -21,23 +21,23 @@ git:
   # GitHub configuration (github.com or GitHub Enterprise)
   github:
     base_url: https://github.com  # or https://github.mycompany.com
-    webhook_secret: ${FRAISIER_WEBHOOK_SECRET}  # from environment
+    webhook_secret: !envvar FRAISIER_WEBHOOK_SECRET  # resolved from $FRAISIER_WEBHOOK_SECRET at load time
 
   # GitLab configuration (gitlab.com or self-hosted)
   gitlab:
     base_url: https://gitlab.com  # or https://gitlab.mycompany.com
-    secret_token: ${FRAISIER_WEBHOOK_SECRET}
+    secret_token: !envvar FRAISIER_WEBHOOK_SECRET
 
   # Gitea configuration (self-hosted, also works with Forgejo)
   gitea:
     base_url: https://gitea.mycompany.com
-    webhook_secret: ${FRAISIER_WEBHOOK_SECRET}
+    webhook_secret: !envvar FRAISIER_WEBHOOK_SECRET
 
   # Bitbucket configuration (Cloud or Server)
   bitbucket:
     base_url: https://bitbucket.org  # or https://bitbucket.mycompany.com
     server: false  # set to true for Bitbucket Server/Data Center
-    webhook_secret: ${FRAISIER_WEBHOOK_SECRET}
+    webhook_secret: !envvar FRAISIER_WEBHOOK_SECRET
 
 # ============================================================
 # FRAISES (Services)

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -123,6 +123,23 @@ fraises:
         health_check:
           url: https://api.myapp.io/health
           timeout: 30
+        # Optional authenticated smoke tests (#204). Run after the
+        # unauthenticated health_check passes. JSONPath is the minimal
+        # $.dotted.path subset — no $..foo, no array indexing, no wildcards.
+        # Authorization headers may be sourced from os.environ via !envvar.
+        # smoke_tests:
+        #   - name: authenticated_me
+        #     method: POST
+        #     url: /graphql          # relative — joined onto health_check.url
+        #     timeout: 5
+        #     headers:
+        #       Authorization: !envvar SMOKE_TEST_JWT
+        #     body: '{"query":"{ me { id role } }"}'
+        #     on_failure: rollback    # rollback (default) | halt | warn
+        #     assert:
+        #       - { json_path: $.data.me.id, not_null: true }
+        #       - { json_path: $.data.me.role, equals: admin }
+        #       - { json_path: $.errors, null: true }
         service:
           type: exec               # systemd Type= (default: exec)
           user: myapp              # app runs as myapp (least privilege)

--- a/fraisier/config/_validation.py
+++ b/fraisier/config/_validation.py
@@ -247,6 +247,10 @@ def _validate_environment(fraise_name: str, env: dict) -> None:
     if isinstance(db, dict) and db.get("post_migrate") is not None:
         errors.extend(_validate_post_migrate(fraise_name, db))
 
+    # smoke_tests validation (#204 PR B)
+    if env.get("smoke_tests") is not None:
+        errors.extend(_validate_smoke_tests(fraise_name, env))
+
     # ZFS configuration validation
     zfs_config = env.get("zfs")
     if zfs_config is not None:
@@ -402,6 +406,31 @@ def _validate_preflight(fraise_name: str, db: dict) -> list[str]:
 
 
 _VALID_POST_MIGRATE_ON_ERROR = frozenset({"halt", "warn"})
+
+
+def _validate_smoke_tests(fraise_name: str, env: dict) -> list[str]:
+    """Run the smoke_tests loader at config-load time to surface errors.
+
+    Defers to ``fraisier.smoke_tests.load_smoke_tests`` so the schema
+    (method, on_failure, JSONPath syntax) is enforced in one place. The
+    base_url is derived from the env's ``health_check.url`` if any.
+    """
+    from urllib.parse import urlparse
+
+    from fraisier.smoke_tests import load_smoke_tests
+
+    hc = env.get("health_check") or {}
+    hc_url = hc.get("url") if isinstance(hc, dict) else None
+    base_url: str | None = None
+    if hc_url:
+        parsed = urlparse(str(hc_url))
+        if parsed.scheme and parsed.netloc:
+            base_url = f"{parsed.scheme}://{parsed.netloc}"
+    try:
+        load_smoke_tests(env, base_url=base_url)
+    except ValueError as exc:
+        return [f"{fraise_name}: smoke_tests {exc}"]
+    return []
 
 
 def _validate_post_migrate(fraise_name: str, db: dict) -> list[str]:

--- a/fraisier/config/loader.py
+++ b/fraisier/config/loader.py
@@ -40,7 +40,7 @@ from fraisier.config.schema import (
     SystemdScaffoldConfig,
     _config_search_locations,
 )
-from fraisier.errors import ValidationError
+from fraisier.errors import ConfigurationError, ValidationError
 
 _DEFAULT_TIMEOUT = 600  # 10 minutes
 _MEMORY_SIZE_RE = re.compile(r"^\d+[KMGT]$")
@@ -54,6 +54,36 @@ _VALID_SERVICE_TYPES = {
     "notify-reload",
     "idle",
 }
+
+
+class _FraisierYamlLoader(yaml.SafeLoader):
+    """SafeLoader subclass that resolves ``!envvar`` tags from os.environ.
+
+    Use:
+        headers:
+          Authorization: !envvar SMOKE_TEST_JWT
+
+    Missing variables raise ``ConfigurationError`` at load time so the
+    misconfig is visible immediately rather than at deploy time. Empty
+    strings are accepted: an env var set to ``""`` is still considered
+    "set" and resolves to the empty string.
+    """
+
+
+def _construct_envvar(loader: yaml.Loader, node: yaml.Node) -> str:
+    if not isinstance(node, yaml.ScalarNode):
+        raise ConfigurationError(
+            f"!envvar expects a scalar variable name, got {type(node).__name__}"
+        )
+    name = loader.construct_scalar(node)
+    if name not in os.environ:
+        raise ConfigurationError(
+            f"!envvar references environment variable {name!r} which is not set"
+        )
+    return os.environ[name]
+
+
+_FraisierYamlLoader.add_constructor("!envvar", _construct_envvar)
 
 
 class FraisierConfig:
@@ -100,7 +130,7 @@ class FraisierConfig:
     def _load(self) -> None:
         """Load configuration from YAML file."""
         with Path(self.config_path).open() as f:
-            self._config = yaml.safe_load(f)
+            self._config = yaml.load(f, Loader=_FraisierYamlLoader)
         validate_fraises(self._config.get("fraises", {}))
         validate_servers(self._config.get("servers", {}))
         validate_branch_mapping(

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -47,6 +47,7 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         self.health_check_timeout = hc.get("timeout", 30)
         self.health_check_retries = hc.get("retries", 5)
         self.database_config = config.get("database", {})
+        self.smoke_tests_config = config.get("smoke_tests")
         self.allow_irreversible = config.get("allow_irreversible", False)
         self.lock_timeout = config.get("lock_timeout", 300)
         self._migrations_applied: int = 0
@@ -206,6 +207,64 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         logger.info("Running database migrations")
         self._run_strategy()
 
+    def _run_smoke_tests_or_halt(
+        self,
+        start_time: float,
+        old_version: str | None,
+        db_pk: int | None,
+    ) -> DeploymentResult | None:
+        """Run configured smoke tests post-health; return a failed result if any fail.
+
+        Returns ``None`` when no smoke tests are configured or all pass.
+        On failure: if the failing test's ``on_failure`` is ``rollback``,
+        invoke the existing rollback path and return a rolled-back result.
+        If ``halt``, return a failed result without rollback. ``warn``
+        failures are absorbed by ``run_smoke_tests`` itself and never
+        reach this method.
+        """
+        if not self.smoke_tests_config:
+            return None
+        from fraisier import smoke_tests
+
+        # Health check URL provides the scheme+host base for relative
+        # smoke_test URLs. Stripped to scheme://host (no path).
+        base_url: str | None = None
+        if self.health_check_url:
+            from urllib.parse import urlparse
+
+            parsed = urlparse(self.health_check_url)
+            base_url = f"{parsed.scheme}://{parsed.netloc}"
+        tests = smoke_tests.load_smoke_tests(
+            {"smoke_tests": self.smoke_tests_config, "health_check": {}},
+            base_url=base_url,
+        )
+        if not tests:
+            return None
+        try:
+            smoke_tests.run_smoke_tests(tests)
+        except smoke_tests.SmokeTestError as exc:
+            duration = time.time() - start_time
+            logger.warning("Smoke test failed: %s", exc)
+            if exc.rollback and self._previous_sha:
+                rollback_result = self.rollback()
+                result = self._build_rollback_result(
+                    rollback_result, old_version, duration
+                )
+                self._complete_db_record(db_pk, result)
+                return result
+            # halt: abort without rollback.
+            self._write_status("failed", error_message=str(exc))
+            result = DeploymentResult(
+                success=False,
+                status=DeploymentStatus.FAILED,
+                old_version=old_version,
+                duration_seconds=duration,
+                error_message=str(exc),
+            )
+            self._complete_db_record(db_pk, result)
+            return result
+        return None
+
     def _run_post_migrate(self) -> None:
         """Run database.post_migrate SQL hooks (#204).
 
@@ -329,6 +388,13 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
                     )
                     if early is not None:
                         return early
+
+                # Step 5.5: Authenticated smoke tests (#204 PR B)
+                smoke = self._run_smoke_tests_or_halt(
+                    start_time, old_version, db_pk
+                )
+                if smoke is not None:
+                    return smoke
 
                 new_version = new_sha[:8] if new_sha else None
                 duration = time.time() - start_time

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -390,9 +390,7 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
                         return early
 
                 # Step 5.5: Authenticated smoke tests (#204 PR B)
-                smoke = self._run_smoke_tests_or_halt(
-                    start_time, old_version, db_pk
-                )
+                smoke = self._run_smoke_tests_or_halt(start_time, old_version, db_pk)
                 if smoke is not None:
                     return smoke
 

--- a/fraisier/smoke_tests.py
+++ b/fraisier/smoke_tests.py
@@ -1,0 +1,300 @@
+"""Authenticated smoke-test runner (#204 PR B).
+
+After ``/health`` passes, the deploy pipeline runs configured HTTP
+requests with bearer credentials and JSONPath assertions. Failure
+default is ``rollback`` — the whole point of this hook is to catch
+regressions that unauthenticated ``/health`` missed; if the
+authenticated probe fails too, the new code is broken.
+
+JSONPath is intentionally a minimal ``$.dotted.path`` subset — no
+recursion (``$..foo``), no array filters (``$.a[0]``), no wildcards
+(``$.*``). Unsupported shapes are rejected at schema parse time with
+the message ``unsupported JSONPath syntax: use $.dotted.path only``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_METHODS = frozenset({"GET", "POST", "PUT", "PATCH", "DELETE"})
+_VALID_ON_FAILURE = frozenset({"rollback", "halt", "warn"})
+_VALID_ASSERTION_KEYS = frozenset({"json_path", "not_null", "null", "equals"})
+
+
+class _Missing:
+    """Sentinel returned by ``_walk_json_path`` when a key is absent.
+
+    Distinct from JSON ``null`` (Python ``None``). The two need different
+    handling for the ``null`` assertion verb — both should satisfy a
+    ``null: true`` assertion ("the key isn't there or is explicitly
+    null"); only ``not_null: true`` distinguishes them.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "<missing>"
+
+
+_MISSING = _Missing()
+
+
+# Reject any path that includes recursion, array indexing, or wildcards
+# at parse time. The hand-rolled walker only understands `$.a.b.c`.
+_UNSUPPORTED_JSONPATH_CHARS = re.compile(r"\.\.|[\[*@]")
+
+
+class SmokeTestError(Exception):
+    """Raised by ``run_smoke_tests`` when a probe fails.
+
+    ``rollback`` is ``True`` when the failing test's policy was
+    ``rollback`` (default) so the deploy pipeline can dispatch to
+    ``_restore_previous_state``. When ``False`` (``halt`` policy), the
+    deploy still aborts but no rollback runs — the operator must
+    investigate manually because the failure is policy-marked as
+    irrecoverable by the smoke-test itself.
+    """
+
+    def __init__(self, message: str, *, rollback: bool):
+        super().__init__(message)
+        self.rollback = rollback
+
+
+@dataclass(frozen=True)
+class Assertion:
+    """One assertion against the JSON response body."""
+
+    json_path: str
+    not_null: bool = False
+    null: bool = False
+    equals: Any = _MISSING  # _MISSING means "this verb not in use"
+
+    def matches(self, doc: Any) -> bool:
+        actual = _walk_json_path(doc, self.json_path)
+        if self.not_null:
+            return actual is not _MISSING and actual is not None
+        if self.null:
+            return actual is _MISSING or actual is None
+        if self.equals is not _MISSING:
+            return actual == self.equals
+        # No verb set — vacuously true (loader rejects this shape).
+        return True
+
+
+@dataclass(frozen=True)
+class SmokeTest:
+    """One smoke-test entry."""
+
+    name: str
+    method: str
+    url: str
+    headers: dict[str, str]
+    body: str | None
+    timeout: int
+    on_failure: Literal["rollback", "halt", "warn"]
+    assertions: list[Assertion]
+
+
+def _walk_json_path(doc: Any, path: str) -> Any:
+    """Walk a ``$.a.b.c`` path through *doc*; return ``_MISSING`` if absent.
+
+    The leading ``$`` is required; ``$`` alone returns the root document.
+    Any intermediate value that is not a ``dict`` short-circuits to
+    ``_MISSING``.
+    """
+    if not path.startswith("$"):
+        raise ValueError(f"JSONPath must start with $: {path!r}")
+    if path == "$":
+        return doc
+    if not path.startswith("$."):
+        raise ValueError("unsupported JSONPath syntax: use $.dotted.path only")
+    parts = path[2:].split(".")
+    current: Any = doc
+    for key in parts:
+        if not isinstance(current, dict):
+            return _MISSING
+        if key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def _parse_assertion(raw: dict) -> Assertion:
+    unknown = set(raw) - _VALID_ASSERTION_KEYS
+    if unknown:
+        raise ValueError(
+            f"unknown assertion key(s): {sorted(unknown)!r}; valid: "
+            f"{sorted(_VALID_ASSERTION_KEYS)!r}"
+        )
+    if "json_path" not in raw:
+        raise ValueError("assertion is missing required 'json_path'")
+    json_path = raw["json_path"]
+    if _UNSUPPORTED_JSONPATH_CHARS.search(json_path):
+        raise ValueError(
+            "unsupported JSONPath syntax: use $.dotted.path only "
+            f"(got {json_path!r})"
+        )
+    # Validate the walker can parse it (raises on missing $).
+    _walk_json_path({}, json_path)
+    return Assertion(
+        json_path=json_path,
+        not_null=bool(raw.get("not_null", False)),
+        null=bool(raw.get("null", False)),
+        equals=raw.get("equals", _MISSING),
+    )
+
+
+def _resolve_url(url: str, *, base_url: str | None) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        # Absolute URL.
+        return url
+    if url.startswith("/"):
+        if base_url is None:
+            raise ValueError(
+                "smoke_tests.url is relative but no health_check.url is "
+                "configured to resolve against — provide an absolute URL "
+                "or configure health_check"
+            )
+        return urljoin(base_url.rstrip("/") + "/", url.lstrip("/"))
+    raise ValueError(
+        f"smoke_tests.url must be absolute (scheme://host/...) or relative "
+        f"with a leading '/', got {url!r}"
+    )
+
+
+def load_smoke_tests(
+    env_config: dict,
+    *,
+    base_url: str | None,
+) -> list[SmokeTest]:
+    """Parse ``smoke_tests:`` into a list of ``SmokeTest`` objects.
+
+    *base_url* is the scheme+host of ``health_check.url`` (without path).
+    Relative entries (``url: /graphql``) are joined onto it. When
+    *base_url* is ``None`` and any entry is relative, raises ``ValueError``.
+    """
+    raw = env_config.get("smoke_tests") or []
+    tests: list[SmokeTest] = []
+    for entry in raw:
+        method = (entry.get("method") or "GET").upper()
+        if method not in _VALID_METHODS:
+            raise ValueError(
+                f"smoke_tests.method must be one of {sorted(_VALID_METHODS)!r}, "
+                f"got {method!r}"
+            )
+
+        on_failure = entry.get("on_failure", "rollback")
+        if on_failure not in _VALID_ON_FAILURE:
+            raise ValueError(
+                f"smoke_tests.on_failure must be one of "
+                f"{sorted(_VALID_ON_FAILURE)!r}, got {on_failure!r}"
+            )
+
+        url = _resolve_url(entry["url"], base_url=base_url)
+
+        assertions = [_parse_assertion(a) for a in entry.get("assert", [])]
+
+        tests.append(
+            SmokeTest(
+                name=entry.get("name", url),
+                method=method,
+                url=url,
+                headers=dict(entry.get("headers") or {}),
+                body=entry.get("body"),
+                timeout=int(entry.get("timeout", 5)),
+                on_failure=on_failure,
+                assertions=assertions,
+            )
+        )
+    return tests
+
+
+def _should_rollback(test: SmokeTest) -> bool:
+    return test.on_failure == "rollback"
+
+
+def _redacted_headers(headers: dict[str, str]) -> dict[str, str]:
+    redacted = {}
+    for k, v in headers.items():
+        if k.lower() in {"authorization", "cookie", "x-api-key"}:
+            redacted[k] = "***redacted***"
+        else:
+            redacted[k] = v
+    return redacted
+
+
+def _run_one(test: SmokeTest) -> None:
+    logger.info(
+        "Running smoke test %s: %s %s (headers=%s)",
+        test.name,
+        test.method,
+        test.url,
+        _redacted_headers(test.headers),
+    )
+    try:
+        with httpx.Client(timeout=test.timeout) as client:
+            response = client.request(
+                test.method,
+                test.url,
+                headers=test.headers,
+                content=test.body,
+            )
+    except httpx.TimeoutException as exc:
+        raise SmokeTestError(
+            f"smoke test {test.name!r} timed out after {test.timeout}s: {exc}",
+            rollback=_should_rollback(test),
+        ) from exc
+    except httpx.RequestError as exc:
+        raise SmokeTestError(
+            f"smoke test {test.name!r} request failed: {exc}",
+            rollback=_should_rollback(test),
+        ) from exc
+
+    if not (200 <= response.status_code < 300):
+        raise SmokeTestError(
+            f"smoke test {test.name!r} returned HTTP {response.status_code}",
+            rollback=_should_rollback(test),
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise SmokeTestError(
+            f"smoke test {test.name!r} returned non-JSON body: {exc}",
+            rollback=_should_rollback(test),
+        ) from exc
+
+    for assertion in test.assertions:
+        if not assertion.matches(body):
+            actual = _walk_json_path(body, assertion.json_path)
+            raise SmokeTestError(
+                f"smoke test {test.name!r} assertion failed: "
+                f"{assertion.json_path}={actual!r} did not satisfy {assertion!r}",
+                rollback=_should_rollback(test),
+            )
+
+
+def run_smoke_tests(tests: list[SmokeTest]) -> None:
+    """Run each test in order.
+
+    A ``rollback`` or ``halt`` failure raises ``SmokeTestError``
+    immediately; the deploy pipeline reads ``exc.rollback`` to decide
+    whether to invoke ``_restore_previous_state``. A ``warn`` failure
+    is logged at WARNING and iteration continues.
+    """
+    for test in tests:
+        try:
+            _run_one(test)
+        except SmokeTestError as exc:
+            if test.on_failure == "warn":
+                logger.warning("smoke test %s failed (warn): %s", test.name, exc)
+                continue
+            raise

--- a/fraisier/smoke_tests.py
+++ b/fraisier/smoke_tests.py
@@ -138,8 +138,7 @@ def _parse_assertion(raw: dict) -> Assertion:
     json_path = raw["json_path"]
     if _UNSUPPORTED_JSONPATH_CHARS.search(json_path):
         raise ValueError(
-            "unsupported JSONPath syntax: use $.dotted.path only "
-            f"(got {json_path!r})"
+            f"unsupported JSONPath syntax: use $.dotted.path only (got {json_path!r})"
         )
     # Validate the walker can parse it (raises on missing $).
     _walk_json_path({}, json_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.20.0"
+version = "0.21.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_api_deploy_smoke.py
+++ b/tests/test_api_deploy_smoke.py
@@ -1,0 +1,132 @@
+"""Tests for the authenticated smoke-test hook wired into the API deploy
+pipeline (#204 PR B).
+
+The smoke-test step runs *after* the unauthenticated ``/health`` poll
+succeeds and *before* the success result is constructed. Three policies:
+
+- ``rollback`` (default) — raise SmokeTestError, dispatch to
+  ``_restore_previous_state``, return a rolled-back result.
+- ``halt`` — raise SmokeTestError, do NOT invoke
+  ``_restore_previous_state``; deploy aborts with status=failed.
+- ``warn`` — log and continue; deploy ends in success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fraisier.deployers.api import APIDeployer
+from fraisier.smoke_tests import SmokeTestError
+
+
+def _make_deployer(smoke_tests=None, **overrides):
+    config = {
+        "fraise_name": "myapi",
+        "environment": "production",
+        "app_path": "/srv/myapi",
+        "clone_url": "git@github.com:org/myapi.git",
+        "branch": "main",
+        "systemd_service": "myapi.service",
+        "health_check": {"url": "http://localhost:8000/health", "timeout": 5},
+        "repos_base": "/tmp/repos",
+    }
+    if smoke_tests is not None:
+        config["smoke_tests"] = smoke_tests
+    config.update(overrides)
+    return APIDeployer(config)
+
+
+class TestSmokeTestsCallOrder:
+    def test_smoke_tests_run_after_health_check_success(self):
+        smoke = [{"name": "auth", "url": "/me", "assert": []}]
+        deployer = _make_deployer(smoke_tests=smoke)
+        call_order = []
+
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+            patch(
+                "fraisier.smoke_tests.run_smoke_tests",
+                side_effect=lambda *_a, **_kw: call_order.append("smoke"),
+            ),
+            patch.object(
+                deployer,
+                "_check_health_or_rollback",
+                side_effect=lambda *_a, **_kw: (
+                    call_order.append("health"),
+                    None,
+                )[-1],
+            ),
+        ):
+            result = deployer.execute()
+
+        assert result.success is True
+        assert call_order == ["health", "smoke"]
+
+    def test_no_smoke_tests_means_no_change_in_deploy_path(self):
+        deployer = _make_deployer()
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+            patch("fraisier.smoke_tests.run_smoke_tests") as mock_run,
+        ):
+            result = deployer.execute()
+        assert result.success is True
+        mock_run.assert_not_called()
+
+
+class TestSmokeTestsFailureSemantics:
+    def test_rollback_on_failure_invokes_restore_previous_state(self):
+        smoke = [{"name": "auth", "url": "/me", "assert": []}]
+        deployer = _make_deployer(smoke_tests=smoke)
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+            patch(
+                "fraisier.smoke_tests.run_smoke_tests",
+                side_effect=SmokeTestError("auth check failed", rollback=True),
+            ),
+            patch.object(deployer, "rollback") as mock_rollback,
+        ):
+            mock_rollback.return_value = MagicMock(success=True)
+            result = deployer.execute()
+
+        assert result.success is False
+        mock_rollback.assert_called_once()
+
+    def test_halt_on_failure_does_not_invoke_restore_previous_state(self):
+        smoke = [{"name": "auth", "url": "/me", "on_failure": "halt", "assert": []}]
+        deployer = _make_deployer(smoke_tests=smoke)
+        with (
+            patch("fraisier.deployers.mixins.clone_bare_repo"),
+            patch(
+                "fraisier.deployers.mixins.fetch_and_checkout",
+                return_value=("old", "new"),
+            ),
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_wait_for_health", return_value=True),
+            patch(
+                "fraisier.smoke_tests.run_smoke_tests",
+                side_effect=SmokeTestError("auth check failed", rollback=False),
+            ),
+            patch.object(deployer, "rollback") as mock_rollback,
+        ):
+            result = deployer.execute()
+
+        assert result.success is False
+        mock_rollback.assert_not_called()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -522,6 +522,7 @@ fraises:
         with pytest.raises(ValidationError, match=r"on_error.*'halt'.*'warn'"):
             FraisierConfig(config_file)
 
+
 class TestSmokeTestsValidation:
     """`smoke_tests` schema validation at config-load time (#204 PR B)."""
 
@@ -538,9 +539,7 @@ fraises:
 """
 
     def _write(self, tmp_path, entries: str):
-        return _write_config(
-            tmp_path, self._BASE_CONFIG.format(entries=entries)
-        )
+        return _write_config(tmp_path, self._BASE_CONFIG.format(entries=entries))
 
     def test_smoke_tests_happy_path(self, tmp_path):
         config_file = self._write(
@@ -556,9 +555,7 @@ fraises:
         )
         FraisierConfig(config_file)
 
-    def test_rejects_relative_url_when_health_check_not_configured(
-        self, tmp_path
-    ):
+    def test_rejects_relative_url_when_health_check_not_configured(self, tmp_path):
         # Drop health_check from the base config.
         yaml = """
 fraises:
@@ -609,16 +606,12 @@ fraises:
         ):
             FraisierConfig(config_file)
 
-    @pytest.mark.parametrize(
-        "bad_path", ["$..foo", "$.a[0]", "$.*", "$.@.x"]
-    )
+    @pytest.mark.parametrize("bad_path", ["$..foo", "$.a[0]", "$.*", "$.@.x"])
     def test_rejects_unsupported_jsonpath_syntax(self, tmp_path, bad_path):
         config_file = self._write(
             tmp_path,
             "[{name: t, method: GET, url: /me, "
             f"assert: [{{json_path: '{bad_path}', not_null: true}}]}}]",
         )
-        with pytest.raises(
-            ValidationError, match=r"unsupported JSONPath"
-        ):
+        with pytest.raises(ValidationError, match=r"unsupported JSONPath"):
             FraisierConfig(config_file)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -521,3 +521,104 @@ fraises:
         config_file = self._write(tmp_path, "[{sql_dir: db/7_grant/, on_error: panic}]")
         with pytest.raises(ValidationError, match=r"on_error.*'halt'.*'warn'"):
             FraisierConfig(config_file)
+
+class TestSmokeTestsValidation:
+    """`smoke_tests` schema validation at config-load time (#204 PR B)."""
+
+    _BASE_CONFIG = """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        health_check:
+          url: https://api.example.com/health
+        smoke_tests: {entries}
+"""
+
+    def _write(self, tmp_path, entries: str):
+        return _write_config(
+            tmp_path, self._BASE_CONFIG.format(entries=entries)
+        )
+
+    def test_smoke_tests_happy_path(self, tmp_path):
+        config_file = self._write(
+            tmp_path,
+            "[{name: me, method: GET, url: /me, "
+            "assert: [{json_path: $.id, not_null: true}]}]",
+        )
+        FraisierConfig(config_file)  # must not raise
+
+    def test_accepts_relative_url_when_health_check_configured(self, tmp_path):
+        config_file = self._write(
+            tmp_path, "[{name: t, method: GET, url: /me, assert: []}]"
+        )
+        FraisierConfig(config_file)
+
+    def test_rejects_relative_url_when_health_check_not_configured(
+        self, tmp_path
+    ):
+        # Drop health_check from the base config.
+        yaml = """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        smoke_tests:
+          - {name: t, method: GET, url: /me, assert: []}
+"""
+        config_file = _write_config(tmp_path, yaml)
+        with pytest.raises(
+            ValidationError, match=r"smoke_tests.*relative.*health_check"
+        ):
+            FraisierConfig(config_file)
+
+    def test_accepts_absolute_url_without_health_check(self, tmp_path):
+        yaml = """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        smoke_tests:
+          - {name: t, method: GET, url: "https://other.example/me",
+             assert: []}
+"""
+        config_file = _write_config(tmp_path, yaml)
+        FraisierConfig(config_file)
+
+    def test_rejects_unknown_method(self, tmp_path):
+        config_file = self._write(
+            tmp_path, "[{name: t, method: MERGE, url: /me, assert: []}]"
+        )
+        with pytest.raises(ValidationError, match=r"smoke_tests.*method"):
+            FraisierConfig(config_file)
+
+    def test_rejects_unknown_assertion_key(self, tmp_path):
+        config_file = self._write(
+            tmp_path,
+            "[{name: t, method: GET, url: /me, "
+            "assert: [{json_path: $.x, regex: '^a$'}]}]",
+        )
+        with pytest.raises(
+            ValidationError, match=r"smoke_tests.*unknown assertion key"
+        ):
+            FraisierConfig(config_file)
+
+    @pytest.mark.parametrize(
+        "bad_path", ["$..foo", "$.a[0]", "$.*", "$.@.x"]
+    )
+    def test_rejects_unsupported_jsonpath_syntax(self, tmp_path, bad_path):
+        config_file = self._write(
+            tmp_path,
+            "[{name: t, method: GET, url: /me, "
+            f"assert: [{{json_path: '{bad_path}', not_null: true}}]}}]",
+        )
+        with pytest.raises(
+            ValidationError, match=r"unsupported JSONPath"
+        ):
+            FraisierConfig(config_file)

--- a/tests/test_envvar_yaml_tag.py
+++ b/tests/test_envvar_yaml_tag.py
@@ -1,0 +1,88 @@
+"""Tests for the !envvar YAML tag (#204 PR B).
+
+Allows secrets to be sourced from the environment at load time rather
+than embedded in the on-disk YAML. Use:
+
+    headers:
+      Authorization: !envvar SMOKE_TEST_JWT
+
+The tag resolves to the string contents of ``os.environ['SMOKE_TEST_JWT']``.
+Missing variables raise ``ConfigurationError`` at load time so the
+misconfig is visible immediately rather than at deploy time when the
+secret is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.errors import ConfigurationError
+
+
+def _write_config(tmp_path, content):
+    config_file = tmp_path / "fraises.yaml"
+    config_file.write_text(content)
+    return config_file
+
+
+_TEMPLATE = """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        secret: {expr}
+"""
+
+
+class TestEnvvarYamlTag:
+    def test_resolves_string_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SMOKE_TEST_JWT", "eyJsuper-secret")
+        config_file = _write_config(
+            tmp_path, _TEMPLATE.format(expr="!envvar SMOKE_TEST_JWT")
+        )
+        config = FraisierConfig(config_file)
+        fraise = config.get_fraise_environment("my_api", "production")
+        assert fraise["secret"] == "eyJsuper-secret"
+
+    def test_raises_when_env_var_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        config_file = _write_config(
+            tmp_path, _TEMPLATE.format(expr="!envvar MISSING_VAR")
+        )
+        with pytest.raises(
+            ConfigurationError, match=r"!envvar.*MISSING_VAR.*not set"
+        ):
+            FraisierConfig(config_file)
+
+    def test_empty_string_env_var_resolves(self, tmp_path, monkeypatch):
+        # An empty string is still a "set" env var; resolves to "".
+        monkeypatch.setenv("EMPTY_VAR", "")
+        config_file = _write_config(
+            tmp_path, _TEMPLATE.format(expr="!envvar EMPTY_VAR")
+        )
+        config = FraisierConfig(config_file)
+        fraise = config.get_fraise_environment("my_api", "production")
+        assert fraise["secret"] == ""
+
+    def test_works_inside_nested_structures(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TOK", "abc")
+        config_file = _write_config(
+            tmp_path,
+            """
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /srv/myapi
+        secrets:
+          - !envvar TOK
+          - literal_value
+""",
+        )
+        config = FraisierConfig(config_file)
+        fraise = config.get_fraise_environment("my_api", "production")
+        assert fraise["secrets"] == ["abc", "literal_value"]

--- a/tests/test_envvar_yaml_tag.py
+++ b/tests/test_envvar_yaml_tag.py
@@ -52,9 +52,7 @@ class TestEnvvarYamlTag:
         config_file = _write_config(
             tmp_path, _TEMPLATE.format(expr="!envvar MISSING_VAR")
         )
-        with pytest.raises(
-            ConfigurationError, match=r"!envvar.*MISSING_VAR.*not set"
-        ):
+        with pytest.raises(ConfigurationError, match=r"!envvar.*MISSING_VAR.*not set"):
             FraisierConfig(config_file)
 
     def test_empty_string_env_var_resolves(self, tmp_path, monkeypatch):

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -1,0 +1,309 @@
+"""Tests for the authenticated smoke test runner (#204 PR B).
+
+After ``/health`` passes, the deploy pipeline runs configured HTTP
+requests with bearer credentials and JSONPath assertions. Failure
+default is ``rollback`` — that's the whole point: unauthenticated
+``/health`` missed the regression, so if the authenticated probe fails
+too, the new code is broken.
+
+Hand-rolled JSONPath supports ``$.dotted.path`` only — no ``$..foo``
+recursion, no array filters, no wildcards. Reject the unsupported
+shapes at schema parse time.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fraisier.smoke_tests import (
+    _MISSING,
+    Assertion,
+    SmokeTest,
+    SmokeTestError,
+    _walk_json_path,
+    load_smoke_tests,
+    run_smoke_tests,
+)
+
+# ---------------------------------------------------------------------------
+# JSONPath walker
+# ---------------------------------------------------------------------------
+
+
+class TestWalkJsonPath:
+    def test_walks_nested_keys(self):
+        doc = {"data": {"me": {"role": "admin"}}}
+        assert _walk_json_path(doc, "$.data.me.role") == "admin"
+
+    def test_returns_missing_sentinel_for_missing_key(self):
+        doc = {"data": {"me": {"role": "admin"}}}
+        assert _walk_json_path(doc, "$.data.me.email") is _MISSING
+
+    def test_returns_missing_when_intermediate_is_not_a_dict(self):
+        doc = {"data": "not-a-dict"}
+        assert _walk_json_path(doc, "$.data.me") is _MISSING
+
+    def test_root_only_path_returns_doc(self):
+        doc = {"a": 1}
+        assert _walk_json_path(doc, "$") == doc
+
+    def test_path_must_start_with_dollar(self):
+        with pytest.raises(ValueError, match=r"must start with \$"):
+            _walk_json_path({}, "data.me")
+
+
+# ---------------------------------------------------------------------------
+# Assertion semantics
+# ---------------------------------------------------------------------------
+
+
+class TestAssertionMatches:
+    def test_not_null_passes_for_value(self):
+        a = Assertion(json_path="$.x", not_null=True)
+        assert a.matches({"x": "anything"}) is True
+
+    def test_not_null_fails_for_missing_key(self):
+        a = Assertion(json_path="$.x", not_null=True)
+        assert a.matches({}) is False
+
+    def test_not_null_fails_for_null_value(self):
+        # JSON null is loaded as Python None; not_null must reject it.
+        a = Assertion(json_path="$.x", not_null=True)
+        assert a.matches({"x": None}) is False
+
+    def test_null_passes_for_missing_key(self):
+        # The plan's intent: `null: true` is satisfied when the key is
+        # absent or its value is JSON null. This is how "no errors"
+        # assertions read in practice — `$.errors` simply not in the
+        # response is the success case.
+        a = Assertion(json_path="$.errors", null=True)
+        assert a.matches({}) is True
+        assert a.matches({"errors": None}) is True
+
+    def test_null_fails_for_present_non_null_value(self):
+        a = Assertion(json_path="$.errors", null=True)
+        assert a.matches({"errors": ["boom"]}) is False
+
+    def test_equals_uses_python_equality(self):
+        a = Assertion(json_path="$.role", equals="admin")
+        assert a.matches({"role": "admin"}) is True
+        assert a.matches({"role": "user"}) is False
+        # Numeric equality through JSON.
+        a_int = Assertion(json_path="$.n", equals=42)
+        assert a_int.matches({"n": 42}) is True
+        assert a_int.matches({"n": "42"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Loader / URL resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSmokeTests:
+    def _entry(self, **overrides: Any) -> dict:
+        base = {
+            "name": "authenticated_me",
+            "method": "POST",
+            "url": "/graphql",
+            "timeout": 5,
+            "headers": {"Authorization": "Bearer token"},
+            "body": '{"query":"{ me { id } }"}',
+            "assert": [
+                {"json_path": "$.data.me.id", "not_null": True},
+                {"json_path": "$.errors", "null": True},
+            ],
+        }
+        base.update(overrides)
+        return base
+
+    def test_loads_happy_path(self):
+        env_config = {
+            "smoke_tests": [self._entry()],
+            "health_check": {"url": "https://api.example.com/health"},
+        }
+        tests = load_smoke_tests(env_config, base_url="https://api.example.com")
+        assert len(tests) == 1
+        t = tests[0]
+        assert isinstance(t, SmokeTest)
+        assert t.name == "authenticated_me"
+        assert t.url == "https://api.example.com/graphql"
+        assert t.on_failure == "rollback"  # default
+        assert len(t.assertions) == 2
+
+    def test_absolute_url_is_preserved(self):
+        env_config = {
+            "smoke_tests": [self._entry(url="https://other.example/api")],
+        }
+        tests = load_smoke_tests(env_config, base_url="https://api.example.com")
+        assert tests[0].url == "https://other.example/api"
+
+    def test_relative_url_requires_base_url(self):
+        env_config = {"smoke_tests": [self._entry(url="/graphql")]}
+        with pytest.raises(ValueError, match=r"relative.*health_check"):
+            load_smoke_tests(env_config, base_url=None)
+
+    def test_rejects_unknown_method(self):
+        env_config = {"smoke_tests": [self._entry(method="MERGE")]}
+        with pytest.raises(ValueError, match=r"method.*MERGE"):
+            load_smoke_tests(env_config, base_url="https://api.example.com")
+
+    def test_rejects_unknown_on_failure(self):
+        env_config = {"smoke_tests": [self._entry(on_failure="explode")]}
+        with pytest.raises(ValueError, match=r"on_failure"):
+            load_smoke_tests(env_config, base_url="https://api.example.com")
+
+    def test_rejects_unknown_assertion_key(self):
+        env_config = {
+            "smoke_tests": [
+                self._entry(
+                    **{
+                        "assert": [
+                            {"json_path": "$.x", "regex": "^foo$"}
+                        ]
+                    }
+                )
+            ]
+        }
+        with pytest.raises(ValueError, match=r"unknown assertion key"):
+            load_smoke_tests(env_config, base_url="https://api.example.com")
+
+    @pytest.mark.parametrize("bad_path", ["$..foo", "$.a[0]", "$.*", "$.@.x"])
+    def test_rejects_unsupported_jsonpath_syntax(self, bad_path):
+        env_config = {
+            "smoke_tests": [
+                self._entry(
+                    **{
+                        "assert": [
+                            {"json_path": bad_path, "not_null": True}
+                        ]
+                    }
+                )
+            ]
+        }
+        with pytest.raises(
+            ValueError, match=r"unsupported JSONPath.*\$\.dotted\.path only"
+        ):
+            load_smoke_tests(env_config, base_url="https://api.example.com")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def _smoke_test(**overrides) -> SmokeTest:
+    base = {
+        "name": "t",
+        "method": "POST",
+        "url": "https://api.example.com/graphql",
+        "headers": {"Authorization": "Bearer token"},
+        "body": '{"query":"{ me { id } }"}',
+        "timeout": 5,
+        "on_failure": "rollback",
+        "assertions": [
+            Assertion(json_path="$.data.me.id", not_null=True),
+        ],
+    }
+    base.update(overrides)
+    return SmokeTest(**base)
+
+
+class TestRunSmokeTests:
+    def test_runs_request_and_asserts_response(self):
+        with patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls:
+            mock_resp = MagicMock(status_code=200)
+            mock_resp.json.return_value = {"data": {"me": {"id": "u1"}}}
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            # Must not raise.
+            run_smoke_tests([_smoke_test()])
+
+    def test_failing_assertion_raises_with_path_and_actual(self):
+        with patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls:
+            mock_resp = MagicMock(status_code=200)
+            mock_resp.json.return_value = {"data": {"me": None}}
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SmokeTestError) as exc_info:
+                run_smoke_tests([_smoke_test()])
+            assert "$.data.me.id" in str(exc_info.value)
+
+    def test_non_2xx_response_fails_before_assertion(self):
+        with patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls:
+            mock_resp = MagicMock(status_code=500)
+            mock_resp.json.return_value = {"data": {"me": {"id": "u1"}}}
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SmokeTestError, match=r"500"):
+                run_smoke_tests([_smoke_test()])
+
+    def test_timeout_treated_as_failure(self):
+        import httpx
+
+        with patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.side_effect = httpx.TimeoutException("timeout")
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SmokeTestError, match=r"timeout"):
+                run_smoke_tests([_smoke_test()])
+
+    def test_authorization_header_redacted_from_logs(self, caplog):
+        with (
+            patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls,
+            caplog.at_level(logging.INFO, logger="fraisier.smoke_tests"),
+        ):
+            mock_resp = MagicMock(status_code=200)
+            mock_resp.json.return_value = {"data": {"me": {"id": "u1"}}}
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            run_smoke_tests([_smoke_test()])
+
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "Bearer token" not in joined
+
+    def test_on_failure_warn_does_not_raise(self, caplog):
+        with (
+            patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls,
+            caplog.at_level(logging.WARNING, logger="fraisier.smoke_tests"),
+        ):
+            mock_resp = MagicMock(status_code=500)
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            # Must not raise.
+            run_smoke_tests([_smoke_test(on_failure="warn")])
+
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "500" in joined
+
+    def test_on_failure_halt_raises_with_halt_marker(self):
+        with patch("fraisier.smoke_tests.httpx.Client") as mock_client_cls:
+            mock_resp = MagicMock(status_code=500)
+            mock_client = MagicMock()
+            mock_client.__enter__.return_value = mock_client
+            mock_client.request.return_value = mock_resp
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SmokeTestError) as exc_info:
+                run_smoke_tests([_smoke_test(on_failure="halt")])
+            assert exc_info.value.rollback is False

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -159,13 +159,7 @@ class TestLoadSmokeTests:
     def test_rejects_unknown_assertion_key(self):
         env_config = {
             "smoke_tests": [
-                self._entry(
-                    **{
-                        "assert": [
-                            {"json_path": "$.x", "regex": "^foo$"}
-                        ]
-                    }
-                )
+                self._entry(**{"assert": [{"json_path": "$.x", "regex": "^foo$"}]})
             ]
         }
         with pytest.raises(ValueError, match=r"unknown assertion key"):
@@ -175,13 +169,7 @@ class TestLoadSmokeTests:
     def test_rejects_unsupported_jsonpath_syntax(self, bad_path):
         env_config = {
             "smoke_tests": [
-                self._entry(
-                    **{
-                        "assert": [
-                            {"json_path": bad_path, "not_null": True}
-                        ]
-                    }
-                )
+                self._entry(**{"assert": [{"json_path": bad_path, "not_null": True}]})
             ]
         }
         with pytest.raises(

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

PR B of the two-PR `#204` plan. Replaces [#211](https://github.com/fraiseql/fraisier/pull/211) which GitHub auto-closed when PR A's branch was deleted. Rebased onto `main` after #210 landed; no overlap with PR A.

Adds an optional `smoke_tests:` list that runs configured HTTP requests with bearer credentials and JSONPath assertions immediately after the unauthenticated `/health` poll succeeds. Closes the class of regressions where a new table or `CREATE OR REPLACE VIEW` slips past unauthenticated `/health` and only fails under authenticated traffic.

Three failure policies:
- `rollback` (default) — dispatch to `_restore_previous_state`; deploy returns a rolled-back result. The whole point of the probe is to catch regressions the unauthenticated path missed; the safest default is to restore the previous version.
- `halt` — record `status=failed` without rolling back; operator decides.
- `warn` — log and continue; deploy still ends in success.

JSONPath is the minimal `$.dotted.path` subset — recursion (`$..foo`), array indexing (`$.a[0]`), and wildcards (`$.*`, `$.@.x`) are rejected at config-load time with the message `unsupported JSONPath syntax: use $.dotted.path only`.

Also adds a new `!envvar` YAML tag so secrets can be sourced from `os.environ` at load time:

```yaml
headers:
  Authorization: !envvar SMOKE_TEST_JWT
```

Missing variables raise `ConfigurationError` immediately. `Authorization`, `Cookie`, and `X-API-Key` header values are redacted in log output. Docs commit fixes pre-existing broken `${VAR}` references in `fraises.example.yaml` (the literal `${FRAISIER_WEBHOOK_SECRET}` was shadowing the env-var-sourced value via dict merge order in `webhook.py`).

## Test plan

- [x] `uv run pytest tests/test_envvar_yaml_tag.py tests/test_smoke_tests.py tests/test_api_deploy_smoke.py tests/test_config_validation.py tests/test_post_migrate.py tests/test_api_deploy_post_migrate.py` — 92 tests pass.
- [x] `uv run ruff check` + `uv run ty check` — clean.
- [ ] Manual happy path: smoke test asserts `$.data.me.role: admin`; deploy proceeds; log shows `Authorization: ***redacted***`.
- [ ] Manual rollback: revoke the smoke-test JWT's role; redeploy; confirm `_restore_previous_state` runs and the previous version serves again.
- [ ] Manual halt: same broken JWT but with `on_failure: halt`; confirm the deploy fails with `status=failed` without restoring the previous version.

Refs #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)