### PR TITLE
release: v0.24.0 — sudoers diff before overwrite (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] - 2026-05-27
+
+### Added
+
+- **`scaffold-install` now diffs the current `/etc/sudoers.d/<project>` against the rendered fragment and warns about rules that would be removed** ([#224](https://github.com/fraiseql/fraisier/issues/224)). Previously the install silently overwrote the target file, so any operator-added rule (workarounds, non-fraisier components' rules, leftover entries from prior fraisier versions) silently disappeared on next `scaffold-install`. The wrapper now reads the current sudoers file via `sudo cat` (piggybacking on the existing sudo timestamp — no extra password prompt in practice), diffs against the rendered fragment using a line-set comparison that ignores comments and normalizes whitespace, and prints a clearly-formatted list of rules that would be removed. In interactive mode the existing `Proceed with installation?` confirm covers both the install plan and the sudoers diff — there is deliberately no second prompt. In `--yes` / `--dry-run` / `--validate-only` modes the diff still prints (`--yes` opts out of the prompt, not out of visibility). The check is silently skipped when `/etc/sudoers.d/<project>` doesn't exist yet (fresh installs).
+- **`scaffold-install --strict-sudoers` flag** for CI/automation that should fail loud on any sudoers removal. Exits with code 3 (distinct from generic `1` and user-abort `2`) when rules would be removed OR when the current sudoers state can't be read — "couldn't verify" is treated as failure under strict, not silently as "no changes". Naming is deliberately per-resource: future nginx/systemd safety nets get sibling flags (`--strict-nginx`, ...) rather than a single coarse `--strict-overwrites`.
+- **New module `fraisier.scaffold.sudoers_diff`** — pure-function `diff_sudoers(current, new) -> SudoersDiff` with `added` / `removed` rule lists and a `has_changes` property. Stdlib-only, no I/O, fully unit-tested.
+
 ## [0.23.1] - 2026-05-27
 
 ### Fixed

--- a/fraisier/cli/scaffold.py
+++ b/fraisier/cli/scaffold.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from typing import Literal
 
 import click
 
+from fraisier.scaffold.sudoers_diff import SudoersDiff, diff_sudoers
+
 from ._helpers import console, require_config
 from .main import main
+
+# Distinct exit code for --strict-sudoers aborts (#224). 1 stays generic;
+# this lets CI/automation distinguish "sudoers would change" from any other
+# install failure without parsing the output.
+STRICT_SUDOERS_EXIT_CODE = 3
 
 
 @main.command(name="scaffold-diff")
@@ -211,6 +219,93 @@ def _print_install_failure(
     )
 
 
+def _read_current_sudoers(
+    project_name: str,
+) -> tuple[str | None, Literal["ok", "missing", "unreadable"]]:
+    """Read `/etc/sudoers.d/<project_name>` via sudo for the diff check (#224).
+
+    Returns:
+        ``(content, "ok")`` when the file was read successfully.
+        ``(None, "missing")`` when the file does not exist (fresh install).
+        ``(None, "unreadable")`` when sudo refused, the file was unreadable,
+        or any other I/O error occurred.
+
+    Uses plain ``sudo`` (not ``sudo -n``) so the read piggybacks on the
+    existing scaffold-install sudo timestamp: interactive runs warm it via
+    the preceding install.sh preview; ``--yes`` runs warm it via the
+    install itself. ``sudo test -f`` distinguishes "missing" from
+    "can't read" without paying a second password prompt.
+    """
+    target = f"/etc/sudoers.d/{project_name}"
+    try:
+        probe = subprocess.run(
+            ["sudo", "test", "-f", target],
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return None, "unreadable"
+    if probe.returncode == 1:
+        return None, "missing"
+    if probe.returncode != 0:
+        return None, "unreadable"
+    try:
+        result = subprocess.run(
+            ["sudo", "cat", target],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None, "unreadable"
+    if result.returncode != 0:
+        return None, "unreadable"
+    return result.stdout, "ok"
+
+
+def _print_sudoers_diff(
+    *,
+    sudoers_src: Path,
+    project_name: str,
+    strict: bool,
+) -> SudoersDiff | None:
+    """Print the sudoers-rule removal warning and return the diff (#224).
+
+    Returns ``None`` if the check was skipped (no source file, no target on
+    disk, or unreadable target in non-strict mode). Raises ``SystemExit(3)``
+    in strict mode when the current sudoers can't be read.
+    """
+    if not sudoers_src.exists():
+        return None
+    content, status = _read_current_sudoers(project_name)
+    if status == "missing":
+        return None
+    if status == "unreadable":
+        if strict:
+            console.print(
+                "\n[red]✗ --strict-sudoers: could not read "
+                f"/etc/sudoers.d/{project_name} to verify what would "
+                "change.[/red]"
+            )
+            raise SystemExit(STRICT_SUDOERS_EXIT_CODE)
+        console.print(
+            f"\n[yellow]Note: could not read /etc/sudoers.d/{project_name}; "
+            "skipping sudoers diff.[/yellow]"
+        )
+        return None
+    assert content is not None  # status == "ok" implies content is set
+    diff = diff_sudoers(content, sudoers_src.read_text())
+    if diff.removed:
+        console.print(
+            f"\n[yellow]⚠ {len(diff.removed)} sudoers rule(s) currently in "
+            f"/etc/sudoers.d/{project_name} are not in your fraises.yaml "
+            "and would be removed:[/yellow]"
+        )
+        for rule in diff.removed:
+            console.print(f"  - {rule}")
+    return diff
+
+
 @main.command(name="scaffold-install")
 @click.option("--dry-run", is_flag=True, help="Preview what would be installed")
 @click.option(
@@ -218,6 +313,14 @@ def _print_install_failure(
 )
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
+@click.option(
+    "--strict-sudoers",
+    is_flag=True,
+    help=(
+        "Abort (exit 3) if sudoers rules would be removed or current "
+        "/etc/sudoers.d/<project> can't be read. Intended for CI/automation."
+    ),
+)
 @click.pass_context
 def scaffold_install(
     ctx: click.Context,
@@ -225,6 +328,7 @@ def scaffold_install(
     validate_only: bool,
     yes: bool,
     verbose: bool,
+    strict_sudoers: bool,
 ) -> None:
     """Install generated scaffold files to system locations.
 
@@ -312,14 +416,45 @@ def scaffold_install(
     else:
         console.print("[cyan]Installation plan:[/cyan]\n")
 
+    sudoers_src = output_dir / "sudoers"
+
+    def _check_sudoers_diff() -> None:
+        """Print the sudoers diff and honor --strict-sudoers.
+
+        Closure over `config.project_name`, `sudoers_src`, and `strict_sudoers`
+        so the call sites below stay short. Raises SystemExit(3) when
+        --strict-sudoers detects a removal or an unreadable target.
+        """
+        diff = _print_sudoers_diff(
+            sudoers_src=sudoers_src,
+            project_name=config.project_name,
+            strict=strict_sudoers,
+        )
+        if strict_sudoers and diff is not None and diff.removed:
+            console.print(
+                "\n[red]✗ --strict-sudoers: aborting because sudoers rules "
+                "would be removed. Add them to sudoers_rules in fraises.yaml "
+                "or remove --strict-sudoers.[/red]"
+            )
+            raise SystemExit(STRICT_SUDOERS_EXIT_CODE)
+
     # If not --yes and not validating/dry-running, show preview first
     if not yes and not validate_only and not dry_run:
         preview_cmd = _build_preview_cmd(cmd)
         _run_script(preview_cmd)
         console.print()
+        # Single prompt covers BOTH the install plan AND the sudoers diff:
+        # chaining a second `click.confirm` here would train operators to mash
+        # `y` past safety questions.
+        _check_sudoers_diff()
         if not click.confirm("Proceed with installation?"):
             console.print("[yellow]Aborted.[/yellow]")
             return
+    else:
+        # --yes / --dry-run / --validate-only: still surface the diff (loudly
+        # in --yes, as part of the preview output otherwise). The operator
+        # opted out of the prompt, not out of seeing what would change.
+        _check_sudoers_diff()
 
     # Run the actual command
     returncode = _run_script(cmd)

--- a/fraisier/scaffold/sudoers_diff.py
+++ b/fraisier/scaffold/sudoers_diff.py
@@ -1,0 +1,66 @@
+"""Compute a line-level diff between two `/etc/sudoers.d/<project>` fragments.
+
+Pure-function module used by `scaffold-install` (#224) to detect rules that
+would be silently removed when the generated sudoers fragment overwrites the
+one currently on disk. The diff treats each non-comment, non-blank line as an
+opaque normalized string — sudoers files are line-oriented and structural
+parsing is unnecessary for our "set of rules" comparison.
+
+Caveat: `_normalize_whitespace` collapses interior whitespace, which means
+``Defaults env_keep += "A  B"`` and ``Defaults env_keep += "A B"`` compare
+equal. Fraisier-generated rules never contain interior quoted whitespace; a
+hand-edited rule that depends on it is vanishingly rare and would be a
+false negative (not a false positive — we'd say "no change" when there is
+one), so the safety net never warns incorrectly. Accept the trade.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SudoersDiff:
+    """Result of comparing two sudoers fragments as sets of normalized rules.
+
+    `added` and `removed` preserve the order they appear in their source file
+    (new rules iterated against current set; current rules iterated against
+    new set).
+    """
+
+    added: list[str]
+    removed: list[str]
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.removed)
+
+
+def diff_sudoers(current: str, new: str) -> SudoersDiff:
+    """Return the rules added in `new` and removed from `current`.
+
+    Comments and blank lines are ignored; whitespace within rules is normalized
+    (see module docstring caveat).
+    """
+    cur_rules = _parse_rules(current)
+    new_rules = _parse_rules(new)
+    cur_set = set(cur_rules)
+    new_set = set(new_rules)
+    return SudoersDiff(
+        added=[r for r in new_rules if r not in cur_set],
+        removed=[r for r in cur_rules if r not in new_set],
+    )
+
+
+def _parse_rules(content: str) -> list[str]:
+    out: list[str] = []
+    for raw in content.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append(_normalize_whitespace(stripped))
+    return out
+
+
+def _normalize_whitespace(rule: str) -> str:
+    return " ".join(rule.split())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.23.1"
+version = "0.24.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -4125,6 +4125,200 @@ fraises: {{}}
         assert "--dry-run" in result.output
         assert "--yes" in result.output
 
+    # --- #224: sudoers diff-and-warn before overwrite -----------------------
+
+    def _setup_sudoers_install(self, tmp_path, *, source_sudoers: str):
+        """Build a minimal install.sh + rendered sudoers for the #224 tests."""
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(
+            f"""
+name: myproj
+scaffold:
+  output_dir: {tmp_path / "output"}
+fraises: {{}}
+"""
+        )
+        output_dir = tmp_path / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        install_script = output_dir / "install.sh"
+        install_script.write_text("#!/bin/sh\nexit 0\n")
+        install_script.chmod(0o755)
+        sudoers_src = output_dir / "sudoers"
+        sudoers_src.write_text(source_sudoers)
+        return cfg
+
+    def test_sudoers_diff_warns_on_removed_rules(self, tmp_path, monkeypatch):
+        """A rule on disk but not in the rendered fragment surfaces as 'removed' (#224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = self._setup_sudoers_install(
+            tmp_path,
+            source_sudoers="user1 ALL=(root) NOPASSWD: /usr/bin/foo\n",
+        )
+
+        # Currently on disk: an extra rule that's about to disappear.
+        monkeypatch.setattr(
+            scaffold_mod,
+            "_read_current_sudoers",
+            lambda _name: (
+                "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+                "admin ALL=(root) NOPASSWD: /usr/bin/baz\n",
+                "ok",
+            ),
+        )
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 0)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["-c", str(cfg), "scaffold-install", "--yes"])
+        assert result.exit_code == 0
+        assert "would be removed" in result.output.lower()
+        assert "admin ALL=(root) NOPASSWD: /usr/bin/baz" in result.output
+
+    def test_sudoers_diff_silent_when_fresh_install(self, tmp_path, monkeypatch):
+        """No target file on disk → no diff section, no warning (#224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = self._setup_sudoers_install(
+            tmp_path,
+            source_sudoers="user1 ALL=(root) NOPASSWD: /usr/bin/foo\n",
+        )
+        monkeypatch.setattr(
+            scaffold_mod,
+            "_read_current_sudoers",
+            lambda _name: (None, "missing"),
+        )
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 0)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["-c", str(cfg), "scaffold-install", "--yes"])
+        assert result.exit_code == 0
+        assert "would be removed" not in result.output.lower()
+
+    def test_sudoers_diff_silent_when_identical(self, tmp_path, monkeypatch):
+        """Identical current and new → no diff section (#224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        rule = "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        cfg = self._setup_sudoers_install(tmp_path, source_sudoers=rule)
+        monkeypatch.setattr(
+            scaffold_mod, "_read_current_sudoers", lambda _name: (rule, "ok")
+        )
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 0)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["-c", str(cfg), "scaffold-install", "--yes"])
+        assert result.exit_code == 0
+        assert "would be removed" not in result.output.lower()
+
+    def test_sudoers_diff_unreadable_non_strict_warns_and_proceeds(
+        self, tmp_path, monkeypatch
+    ):
+        """Unreadable sudoers + no --strict-sudoers → note + skip diff + proceed."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = self._setup_sudoers_install(
+            tmp_path,
+            source_sudoers="user1 ALL=(root) NOPASSWD: /usr/bin/foo\n",
+        )
+        monkeypatch.setattr(
+            scaffold_mod,
+            "_read_current_sudoers",
+            lambda _name: (None, "unreadable"),
+        )
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 0)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["-c", str(cfg), "scaffold-install", "--yes"])
+        assert result.exit_code == 0
+        assert "could not read" in result.output.lower()
+
+    def test_strict_sudoers_aborts_with_exit_code_3(self, tmp_path, monkeypatch):
+        """--strict-sudoers + diff → exit 3, do not run install (#224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = self._setup_sudoers_install(
+            tmp_path,
+            source_sudoers="user1 ALL=(root) NOPASSWD: /usr/bin/foo\n",
+        )
+        monkeypatch.setattr(
+            scaffold_mod,
+            "_read_current_sudoers",
+            lambda _name: (
+                "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+                "admin ALL=(root) NOPASSWD: /usr/bin/baz\n",
+                "ok",
+            ),
+        )
+
+        ran: list[list[str]] = []
+
+        def fake_run(cmd):
+            ran.append(cmd)
+            return 0
+
+        monkeypatch.setattr(scaffold_mod, "_run_script", fake_run)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["-c", str(cfg), "scaffold-install", "--yes", "--strict-sudoers"],
+        )
+        assert result.exit_code == 3
+        assert "strict-sudoers" in result.output.lower()
+        assert ran == []  # install must not have been invoked
+
+    def test_strict_sudoers_aborts_on_unreadable_sudoers(self, tmp_path, monkeypatch):
+        """--strict-sudoers + unreadable target → exit 3 (couldn't verify, #224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+        from fraisier.cli import scaffold as scaffold_mod
+
+        cfg = self._setup_sudoers_install(
+            tmp_path,
+            source_sudoers="user1 ALL=(root) NOPASSWD: /usr/bin/foo\n",
+        )
+        monkeypatch.setattr(
+            scaffold_mod,
+            "_read_current_sudoers",
+            lambda _name: (None, "unreadable"),
+        )
+        monkeypatch.setattr(scaffold_mod, "_run_script", lambda _cmd: 0)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["-c", str(cfg), "scaffold-install", "--yes", "--strict-sudoers"],
+        )
+        assert result.exit_code == 3
+        assert "could not read" in result.output.lower()
+
+    def test_scaffold_install_help_includes_strict_sudoers(self, tmp_path):
+        """scaffold-install --help lists the new --strict-sudoers flag (#224)."""
+        from click.testing import CliRunner
+
+        from fraisier.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["scaffold-install", "--help"])
+        assert result.exit_code == 0
+        assert "--strict-sudoers" in result.output
+
 
 class TestDeploySocketServiceUnits:
     """Regression tests for issue #72 — socket/service unit correctness."""

