### PR TITLE
release: v0.22.2 — surface webhook self-upgrade allowlist rejection (#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2] - 2026-05-23
+
+### Fixed
+
+- **Webhook self-upgrade now surfaces helper allowlist rejections in the journal** ([#218](https://github.com/fraiseql/fraisier/issues/218)). The scaffold-template fix landed in 0.18.0 (`fraisier-{project}-webhook.service` is unconditionally prepended to the helper allowlist by `_collect_allowed_services`), so any host re-scaffolded on 0.18.0+ already self-upgrades end-to-end. Hosts originally bootstrapped before 0.18.0 still carry a stale `/etc/systemd/system/fraisier-{project}-systemctl-helper.service` whose `ExecStart` argv omits the webhook unit — `uv tool install` upgrading the binary doesn't rewrite that file — so the detached worker's restart RPC silently fails, recorded only in `/var/lib/fraisier/self-upgrade/<project>-<ts>.log`.
+- **Pre-flight check in `maybe_self_upgrade`.** Before spawning the detached worker, the parent webhook now sends a read-only `is-active` RPC for its own service unit (`fraisier/webhook_self_upgrade.py:_preflight_helper_allowlist`). On a `service not allowed` rejection the webhook logs a WARNING **in its own journal** naming the cause and the remediation — `fraisier scaffold && fraisier scaffold-install --yes` — and skips the upgrade entirely (avoiding the half-state where the binary is upgraded but the process isn't). Operators watching `journalctl -u fraisier-<project>-webhook.service` see the actionable error on the next deploy attempt instead of having to discover the per-event log file.
+- **Narrow scope.** Empty `FRAISIER_SYSTEMCTL_SOCKET` (install-only mode) and transient `ConnectionRefusedError` (startup races) fall through unchanged — those are non-actionable here and let the existing worker behaviour log its own per-event failure.
+
 ## [0.22.1] - 2026-05-23
 
 ### Fixed

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -62,6 +62,34 @@ def _parse_semver(version: str) -> tuple[int, int, int]:
     return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
+def _preflight_helper_allowlist(socket_path: str, service: str) -> str | None:
+    """Detect a known-bad systemctl-helper allowlist before spawning the worker.
+
+    Sends a read-only ``is-active`` RPC; if the helper rejects with
+    ``service not allowed``, returns the rejection reason. All other outcomes
+    (no socket configured, connection refused, service inactive, etc.) return
+    None — those are non-actionable here and let the worker proceed with its
+    own logging.
+
+    This pre-flight exists because ``_spawn_upgrade`` detaches the worker that
+    actually does the restart RPC, so its failure is recorded only under
+    ``/var/lib/fraisier/self-upgrade/`` and never reaches the webhook's main
+    journal (issue #218). Hoisting the allowlist check into the parent surfaces
+    the most common scaffold-staleness case where operators are looking.
+    """
+    if not socket_path:
+        return None
+    try:
+        _call_via_socket(socket_path, "is-active", service, check=True)
+    except ConnectionRefusedError:
+        return None
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        if "not allowed" in stderr.lower():
+            return stderr
+    return None
+
+
 def maybe_self_upgrade(
     app_path: Path,
     *,
@@ -91,6 +119,21 @@ def maybe_self_upgrade(
                 "(required=%s installed=%s)",
                 required,
                 installed,
+            )
+            return
+        socket_path = os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", "")
+        service = f"fraisier-{project_name}-webhook.service"
+        rejection = _preflight_helper_allowlist(socket_path, service)
+        if rejection is not None:
+            log.warning(
+                "self-upgrade: skipping upgrade to %s — systemctl helper "
+                "rejected pre-flight: %s. The webhook unit is missing from "
+                "the helper allowlist (typically because this host was "
+                "scaffolded before fraisier 0.18.0). Re-run "
+                "`fraisier scaffold && fraisier scaffold-install --yes` to "
+                "refresh it, then the next deploy will self-upgrade.",
+                required,
+                rejection,
             )
             return
         log.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.22.1"
+version = "0.22.2"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_webhook_self_upgrade.py
+++ b/tests/test_webhook_self_upgrade.py
@@ -12,6 +12,7 @@ import pytest
 
 from fraisier.webhook_self_upgrade import (
     _build_install_cmd,
+    _preflight_helper_allowlist,
     _run_upgrade,
     _spawn_upgrade,
     maybe_self_upgrade,
@@ -102,6 +103,143 @@ class TestMaybeSelfUpgrade:
             maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
         # Conservative: skip when we can't compare.
         spawn.assert_not_called()
+
+    def test_preflight_rejection_skips_spawn_and_warns(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """When the helper rejects the pre-flight (#218), don't spawn the worker.
+
+        Without this, ``_spawn_upgrade`` installs the new binary in a detached
+        subprocess whose restart RPC then fails silently in a per-event log
+        under /var/lib/fraisier/self-upgrade/, leaving the webhook process on
+        the old code with no signal in its journal.
+        """
+        import logging
+
+        _write_pyproject(tmp_path, "2.0.0")
+        monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+        spawn = MagicMock()
+        with (
+            patch(
+                "fraisier.webhook_self_upgrade.importlib_metadata.version",
+                return_value="1.2.3",
+            ),
+            patch(
+                "fraisier.webhook_self_upgrade._call_via_socket",
+                side_effect=subprocess.CalledProcessError(
+                    1,
+                    "is-active",
+                    stderr="service not allowed: fraisier-foo-webhook.service",
+                ),
+            ),
+            caplog.at_level(logging.WARNING, logger="fraisier.webhook_self_upgrade"),
+        ):
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
+        spawn.assert_not_called()
+        assert "service not allowed" in caplog.text
+        assert "scaffold-install" in caplog.text
+
+    def test_preflight_pass_still_spawns(self, tmp_path, monkeypatch):
+        """A clean pre-flight must not block the upgrade."""
+        _write_pyproject(tmp_path, "2.0.0")
+        monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+        spawn = MagicMock()
+        with (
+            patch(
+                "fraisier.webhook_self_upgrade.importlib_metadata.version",
+                return_value="1.2.3",
+            ),
+            patch(
+                "fraisier.webhook_self_upgrade._call_via_socket",
+                return_value=SimpleNamespace(stdout="active", stderr="", returncode=0),
+            ),
+        ):
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
+        spawn.assert_called_once_with("2.0.0", "foo")
+
+    def test_preflight_unreachable_socket_still_spawns(self, tmp_path, monkeypatch):
+        """A transient socket failure must not punish the upgrade.
+
+        ConnectionRefusedError can happen during webhook/helper startup races.
+        Falling through to the worker preserves the existing install-anyway
+        behaviour; the worker will log its own per-event failure if restart
+        also fails.
+        """
+        _write_pyproject(tmp_path, "2.0.0")
+        monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+        spawn = MagicMock()
+        with (
+            patch(
+                "fraisier.webhook_self_upgrade.importlib_metadata.version",
+                return_value="1.2.3",
+            ),
+            patch(
+                "fraisier.webhook_self_upgrade._call_via_socket",
+                side_effect=ConnectionRefusedError("socket missing"),
+            ),
+        ):
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
+        spawn.assert_called_once_with("2.0.0", "foo")
+
+    def test_preflight_no_socket_env_still_spawns(self, tmp_path, monkeypatch):
+        """install-only mode (no helper configured) keeps working."""
+        _write_pyproject(tmp_path, "2.0.0")
+        monkeypatch.delenv("FRAISIER_SYSTEMCTL_SOCKET", raising=False)
+        spawn = MagicMock()
+        with (
+            patch(
+                "fraisier.webhook_self_upgrade.importlib_metadata.version",
+                return_value="1.2.3",
+            ),
+            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+        ):
+            maybe_self_upgrade(tmp_path, project_name="foo", enabled=True, spawn=spawn)
+        spawn.assert_called_once_with("2.0.0", "foo")
+        mock_socket.assert_not_called()
+
+
+class TestPreflightHelperAllowlist:
+    def test_empty_socket_returns_none(self):
+        assert _preflight_helper_allowlist("", "any.service") is None
+
+    def test_rejection_returns_stderr(self):
+        with patch(
+            "fraisier.webhook_self_upgrade._call_via_socket",
+            side_effect=subprocess.CalledProcessError(
+                1, "is-active", stderr="service not allowed: x.service"
+            ),
+        ):
+            result = _preflight_helper_allowlist("/run/x.sock", "x.service")
+        assert result == "service not allowed: x.service"
+
+    def test_inactive_service_is_not_a_rejection(self):
+        """`systemctl is-active` returning exit 3 (inactive) is not an allowlist
+        problem — the helper accepted the call, the service just isn't running.
+        """
+        with patch(
+            "fraisier.webhook_self_upgrade._call_via_socket",
+            side_effect=subprocess.CalledProcessError(
+                3, "is-active", stderr="unknown error from systemctl helper"
+            ),
+        ):
+            result = _preflight_helper_allowlist("/run/x.sock", "x.service")
+        assert result is None
+
+    def test_connection_refused_returns_none(self):
+        with patch(
+            "fraisier.webhook_self_upgrade._call_via_socket",
+            side_effect=ConnectionRefusedError("nope"),
+        ):
+            result = _preflight_helper_allowlist("/run/x.sock", "x.service")
+        assert result is None
+
+    def test_clean_response_returns_none(self):
+        with patch(
+            "fraisier.webhook_self_upgrade._call_via_socket",
+            return_value=SimpleNamespace(stdout="active", stderr="", returncode=0),
+        ):
+            result = _preflight_helper_allowlist("/run/x.sock", "x.service")
+        assert result is None
 
 
 class TestSpawnUpgrade:

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes [#218](https://github.com/fraiseql/fraisier/issues/218) — webhook self-upgrade silently failing on hosts whose helper allowlist is missing the webhook unit.

The scaffold-template piece of #218 is already in place (`fa50f85`, v0.18.0+). What was still broken: on hosts originally scaffolded **before** 0.18.0, the stale `/etc/systemd/system/fraisier-{project}-systemctl-helper.service` argv omits the webhook unit. `uv tool install` upgrading the binary doesn't rewrite that file. The detached `_spawn_upgrade` worker's restart RPC then fails silently, recorded only in `/var/lib/fraisier/self-upgrade/<project>-<ts>.log` — the webhook journal sees nothing.

This PR adds a pre-flight check in the **parent** webhook process: before spawning the worker, send a read-only `is-active` RPC for the webhook's own service unit. On `service not allowed`, log a WARNING in the webhook's main journal naming the cause and the remediation (`fraisier scaffold && fraisier scaffold-install --yes`) and skip the upgrade entirely. Empty `FRAISIER_SYSTEMCTL_SOCKET` and transient `ConnectionRefusedError` fall through unchanged so install-only mode and startup races keep working.

- `fraisier/webhook_self_upgrade.py:_preflight_helper_allowlist` — the pre-flight
- `fraisier/webhook_self_upgrade.py:maybe_self_upgrade` — calls pre-flight before `_spawn_upgrade`
- `tests/test_webhook_self_upgrade.py` — 5 new tests (rejection / pass / unreachable / no-env / unit tests for the pre-flight)
- `pyproject.toml` + `CHANGELOG.md` — 0.22.1 → 0.22.2

## Test plan

- [x] `uv run pytest tests/test_webhook_self_upgrade.py` → 26 passed
- [x] `uv run pytest tests/test_scaffold.py tests/test_systemctl_helper.py tests/test_systemd.py` → 236 passed
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → 348 files already formatted
- [x] `uv run ty check fraisier/webhook_self_upgrade.py` → clean
- [ ] CI Quality Gate green
- [ ] On merge + tag, Publish workflow pushes to PyPI and creates the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)