### PR TITLE
release: v0.23.1 — surface install.sh exit code on failure (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-05-27
+
+### Fixed
+
+- **`scaffold-install` no longer crashes with an unhandled `PermissionError` on `Path.exists()` / `is_file()` / `chmod()`** ([#222](https://github.com/fraiseql/fraisier/issues/222)). On hosts where a parent directory of the generated `install.sh` isn't traversable by the invoking user, `Path.exists()` propagates `EACCES` as `PermissionError` rather than returning `False`. `is_file()` has the same failure mode. The wrapper now treats any `OSError` from those probes as "can't see the file" and prints the friendly "not found or not readable" error instead of a traceback. `chmod(0o755)` is similarly hardened: when the file is owned by another user the chmod is allowed to fail silently as long as the file is already executable (the common case for a freshly-generated script).
+
+### Changed
+
+- **`scaffold-install` failure messages now include the install.sh exit code and a copy-pasteable rerun command** ([#225](https://github.com/fraiseql/fraisier/issues/225)). The previous "Review the output above for details" line was misleading when no output existed (the wrapper inherits stdio, so a quiet `install.sh` produces no preceding output). Failures now print the actual exit code (`Preview exited with code 42` / `Validation exited with code 42` / `Installation failed (exit code 42)`) and a verbose+tee command the operator can paste to reproduce with a persistent log: `sudo /opt/<project>/scripts/generated/install.sh <flags> --verbose 2>&1 | tee /tmp/install.log`. `--verbose` is added only when not already present in the original invocation. The success path is unchanged. No behavioral change to subprocess invocation — this is strictly an error-message UX fix.
+
 ## [0.23.0] - 2026-05-26
 
 ### Changed

--- a/fraisier/cli/scaffold.py
+++ b/fraisier/cli/scaffold.py
@@ -182,6 +182,35 @@ def _build_preview_cmd(cmd: list[str]) -> list[str]:
     return preview
 
 
+def _print_install_failure(
+    *,
+    install_script: Path,
+    returncode: int,
+    cmd: list[str],
+    phase: str | None,
+) -> None:
+    """Print the failure message for a non-zero install.sh exit.
+
+    ``phase`` is ``"Validation"`` or ``"Preview"`` for the dry-run / validate
+    paths, or ``None`` for a real install. The rerun hint adds ``--verbose``
+    if it wasn't already present so the operator's copy-paste produces a
+    diagnostic log even when the original invocation didn't.
+    """
+    rerun_flags = " ".join(cmd[2:])  # skip ["sudo", install_script]
+    if "--verbose" not in rerun_flags:
+        rerun_flags = f"{rerun_flags} --verbose".strip()
+    if phase is not None:
+        headline = f"[yellow]⚠ {phase} exited with code {returncode}.[/yellow]"
+    else:
+        headline = f"[red]✗ Installation failed (exit code {returncode}).[/red]"
+    console.print(
+        f"\n{headline}\n"
+        "To capture the full output for debugging:\n"
+        f"  sudo {install_script} {rerun_flags} 2>&1 | tee /tmp/install.log",
+        soft_wrap=True,
+    )
+
+
 @main.command(name="scaffold-install")
 @click.option("--dry-run", is_flag=True, help="Preview what would be installed")
 @click.option(
@@ -313,14 +342,16 @@ def scaffold_install(
                 "     fraisier trigger-deploy <fraise> <environment>"
             )
     else:
-        if validate_only or dry_run:
-            console.print(
-                "\n[yellow]⚠ Preview/validation encountered issues.[/yellow]\n"
-                "Review the output above for details."
-            )
+        if validate_only:
+            phase: str | None = "Validation"
+        elif dry_run:
+            phase = "Preview"
         else:
-            console.print(
-                "\n[red]✗ Installation failed[/red]\n"
-                "Review the output above for details."
-            )
+            phase = None
+        _print_install_failure(
+            install_script=install_script,
+            returncode=returncode,
+            cmd=cmd,
+            phase=phase,
+        )
         raise SystemExit(returncode)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.23.0"
+version = "0.23.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -3989,6 +3989,85 @@ fraises: {{}}
         assert "Traceback" not in result.output
         assert "executable" in result.output.lower()
 
+    def test_scaffold_install_failure_message_includes_exit_code(
+        self, tmp_path, monkeypatch
+    ):
+        """scaffold-install --dry-run failure surfaces exit code + log hint (#225).
+
+        Regression for #225: when install.sh exits non-zero in dry-run/validate
+        mode, the wrapper's failure message must include the actual exit code
+        and a copy-pasteable command (with --verbose + tee) that produces a
+        persistent log. Replaces the previous "Review the output above" hint
+        that was useless when no output existed.
+        """
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(
+            f"""
+name: tp
+scaffold:
+  output_dir: {tmp_path / "output"}
+fraises: {{}}
+"""
+        )
+        install_script = tmp_path / "output" / "install.sh"
+        install_script.parent.mkdir(parents=True)
+        install_script.write_text("#!/bin/sh\nexit 42\n")
+        install_script.chmod(0o755)
+
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 42)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["-c", str(cfg), "scaffold-install", "--dry-run", "--yes"]
+        )
+        assert result.exit_code == 42
+        assert "42" in result.output
+        assert "install.sh" in result.output
+        assert "tee" in result.output
+
+    def test_scaffold_install_install_failure_message_includes_exit_code(
+        self, tmp_path, monkeypatch
+    ):
+        """scaffold-install (non-preview) failure surfaces exit code + hint (#225).
+
+        Parallel regression to the dry-run path: when install.sh exits non-zero
+        outside of preview/validate, the message must include the exit code and
+        the verbose-log rerun hint.
+        """
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(
+            f"""
+name: tp
+scaffold:
+  output_dir: {tmp_path / "output"}
+fraises: {{}}
+"""
+        )
+        install_script = tmp_path / "output" / "install.sh"
+        install_script.parent.mkdir(parents=True)
+        install_script.write_text("#!/bin/sh\nexit 7\n")
+        install_script.chmod(0o755)
+
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 7)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["-c", str(cfg), "scaffold-install", "--yes"])
+        assert result.exit_code == 7
+        assert "7" in result.output
+        assert "install.sh" in result.output
+        assert "tee" in result.output
+        assert "Installation failed" in result.output
+
     def test_scaffold_then_install_workflow(self, tmp_path):
         """Complete workflow: scaffold generates files, scaffold-install installs."""
         from click.testing import CliRunner

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `scaffold-install` failure messages now include the install.sh exit code and a copy-pasteable rerun command with `--verbose` + tee to `/tmp/install.log` (closes #225).
- Bumps to v0.23.1; the CHANGELOG also documents the already-landed #222 PermissionError hardening that ships in this release.

## Why

The old message — `⚠ Preview/validation encountered issues. Review the output above for details.` — was useless when "the output above" was empty (the wrapper inherits stdio, so a silent install.sh produces no preceding lines). Operators had no exit code, no way to differentiate preview/validate/install failures, and no immediate next step. The fix:

- Surfaces the actual exit code in the failure message.
- Distinguishes Preview / Validation / Installation failure phases.
- Prints a verbose-rerun command the operator can paste to produce a persistent log file (`/tmp/install.log`) suitable for bug reports — adding `--verbose` only if it wasn't already in the original invocation.

This is strictly a wording + exit-code-surfacing change. No subprocess invocation behavior changes; the success path is unchanged.

## Test plan

- [x] `uv run pytest tests/test_scaffold.py::TestScaffoldCLI -q` — 12 passed (2 new regression tests for the dry-run and install failure paths).
- [x] `uv run ruff check fraisier/cli/scaffold.py tests/test_scaffold.py` — clean.
- [x] `uv run ruff format --check .` — clean repo-wide.
- [x] `uv run ty check fraisier/cli/scaffold.py` — clean.
- [x] Full unit suite (with the known `test_install_helper.py` flake deselected per project memory) — 3699 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)