--- a/tests/test_sudoers_diff.py
+++ b/tests/test_sudoers_diff.py
@@ -1,0 +1,123 @@
+"""Unit tests for the sudoers diff helpers (#224).
+
+Pure-function tests over `fraisier.scaffold.sudoers_diff`. Strings in, dataclass
+out — no I/O, no monkeypatching. The wrapper-side integration is covered by
+`tests/test_scaffold.py::TestScaffoldCLI`.
+"""
+
+from __future__ import annotations
+
+
+class TestParseRules:
+    """`_parse_rules` extracts non-comment, non-blank, whitespace-normalized lines."""
+
+    def test_strips_comments_and_blanks(self):
+        from fraisier.scaffold.sudoers_diff import _parse_rules
+
+        content = """\
+# header comment
+# do not edit
+
+user1 ALL=(root) NOPASSWD: /usr/bin/foo
+# inline-ish comment
+user2 ALL=(root) NOPASSWD: /usr/bin/bar
+"""
+        assert _parse_rules(content) == [
+            "user1 ALL=(root) NOPASSWD: /usr/bin/foo",
+            "user2 ALL=(root) NOPASSWD: /usr/bin/bar",
+        ]
+
+    def test_collapses_interior_whitespace(self):
+        from fraisier.scaffold.sudoers_diff import _parse_rules
+
+        content = "user1  ALL=(root)   NOPASSWD: /usr/bin/foo\n"
+        assert _parse_rules(content) == [
+            "user1 ALL=(root) NOPASSWD: /usr/bin/foo",
+        ]
+
+    def test_empty_input_yields_empty_list(self):
+        from fraisier.scaffold.sudoers_diff import _parse_rules
+
+        assert _parse_rules("") == []
+        assert _parse_rules("\n\n# only comments\n\n") == []
+
+
+class TestDiffSudoers:
+    """`diff_sudoers` returns added / removed sets (order-preserving)."""
+
+    def test_detects_removed_rules(self):
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = (
+            "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+            "admin ALL=(root) NOPASSWD: /usr/bin/baz\n"
+        )
+        new = "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        diff = diff_sudoers(current, new)
+        assert diff.removed == ["admin ALL=(root) NOPASSWD: /usr/bin/baz"]
+        assert diff.added == []
+        assert diff.has_changes is True
+
+    def test_detects_added_rules(self):
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        new = (
+            "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+            "newcomer ALL=(root) NOPASSWD: /usr/bin/qux\n"
+        )
+        diff = diff_sudoers(current, new)
+        assert diff.added == ["newcomer ALL=(root) NOPASSWD: /usr/bin/qux"]
+        assert diff.removed == []
+        assert diff.has_changes is True
+
+    def test_mixed_add_and_remove(self):
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = (
+            "a ALL=(root) NOPASSWD: /usr/bin/a\nb ALL=(root) NOPASSWD: /usr/bin/b\n"
+        )
+        new = "b ALL=(root) NOPASSWD: /usr/bin/b\nc ALL=(root) NOPASSWD: /usr/bin/c\n"
+        diff = diff_sudoers(current, new)
+        assert diff.removed == ["a ALL=(root) NOPASSWD: /usr/bin/a"]
+        assert diff.added == ["c ALL=(root) NOPASSWD: /usr/bin/c"]
+        assert diff.has_changes is True
+
+    def test_identical_files_have_no_changes(self):
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        content = "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        diff = diff_sudoers(content, content)
+        assert diff.added == []
+        assert diff.removed == []
+        assert diff.has_changes is False
+
+    def test_whitespace_only_differences_are_unchanged(self):
+        """Rules differing only in interior whitespace are treated as equal."""
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = "user1  ALL=(root)   NOPASSWD: /usr/bin/foo\n"
+        new = "user1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        diff = diff_sudoers(current, new)
+        assert diff.has_changes is False
+
+    def test_comment_only_differences_are_unchanged(self):
+        """Comment lines do not participate in the diff."""
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = "# old header\nuser1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        new = "# new header\n# extra context\nuser1 ALL=(root) NOPASSWD: /usr/bin/foo\n"
+        diff = diff_sudoers(current, new)
+        assert diff.has_changes is False
+
+    def test_order_preserved_from_source_list(self):
+        from fraisier.scaffold.sudoers_diff import diff_sudoers
+
+        current = "z ALL=(root) NOPASSWD: /a\na ALL=(root) NOPASSWD: /b\n"
+        new = ""
+        diff = diff_sudoers(current, new)
+        # Order of `removed` follows the order in `current`, not sorted.
+        assert diff.removed == [
+            "z ALL=(root) NOPASSWD: /a",
+            "a ALL=(root) NOPASSWD: /b",
+        ]

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.23.1"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `scaffold-install` now diffs `/etc/sudoers.d/<project>` against the rendered sudoers fragment and warns about rules that would be removed (closes #224).
- New `--strict-sudoers` flag exits 3 on any removal or unreadable target — for CI/automation.
- New pure-function module `fraisier.scaffold.sudoers_diff` (10 unit tests).
- Bumps to v0.24.0.

