### PR TITLE
chore: #204 closeout — verify rollback chain + post-migration verification docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Most deployment tools get migrations wrong:
 
 **Atomic coordination**: Preflight checks → framework-specific migrations → service restart → health validation → automatic rollback on failure.
 
+**Post-migration verification**: idempotent SQL hooks (`database.post_migrate`) and authenticated `smoke_tests` probes wrap the migrate/restart with a verification layer. See [Post-migration verification](docs/deployment-guide.md#post-migration-verification) in the deployment guide.
+
 **Multi-framework support**: Works with Django, Alembic, Peewee, and Confiture.
 
 ### Who this is for

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -531,6 +531,118 @@ database name) — the SQL is the same.
 
 ---
 
+## Post-migration verification
+
+Fraisier ships two complementary hooks that run after `confiture migrate` and
+before the deployment is reported successful:
+
+| Hook | Runs | Reads | Failure policy |
+|---|---|---|---|
+| `database.post_migrate` | after migrate, before service restart | DB only (no app) | `on_error: halt | warn` |
+| `smoke_tests` | after service restart and `/health` passes | the live HTTP app | `on_failure: rollback | halt | warn` |
+
+The two solve different problems. `post_migrate` is for **schema-side**
+side effects that the migration tool itself doesn't cover (grant
+reconciliation, materialized view refreshes, vendor extension setup).
+`smoke_tests` is for **application-side** behavior that an
+unauthenticated `/health` probe can't reach (authenticated queries,
+permission boundaries, cross-service contracts).
+
+### `database.post_migrate`: SQL hooks after migrate
+
+A list of steps; each step runs exactly one of `sql_dir` (every `.sql`
+file in the directory, sorted) or `sql_file` (a single file) against the
+fraise's `database_url`. Both modes are designed to be idempotent so a
+re-deploy after a partial failure is safe.
+
+```yaml
+database:
+  database_url: !envvar DATABASE_URL
+  strategy: apply
+  post_migrate:
+    - sql_dir: db/7_grant/   # idempotent grant sweep — see below
+      on_error: halt          # default: abort before restart
+    - sql_file: db/post_migrate.sql
+      on_error: warn          # log and continue
+```
+
+**Failure policy**:
+
+- `halt` (default) — raises `DeploymentError` and aborts the deploy *before*
+  the service is restarted. The new code never serves traffic, so no
+  rollback is needed: the old service keeps running on the old commit.
+- `warn` — logs the failure and continues. Use sparingly; this is
+  appropriate for housekeeping (e.g. refresh a stale materialized view)
+  but never for grants the app is about to require.
+
+The canonical use case is **grant reconciliation**: when a confiture
+migration creates a new relation, the app role's grants aren't
+automatically extended. A small idempotent SQL file under `db/7_grant/`
+keeps the app role's privileges in sync with whatever the migration
+introduced.
+
+### `smoke_tests`: authenticated probes after restart
+
+A list of HTTP probes that run against the freshly-deployed service,
+authenticated either via a static `!envvar` header or via a
+`token_provider` block (see [Token providers for authenticated smoke
+tests](#token-providers-for-authenticated-smoke-tests) earlier in this
+guide for the provider catalog).
+
+**Failure policy** — `on_failure:` on each probe:
+
+- `rollback` (default) — invoke `ApiDeployer.rollback()`, which checks
+  out the previous SHA, reverses migrations if reversible, and restarts
+  the service. The deploy returns `status=rolled_back`.
+- `halt` — leave the broken-but-unhealthy revision live. The deploy
+  returns `status=failed`. Use when rollback would itself cause data
+  loss (e.g. an irreversible migration just ran) — the operator
+  investigates while the broken code keeps serving.
+- `warn` — log the failure and let the deploy succeed. Use only for
+  flaky probes whose failures are tolerable.
+
+A token-provider failure (script crash, IdP 401, network error) is
+distinct from a smoke-test failure: it raises `DeploymentError` and
+**halts without rolling back**, since a transient IdP hiccup is not a
+code regression.
+
+### Worked example: post-migrate grants + authenticated smoke
+
+The combined shape — verbatim from `fraises.example.yaml`:
+
+```yaml
+environments:
+  production:
+    database:
+      database_url: !envvar DATABASE_URL
+      strategy: apply
+      backup_before_deploy: true
+      post_migrate:
+        - sql_dir: db/7_grant/
+          on_error: halt
+    health_check:
+      url: https://api.myapp.io/health
+      timeout: 30
+    smoke_tests:
+      - name: authenticated_me
+        method: POST
+        url: /graphql
+        headers:
+          Authorization: !envvar SMOKE_TEST_JWT
+        body: '{"query":"{ me { id role } }"}'
+        on_failure: rollback
+        assert:
+          - { json_path: $.data.me.id, not_null: true }
+          - { json_path: $.data.me.role, equals: admin }
+          - { json_path: $.errors, null: true }
+```
+
+This wires the full chain: migrate → post_migrate grants → restart →
+`/health` poll → authenticated GraphQL probe. Any step's failure
+triggers its declared policy.
+
+---
+
 ## Multi-Environment Setup
 
 A typical setup has staging and production on separate servers. In `fraises.yaml`, assign

--- a/tests/integration/test_smoke_rollback_chain.py
+++ b/tests/integration/test_smoke_rollback_chain.py
@@ -1,0 +1,105 @@
+"""Integration test for the composed smoke-test → rollback chain (#204).
+
+Each piece of the chain — ``smoke_tests.run`` → ``SmokeTestError(rollback=True)``
+→ ``ApiDeployer.rollback()`` → ``_build_rollback_result`` — is exercised by
+unit tests in isolation. This test composes them so that the full
+contract holds end-to-end:
+
+1. ``rollback()`` is invoked exactly once when a smoke test fails with
+   the default ``on_failure: rollback`` policy.
+2. The returned ``DeploymentResult.status`` is ``ROLLED_BACK``.
+3. ``_complete_db_record`` is called with the rolled-back result so the
+   deployment ledger reflects the post-rollback state, not the failed
+   deploy.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fraisier.deployers.api import APIDeployer
+from fraisier.deployers.base import DeploymentResult, DeploymentStatus
+from fraisier.smoke_tests import SmokeTestError
+
+
+def _deployer_with_smoke(smoke):
+    return APIDeployer(
+        {
+            "fraise_name": "myapi",
+            "environment": "production",
+            "app_path": "/srv/myapi",
+            "clone_url": "git@github.com:org/myapi.git",
+            "branch": "main",
+            "systemd_service": "myapi.service",
+            "health_check": {"url": "http://localhost:8000/health", "timeout": 5},
+            "repos_base": "/tmp/repos",
+            "smoke_tests": smoke,
+        }
+    )
+
+
+def test_smoke_failure_with_rollback_policy_completes_chain():
+    """End-to-end: failing smoke → rollback → ROLLED_BACK result recorded."""
+    deployer = _deployer_with_smoke([{"name": "auth", "url": "/me", "assert": []}])
+
+    rollback_inner = DeploymentResult(
+        success=True,
+        status=DeploymentStatus.SUCCESS,
+        new_version="prev-sha",
+    )
+
+    with (
+        patch("fraisier.deployers.mixins.clone_bare_repo"),
+        patch(
+            "fraisier.deployers.mixins.fetch_and_checkout",
+            return_value=("prev-sha", "new-sha"),
+        ),
+        patch.object(deployer, "_restart_service"),
+        patch.object(deployer, "_wait_for_health", return_value=True),
+        patch(
+            "fraisier.smoke_tests.run_smoke_tests",
+            side_effect=SmokeTestError("auth check failed", rollback=True),
+        ),
+        patch.object(deployer, "rollback", return_value=rollback_inner) as mock_rb,
+        patch.object(deployer, "_complete_db_record") as mock_complete,
+    ):
+        result = deployer.execute()
+
+    mock_rb.assert_called_once()
+    assert result.status is DeploymentStatus.ROLLED_BACK
+    assert result.success is False
+
+    assert mock_complete.called, "_complete_db_record was never invoked"
+    recorded_result = mock_complete.call_args.args[1]
+    assert recorded_result is result
+    assert recorded_result.status is DeploymentStatus.ROLLED_BACK
+
+
+def test_smoke_failure_with_halt_policy_skips_rollback_and_records_failed():
+    """Sibling contract: halt policy records FAILED without touching rollback()."""
+    deployer = _deployer_with_smoke(
+        [{"name": "auth", "url": "/me", "on_failure": "halt", "assert": []}]
+    )
+
+    with (
+        patch("fraisier.deployers.mixins.clone_bare_repo"),
+        patch(
+            "fraisier.deployers.mixins.fetch_and_checkout",
+            return_value=("prev-sha", "new-sha"),
+        ),
+        patch.object(deployer, "_restart_service"),
+        patch.object(deployer, "_wait_for_health", return_value=True),
+        patch(
+            "fraisier.smoke_tests.run_smoke_tests",
+            side_effect=SmokeTestError("auth check failed", rollback=False),
+        ),
+        patch.object(deployer, "rollback") as mock_rb,
+        patch.object(deployer, "_complete_db_record") as mock_complete,
+    ):
+        result = deployer.execute()
+
+    mock_rb.assert_not_called()
+    assert result.status is DeploymentStatus.FAILED
+    assert result.success is False
+    recorded_result = mock_complete.call_args.args[1]
+    assert recorded_result.status is DeploymentStatus.FAILED


### PR DESCRIPTION
## Summary
Closes out #204 by locking the composed smoke-test → rollback chain with an end-to-end integration test, and adding a "Post-migration verification" section to the deployment guide that documents `database.post_migrate` and `smoke_tests` side-by-side with their failure policies.

- New `tests/integration/test_smoke_rollback_chain.py` exercises `SmokeTestError(rollback=True)` → `ApiDeployer.rollback()` → `DeploymentResult(status=ROLLED_BACK)` → `_complete_db_record` end-to-end, and adds a sibling test for the `halt` policy contract.
- New "Post-migration verification" section in `docs/deployment-guide.md` covers the `post_migrate` `on_error: halt|warn` matrix and the `smoke_tests` `on_failure: rollback|halt|warn` matrix with a worked example combining both.
- README "Why Fraisier?" gains a one-line pointer to the new doc section.

## Why this is the closeout shape
#204 is substantively shipped across v0.20 – v0.23 (`post_migrate.py`, `smoke_tests.py`, token providers in #215, lazy `!envvar` in #220). What remained was the composed-chain test that proves the pieces work together, plus a user-facing landing page so operators discover the hooks without reading source. Both are in this PR. The static-side counterpart (`confiture drift --check-acls`) is out of scope for fraisier per the issue body and will be filed in the confiture repo when this lands.

## Depends on
[chore: clean ty baseline](https://github.com/fraiseql/fraisier/pull/228) (#228) — merge that first; this PR is branched from it.

## Verification
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest --deselect tests/test_install_helper.py::test_apt_get_install_handles_lock_wait` — 3719 passed, 23 skipped
- [x] `tests/integration/test_smoke_rollback_chain.py` — 2 passed, stable across 3 runs

## Test plan
- [ ] Verify the new doc section renders correctly in the docs site
- [ ] Confirm `tests/test_smoke_tests.py::test_authorization_header_redacted_from_logs` still passes (security gate from finalize-step audit)

## Follow-up after merge
- Post the close-out comment on #204 and close it
- File the `confiture drift --check-acls` follow-up in the confiture repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)