### PR TITLE
release: v0.21.1 — fraisier sync idempotency (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.1] - 2026-05-22
+
+### Fixed
+
+- **`fraisier sync` is now idempotent on retry** ([#213](https://github.com/fraiseql/fraisier/issues/213)). Re-running after a previous interrupted or completed sync no longer fails:
+  - The local sync branch is force-created (`git checkout -B`), so a stale branch from an interrupted prior run is silently overwritten by the fresh checkout. Sync branches are fraisier-owned end-to-end; any commits on them are re-derived from `origin/<source>` + pre-merge on every run.
+  - After pushing, fraisier checks for an existing PR for the sync branch via `gh pr view`. When the prior PR is OPEN, it re-enables auto-merge (idempotent for `--squash`) on the existing PR instead of failing on `gh pr create`. The PR URL appears in the success message as `PR updated and auto-merge enabled: <url>`.
+  - When the prior PR is CLOSED or MERGED, fraisier opens a fresh PR (GitHub allows reusing a head ref after closure). The prior PR URL is logged for operator context.
+
+### Upgrade notes
+
+- A user who has manually committed to a sync branch will lose those commits on the next `fraisier sync` invocation (the new `-B` overwrites the local branch). Sync branches were already documented as fraisier-owned; if you want to keep commits on a sync branch, push them to a non-sync ref.
+
 ## [0.21.0] - 2026-05-22
 
 ### Added

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -127,6 +127,28 @@ def _capture(cmd: list[str]) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
+def _find_existing_pr(sync_branch: str) -> dict | None:
+    """Return PR head-ref lookup result, or None if no PR exists for the branch.
+
+    Result shape: ``{"url": str, "state": "OPEN" | "CLOSED" | "MERGED"}``.
+    Uses ``check=False`` because ``gh`` exits non-zero when no PR matches
+    the head ref — a normal "nothing here yet" signal, not an error.
+    Drafts are reported as state OPEN (the ``isDraft`` bit lives in a
+    separate field we don't query); re-enabling auto-merge on a draft is
+    the desired behavior — GitHub queues the merge for when the PR is
+    marked ready.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", sync_branch, "--json", "url,state"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)
+
+
 def _commit_if_staged(message: str) -> None:
     """Commit the staged index with ``message`` only if there is something staged.
 
@@ -359,6 +381,24 @@ def sync_cmd(
 
         console.print(f"  Pushing [bold]{sync_branch}[/bold]")
         _run(["git", "push", "origin", sync_branch])
+
+        existing = _find_existing_pr(sync_branch)
+        if existing and existing["state"] == "OPEN":
+            pr_url = existing["url"]
+            console.print(
+                f"  Existing open PR found, updating: [bold]{pr_url}[/bold]"
+            )
+            _run(["gh", "pr", "merge", "--auto", "--squash", pr_url])
+            subprocess.run(["git", "checkout", original_branch], check=False)
+            console.print(
+                f"==> [green]Done.[/green] PR updated and auto-merge enabled: {pr_url}"
+            )
+            return
+        if existing:
+            console.print(
+                f"  Prior PR for {sync_branch} was {existing['state'].lower()}: "
+                f"{existing['url']} — opening a new one"
+            )
 
         console.print(f"  Creating PR: [bold]{sync_branch}[/bold] → [bold]{tgt}[/bold]")
         pr_result = subprocess.run(

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -385,9 +385,7 @@ def sync_cmd(
         existing = _find_existing_pr(sync_branch)
         if existing and existing["state"] == "OPEN":
             pr_url = existing["url"]
-            console.print(
-                f"  Existing open PR found, updating: [bold]{pr_url}[/bold]"
-            )
+            console.print(f"  Existing open PR found, updating: [bold]{pr_url}[/bold]")
             _run(["gh", "pr", "merge", "--auto", "--squash", pr_url])
             subprocess.run(["git", "checkout", original_branch], check=False)
             console.print(

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -149,7 +149,7 @@ def _print_dry_run_plan(source: str, tgt: str, sync_branch: str) -> None:
     console.print()
     console.print("  Would run:")
     console.print(f"    git fetch origin {source} {tgt}")
-    console.print(f"    git checkout -b {sync_branch} origin/{source}")
+    console.print(f"    git checkout -B {sync_branch} origin/{source}")
     console.print(f"    git merge origin/{tgt} --no-edit --no-commit")
     console.print(
         f"    # conflicts in [{auto_owned}] auto-resolved from {source};"
@@ -276,7 +276,7 @@ def sync_cmd(
     branch_created = False
     try:
         console.print(f"  Creating [bold]{sync_branch}[/bold] from origin/{source}")
-        _run(["git", "checkout", "-b", sync_branch, f"origin/{source}"])
+        _run(["git", "checkout", "-B", sync_branch, f"origin/{source}"])
         branch_created = True
 
         console.print(f"  Pre-merging origin/{tgt} into {sync_branch}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.21.0"
+version = "0.21.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1002,7 +1002,10 @@ class TestSyncBranchForceCreate:
         checkout_create = [
             cmd
             for cmd in commands
-            if len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "checkout" and "-B" in cmd
+            if len(cmd) >= 2
+            and cmd[0] == "git"
+            and cmd[1] == "checkout"
+            and "-B" in cmd
         ]
         assert checkout_create, (
             "expected a `git checkout -B sync/...` call; got: "
@@ -1092,9 +1095,9 @@ class TestSyncExistingPR:
         assert result.exit_code == 0, result.output
         commands = [c[0][0] for c in m.call_args_list]
         # gh pr create must NOT be called for an existing OPEN PR
-        assert not any(
-            cmd[:3] == ["gh", "pr", "create"] for cmd in commands
-        ), f"gh pr create was called; commands: {commands}"
+        assert not any(cmd[:3] == ["gh", "pr", "create"] for cmd in commands), (
+            f"gh pr create was called; commands: {commands}"
+        )
         # gh pr merge --auto --squash <existing-url> IS called
         assert [
             "gh",
@@ -1122,7 +1125,9 @@ class TestSyncExistingPR:
         commands = [c[0][0] for c in m.call_args_list]
         # gh pr create IS called for a CLOSED prior PR
         create_calls = [cmd for cmd in commands if cmd[:3] == ["gh", "pr", "create"]]
-        assert len(create_calls) == 1, f"expected 1 gh pr create call; got {create_calls}"
+        assert len(create_calls) == 1, (
+            f"expected 1 gh pr create call; got {create_calls}"
+        )
         # New PR URL is the one in the success message
         assert self.NEW_PR_URL in result.output
         # Prior PR URL is surfaced as informational context

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -906,7 +906,7 @@ class TestSyncDryRun:
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
         with patch(_PATCH):
             result = CliRunner().invoke(main, ["-c", cfg, "sync", "--dry-run"])
-        assert "git checkout -b sync/staging-from-dev origin/dev" in result.output
+        assert "git checkout -B sync/staging-from-dev origin/dev" in result.output
 
     def test_dry_run_shows_merge(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -948,3 +948,67 @@ class TestSyncDryRun:
         assert "staging" in result.output
         assert "prod" in result.output
         assert "git fetch origin staging prod" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: branch force-create (issue #213, fragility 1)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBranchForceCreate:
+    """Sync branch is force-created (-B) so a stale local branch from an
+    interrupted prior run is silently overwritten on re-invocation."""
+
+    SHA = "deadbeef" * 5
+    MERGE_BASE = "cafe1234" * 5
+    PR_URL = "https://github.com/org/repo/pull/42"
+
+    def _side_effects(self):
+        return [
+            _mk(stdout="main\n"),  # git rev-parse HEAD
+            _mk(),  # git fetch
+            _mk(stdout=self.SHA + "\n"),  # git rev-parse origin/dev
+            _mk(stdout=self.MERGE_BASE + "\n"),  # git merge-base
+            _mk(returncode=0, stdout='{"version": "1.1.0"}'),  # version dev
+            _mk(returncode=0, stdout='{"version": "1.0.0"}'),  # version staging
+            _mk(),  # git checkout -B
+            _mk(),  # git merge (clean)
+            _mk(returncode=1),  # git diff --cached (staged)
+            _mk(),  # git commit pre-merge
+            _mk(),  # git push
+            _mk(stdout=self.PR_URL + "\n"),  # gh pr create
+            _mk(),  # gh pr merge
+            _mk(),  # git checkout main
+        ]
+
+    def test_uses_capital_B_to_force_create(self, tmp_path):
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = self._side_effects()
+            CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        commands = [c[0][0] for c in m.call_args_list]
+        checkout_create = [
+            cmd
+            for cmd in commands
+            if len(cmd) >= 2 and cmd[0] == "git" and cmd[1] == "checkout" and "-B" in cmd
+        ]
+        assert checkout_create, (
+            "expected a `git checkout -B sync/...` call; got: "
+            f"{[c for c in commands if 'checkout' in c]}"
+        )
+
+    def test_does_not_use_lowercase_b(self, tmp_path):
+        """Regression guard: lowercase -b fails on a stale local branch."""
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = self._side_effects()
+            CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        commands = [c[0][0] for c in m.call_args_list]
+        lowercase = [
+            cmd
+            for cmd in commands
+            if len(cmd) >= 3 and cmd[:2] == ["git", "checkout"] and "-b" in cmd
+        ]
+        assert not lowercase, (
+            f"sync must not use `git checkout -b` (use -B); offenders: {lowercase}"
+        )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -378,6 +378,7 @@ class TestSyncHappyPath:
             _mk(returncode=1),  # git diff --cached (staged)
             _mk(),  # git commit pre-merge
             _mk(),  # git push
+            _mk(returncode=1),  # gh pr view (no existing PR)
             _mk(stdout=self.PR_URL + "\n"),  # gh pr create
             _mk(),  # gh pr merge
             _mk(),  # git checkout main
@@ -430,6 +431,7 @@ class TestSyncHappyPath:
                 _mk(),  # git merge (clean)
                 _mk(returncode=0),  # git diff --cached --quiet (nothing staged)
                 _mk(),  # git push (no commit)
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),
                 _mk(),
                 _mk(),  # git checkout main
@@ -483,6 +485,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -512,6 +515,7 @@ class TestSyncConflicts:
                 _mk(returncode=1),  # git diff --cached --quiet → something staged
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -548,6 +552,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(returncode=0),  # git diff --cached --quiet → nothing staged
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -587,6 +592,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -674,6 +680,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -708,6 +715,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -743,6 +751,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -776,6 +785,7 @@ class TestSyncConflicts:
                 _mk(stdout=""),  # diff --filter=U (remaining: clean)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -828,6 +838,7 @@ class TestSyncConfirmation:
                 _mk(returncode=1),  # git diff --cached (staged)
                 _mk(),  # git commit
                 _mk(),  # git push
+                _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=pr_url + "\n"),  # gh pr create
                 _mk(),  # gh pr merge
                 _mk(),  # git checkout main
@@ -976,6 +987,7 @@ class TestSyncBranchForceCreate:
             _mk(returncode=1),  # git diff --cached (staged)
             _mk(),  # git commit pre-merge
             _mk(),  # git push
+            _mk(returncode=1),  # gh pr view (no existing PR)
             _mk(stdout=self.PR_URL + "\n"),  # gh pr create
             _mk(),  # gh pr merge
             _mk(),  # git checkout main
@@ -1011,4 +1023,167 @@ class TestSyncBranchForceCreate:
         ]
         assert not lowercase, (
             f"sync must not use `git checkout -b` (use -B); offenders: {lowercase}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI: existing-PR detection (issue #213, fragility 2)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncExistingPR:
+    """After pushing, sync looks up an existing PR for the sync branch via
+    `gh pr view`. OPEN → update + re-enable auto-merge + exit; CLOSED or
+    MERGED → log the prior URL and open a fresh PR; absent → unchanged
+    behavior (open a new PR)."""
+
+    SHA = "deadbeef" * 5
+    MERGE_BASE = "cafe1234" * 5
+    EXISTING_PR_URL = "https://github.com/org/repo/pull/40"
+    NEW_PR_URL = "https://github.com/org/repo/pull/42"
+
+    def _calls_up_to_push(self):
+        """Mocked subprocess calls from sync start through `git push`."""
+        return [
+            _mk(stdout="main\n"),  # git rev-parse HEAD
+            _mk(),  # git fetch
+            _mk(stdout=self.SHA + "\n"),  # git rev-parse origin/dev
+            _mk(stdout=self.MERGE_BASE + "\n"),  # git merge-base
+            _mk(returncode=0, stdout='{"version": "1.1.0"}'),  # version dev
+            _mk(returncode=0, stdout='{"version": "1.0.0"}'),  # version staging
+            _mk(),  # git checkout -B
+            _mk(),  # git merge (clean)
+            _mk(returncode=1),  # git diff --cached (staged)
+            _mk(),  # git commit pre-merge
+            _mk(),  # git push
+        ]
+
+    def _pr_view_open(self):
+        return _mk(
+            returncode=0,
+            stdout=f'{{"url":"{self.EXISTING_PR_URL}","state":"OPEN"}}',
+        )
+
+    def _pr_view_closed(self):
+        return _mk(
+            returncode=0,
+            stdout=f'{{"url":"{self.EXISTING_PR_URL}","state":"CLOSED"}}',
+        )
+
+    def _pr_view_merged(self):
+        return _mk(
+            returncode=0,
+            stdout=f'{{"url":"{self.EXISTING_PR_URL}","state":"MERGED"}}',
+        )
+
+    def _pr_view_absent(self):
+        return _mk(returncode=1, stderr="no pull requests found for branch")
+
+    def test_updates_existing_open_pr_instead_of_creating(self, tmp_path):
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                *self._calls_up_to_push(),
+                self._pr_view_open(),
+                _mk(),  # gh pr merge --auto --squash
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        commands = [c[0][0] for c in m.call_args_list]
+        # gh pr create must NOT be called for an existing OPEN PR
+        assert not any(
+            cmd[:3] == ["gh", "pr", "create"] for cmd in commands
+        ), f"gh pr create was called; commands: {commands}"
+        # gh pr merge --auto --squash <existing-url> IS called
+        assert [
+            "gh",
+            "pr",
+            "merge",
+            "--auto",
+            "--squash",
+            self.EXISTING_PR_URL,
+        ] in commands
+        assert "updated" in result.output
+        assert self.EXISTING_PR_URL in result.output
+
+    def test_creates_new_pr_when_existing_is_closed(self, tmp_path):
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                *self._calls_up_to_push(),
+                self._pr_view_closed(),
+                _mk(stdout=self.NEW_PR_URL + "\n"),  # gh pr create
+                _mk(),  # gh pr merge
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        commands = [c[0][0] for c in m.call_args_list]
+        # gh pr create IS called for a CLOSED prior PR
+        create_calls = [cmd for cmd in commands if cmd[:3] == ["gh", "pr", "create"]]
+        assert len(create_calls) == 1, f"expected 1 gh pr create call; got {create_calls}"
+        # New PR URL is the one in the success message
+        assert self.NEW_PR_URL in result.output
+        # Prior PR URL is surfaced as informational context
+        assert self.EXISTING_PR_URL in result.output
+        assert "closed" in result.output.lower()
+
+    def test_creates_new_pr_when_existing_is_merged(self, tmp_path):
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                *self._calls_up_to_push(),
+                self._pr_view_merged(),
+                _mk(stdout=self.NEW_PR_URL + "\n"),  # gh pr create
+                _mk(),  # gh pr merge
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        commands = [c[0][0] for c in m.call_args_list]
+        assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in commands)
+        assert self.NEW_PR_URL in result.output
+        assert self.EXISTING_PR_URL in result.output
+        assert "merged" in result.output.lower()
+
+    def test_creates_new_pr_when_no_existing_pr(self, tmp_path):
+        """No PR exists for the sync branch → behavior unchanged: create one."""
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                *self._calls_up_to_push(),
+                self._pr_view_absent(),
+                _mk(stdout=self.NEW_PR_URL + "\n"),  # gh pr create
+                _mk(),  # gh pr merge
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        commands = [c[0][0] for c in m.call_args_list]
+        assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in commands)
+        assert self.NEW_PR_URL in result.output
+        # No prior PR mentioned
+        assert self.EXISTING_PR_URL not in result.output
+
+    def test_existing_open_pr_url_on_final_done_line(self, tmp_path):
+        """Operators grep the final `==> Done.` line for the PR URL — it
+        must be on the same line as 'Done.' even on the retry path."""
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        with patch(_PATCH) as m:
+            m.side_effect = [
+                *self._calls_up_to_push(),
+                self._pr_view_open(),
+                _mk(),  # gh pr merge
+                _mk(),  # git checkout main
+            ]
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        done_lines = [
+            line
+            for line in result.output.splitlines()
+            if "Done." in line and self.EXISTING_PR_URL in line
+        ]
+        assert done_lines, (
+            "expected the existing PR URL on the final `==> Done.` line; "
+            f"output:\n{result.output}"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.21.0"
+version = "0.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #213. Makes `fraisier sync` idempotent on re-invocation after a previous attempt was interrupted or completed in a non-standard way. Patch release; same command surface, more robust.

Two narrow fixes inside `fraisier/cli/sync.py`:

- **Force-create the sync branch.** `git checkout -b` → `-B`, so a stale local sync branch from an interrupted prior run is silently overwritten by the fresh checkout. Sync branches are fraisier-owned; commits on them are re-derived from `origin/<source>` + pre-merge on every run. Dry-run plan output updated to match.
- **Detect the existing PR before creating a new one.** After `git push`, query `gh pr view <sync-branch> --json url,state`. `OPEN` → re-enable auto-merge (idempotent for `--squash`) on the existing PR and exit with `PR updated and auto-merge enabled: <url>`. `CLOSED` / `MERGED` → log the prior URL and open a fresh PR (GitHub permits reusing a head ref after closure). Absent → unchanged behavior. Drafts report as `OPEN` (the `isDraft` bit lives in a separate field we don't query); re-enabling auto-merge on a draft is the desired behavior — GitHub queues the merge for when the PR is marked ready.

## Test plan

- [x] `tests/test_sync.py::TestSyncBranchForceCreate` — 2 tests (force-create flag is `-B`; lowercase `-b` is not used)
- [x] `tests/test_sync.py::TestSyncExistingPR` — 5 tests (OPEN → update + no `pr create`; CLOSED → fresh `pr create` + prior URL logged; MERGED → same; absent → unchanged; URL appears on the final `==> Done.` line for the OPEN retry path)
- [x] All 13 pre-existing mock side-effect lists updated to mock the new `gh pr view` call between `git push` and `gh pr create`
- [x] `uv run pytest` — 3438 passed, 26 skipped, 1 deselected (known flake — see project memory)
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` on changed files — zero diagnostics in `fraisier/cli/sync.py` / `tests/test_sync.py`
- [ ] Manual: fragility 1 — pre-create a stale local `sync/<x>` branch, run `fraisier sync`, confirm silent overwrite
- [ ] Manual: fragility 2 OPEN — open a PR via fraisier, push an extra commit to the sync branch, re-run; confirm no second PR and the existing URL on the final `Done.` line
- [ ] Manual: fragility 2 CLOSED — close the prior PR in the UI and re-run; confirm a fresh `gh pr create` and the closed URL logged for context

🤖 Generated with [Claude Code](https://claude.com/claude-code)