## Why

Operators who added rules to `/etc/sudoers.d/<project>` for non-fraisier components (separate crons, restore scripts, hotfix workarounds) lost them silently the next time `scaffold-install` ran — the install did a plain `install -m 0440` overwrite with no diff, no prompt, no warning. The "do not edit manually" header in the rendered file only helps operators who happen to read it.

This PR keeps the existing contract (fraisier still owns the file) but adds **visibility**: before applying, the operator sees exactly which rules would disappear. The blessed path for keeping a rule is still `sudoers_rules` in `fraises.yaml`.

## Design highlights

- **Single prompt rule.** The existing `Proceed with installation?` confirm covers both the install plan and the sudoers diff. A second prompt was rejected — chaining confirms trains operators to mash `y`.
- **`sudo cat` (not `sudo -n cat`).** The diff read is timed to piggyback on existing sudo invocations: interactive runs warm the timestamp via the preview, `--yes` runs share the install's own prompt. Net password prompts per run: unchanged.
- **Diff still prints in `--yes` / `--dry-run` / `--validate-only`.** `--yes` opts out of the prompt, not out of visibility.
- **`--strict-sudoers` is per-resource.** If/when nginx/systemd get the same treatment, they get sibling flags (`--strict-nginx`). A single `--strict-overwrites` umbrella would be too coarse — these resources have different overwrite semantics.
- **Exit code 3** distinguishes "sudoers removal" from generic `1` and user-abort `2`, so CI can react specifically.
- **Phase 3 (`# fraisier:keep` block preservation) deliberately deferred.** The diff-and-warn alone solves the footgun; the keep-block feature solves a different problem and warrants operator feedback first.

## Wrapper-side only

No edits to `install.sh.j2` — the diff lives in the Python wrapper, where the rest of the safety UX (confirm prompt, error messages) already lives. The bash side is easier to test from Python and the existing confirm prompt is the natural place to gate visibility.

## Test plan

- [x] `uv run pytest tests/test_sudoers_diff.py -q` — 10 passed (pure-function parser/diff coverage: comments, blanks, whitespace normalization, identical, adds, removes, mixed, order preservation).
- [x] `uv run pytest tests/test_scaffold.py::TestScaffoldCLI -q` — 17 passed (7 new integration tests: warning on removed rules, silent on fresh install, silent on identical, non-strict-unreadable warns-and-proceeds, strict-on-diff exits 3, strict-on-unreadable exits 3, `--help` lists the new flag).
- [x] Full unit suite (`--ignore=tests/integration` + known-flake deselected per project memory) — 3706 passed.
- [x] `uv run ruff check` clean on touched files.
- [x] `uv run ruff format --check .` — clean repo-wide.
- [x] `uv run ty check fraisier/cli/scaffold.py fraisier/scaffold/sudoers_diff.py` — clean.

## Note on merge ordering

This PR follows #226 (v0.23.1 / #225). If #226 merges first, this branch rebases trivially (no file overlap on `pyproject.toml` modulo version, and `CHANGELOG.md` has the same insertion point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)