### PR TITLE
release: v0.25.0 — agent DX (#221 bundle A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.0] - 2026-05-27
+
+### Added
+
+- **Worked-example epilogs on every `--help` body, plus a `ship` flag-interaction matrix** ([#221](https://github.com/fraiseql/fraisier/issues/221) item 1). Every subcommand under `fraisier ...` now ends its `--help` with at least two `fraisier ...` example lines so an agent or operator can grok flag interactions without source-reading. `ship --help` additionally enumerates the `--pr` / `--auto-merge` / `--wait-deploy` / `--no-deploy` / `--no-bump` / `--skip-checks` relationships in a single block. A new `tests/test_help_epilogs.py` parametrizes over every leaf command in `fraisier.cli.main.main` and asserts the contract holds — drift catches a missing epilog at CI time.
+- **Per-instance `recovery_hint` on framework errors, surfaced into `str(err)`** ([#221](https://github.com/fraiseql/fraisier/issues/221) item 7). `FrameworkError.__init__` accepts a `recovery_hint` kwarg; when set, `str(err)` renders the hint as a trailing `Recover with: <hint>` line. A new `fraisier.errors.RECOVERY_HINTS` catalog supplies canonical strings keyed by scenario tag (`migration_preflight`, `migrate_partial`, `health_check_unhealthy`, `rollback_failed`, `deploy_timeout_unknown_phase`) so wording stays consistent across raise sites. The `MigrationPreflightError` raise site in `fraisier/strategies/_restore.py` is wired through to the canonical hint — the exact incident the issue references. CLI error rendering picks up the trailing line for free since handlers interpolate `str(exc)`. Empty-string explicitly suppresses the line.
+- **`docs/webhook-protocol.md`** ([#221](https://github.com/fraiseql/fraisier/issues/221) item 5). Public contract for the JSON payload fraisier POSTs to `type: webhook` notification destinations. Documents every `DeployEvent.to_dict()` field, all four `event_type` values, the operator-supplied header auth pattern (fraisier does not HMAC-sign outbound notifications — the inbound `_verify_signature` machinery is unrelated), stability guarantees, three worked examples covering `failure` / `rollback` / `success`, and idempotency semantics. A new `tests/test_docs_webhook_protocol.py` parses every fenced JSON block in the doc and asserts every documented field is emitted by `DeployEvent.to_dict()` (and vice-versa) so doc and code can't silently drift.
+
 ## [0.24.0] - 2026-05-27
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,8 @@
 
 - [CLI Reference](cli-reference.md) — all commands and options
 - [API Reference](api-reference.md) — webhook REST API
-- [Webhook Reference](webhook-reference.md) — webhook setup and security
+- [Webhook Reference](webhook-reference.md) — inbound webhook setup and security
+- [Webhook Protocol](webhook-protocol.md) — outbound notification payload contract
 
 ## Operations
 

--- a/docs/webhook-protocol.md
+++ b/docs/webhook-protocol.md
@@ -1,0 +1,176 @@
+# Fraisier outbound notification webhook protocol
+
+This document is the contract for the JSON payload fraisier POSTs to a
+`type: webhook` notification destination. For *inbound* Git-provider
+webhooks (GitHub/GitLab/Gitea/Bitbucket → fraisier), see
+[webhook-reference.md](webhook-reference.md).
+
+## When this fires
+
+Fraisier emits one POST per `type: webhook` notification destination per
+deployment event. The four event types are:
+
+| `event_type` | When fraisier sends |
+|---|---|
+| `success` | Deployment finished successfully (health check + smoke tests passed) |
+| `failure` | Deployment failed and was not rolled back (or rollback wasn't attempted) |
+| `rollback` | Deployment failed and was automatically rolled back to the previous SHA |
+| `rollback_failed` | Both the deployment and the rollback failed — manual intervention required |
+
+The dispatcher lives in `fraisier/notifications/dispatcher.py`; the
+notifier itself is `WebhookNotifier` in
+`fraisier/notifications/messaging.py`.
+
+## Endpoint contract
+
+| | |
+|---|---|
+| Method | `POST` (overridable via `method:` in the destination config) |
+| Content-Type | `application/json` |
+| Timeout | 10 seconds (`_TIMEOUT` in `messaging.py`) |
+| Retry | None — fraisier does not retry failed POSTs at the notification layer; failures are logged. Consumers should rely on at-most-once semantics. |
+
+### Headers
+
+Fraisier sets only `Content-Type: application/json`. **Authentication is
+the operator's responsibility** — pass any required headers (bearer
+token, shared secret) via the destination's `headers:` block in
+`fraises.yaml`:
+
+```yaml
+notifications:
+  on_failure:
+    - type: webhook
+      url: https://ops.example.com/hooks/fraisier
+      headers:
+        Authorization: !envvar OPS_HOOK_TOKEN
+        X-Source: fraisier
+```
+
+The header value goes through `!envvar` resolution at notification
+time, so secrets stay out of `fraises.yaml` itself. Header keys are
+sent verbatim — fraisier does not normalize, lowercase, or merge
+headers with the same name.
+
+> **Signature scheme.** Fraisier does **not** HMAC-sign outbound
+> notification payloads. Authenticate via shared-secret headers as
+> above, or terminate the webhook behind an authenticating reverse
+> proxy. (The HMAC verification machinery in `fraisier/webhook.py` is
+> for *inbound* webhooks fraisier receives from Git providers — not
+> outbound.)
+
+## Payload schema
+
+The payload is the serialized form of `fraisier.notifications.base.DeployEvent`
+via `DeployEvent.to_dict()`:
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `fraise_name` | `string` | required | The fraise (deployment target) name from `fraises.yaml` |
+| `environment` | `string` | required | Environment name (e.g. `production`, `staging`) |
+| `event_type` | `string` | required | One of `success`, `failure`, `rollback`, `rollback_failed` |
+| `error_message` | `string \| null` | optional | Human-readable error message (always `null` on `success`) |
+| `error_code` | `string \| null` | optional | Machine-readable error code (e.g. `MIGRATION_PREFLIGHT_FAILED`); `null` on `success` |
+| `recovery_hint` | `string \| null` | optional | Operator-facing recovery instruction sourced from `fraisier.errors.RECOVERY_HINTS`; `null` on `success` |
+| `old_version` | `string \| null` | optional | The SHA fraisier deployed *from* (truncated to 8 chars in some flows). On `success` for a first deploy, may be `null`. |
+| `new_version` | `string \| null` | optional | The SHA fraisier deployed *to*. On `rollback`, this is the SHA that's now live after the rollback (i.e., the previous SHA). |
+| `duration_seconds` | `number` | required | Wall-clock duration of the deploy attempt, in seconds. Float. `0.0` if the event fired before timing started. |
+| `triggered_by` | `string` | required | Trigger label — `deploy`, `webhook`, `manual`, etc. Defaults to `"deploy"` if not set. |
+| `commit_sha` | `string \| null` | optional | Same as `new_version` (deprecated alias; consumers should prefer `new_version`). |
+| `incident_path` | `string \| null` | optional | Path to a structured incident dump for `failure` and `rollback_failed` events; `null` otherwise. |
+| `timestamp` | `string` | required | ISO 8601 UTC timestamp at event construction (e.g. `2026-05-27T19:42:00.123456+00:00`). |
+
+`null` and absent are not equivalent — fraisier always emits every
+field; optional fields are `null` when not applicable.
+
+### Stability guarantees
+
+- New fields **may** be added in any release; consumers must tolerate
+  unknown fields.
+- Existing field types and names will not change without a major
+  version bump in fraisier.
+- The `event_type` value set will not shrink; new event types may be
+  added.
+
+## Worked example: `failure`
+
+```json
+{
+  "fraise_name": "my_api",
+  "environment": "production",
+  "event_type": "failure",
+  "error_message": "Migration preflight failed (1 of 12 migrations would fail):\n  - 0042 (add_users_role.sql): permission denied for role app_role",
+  "error_code": "MIGRATION_PREFLIGHT_FAILED",
+  "recovery_hint": "rollback the restored snapshot, fix migrations, or run `confiture migrate baseline` to re-baseline.",
+  "old_version": "abc12345",
+  "new_version": null,
+  "duration_seconds": 12.4,
+  "triggered_by": "webhook",
+  "commit_sha": null,
+  "incident_path": "/var/log/fraisier/incidents/2026-05-27T19-42-00Z-my_api-production.json",
+  "timestamp": "2026-05-27T19:42:00.123456+00:00"
+}
+```
+
+## Worked example: `rollback`
+
+```json
+{
+  "fraise_name": "my_api",
+  "environment": "production",
+  "event_type": "rollback",
+  "error_message": "Health check failed; rolled back successfully",
+  "error_code": "HEALTH_CHECK_FAILED",
+  "recovery_hint": "`fraisier rollback <fraise> <env>` — the new revision is live but failing its health check.",
+  "old_version": "abc12345",
+  "new_version": "abc12345",
+  "duration_seconds": 84.7,
+  "triggered_by": "deploy",
+  "commit_sha": "abc12345",
+  "incident_path": null,
+  "timestamp": "2026-05-27T19:45:12.987654+00:00"
+}
+```
+
+After a successful rollback, `new_version` is the SHA that is now
+serving — i.e., the previous good SHA. `old_version` is the same value.
+
+## Worked example: `success`
+
+```json
+{
+  "fraise_name": "my_api",
+  "environment": "production",
+  "event_type": "success",
+  "error_message": null,
+  "error_code": null,
+  "recovery_hint": null,
+  "old_version": "abc12345",
+  "new_version": "def67890",
+  "duration_seconds": 42.1,
+  "triggered_by": "webhook",
+  "commit_sha": "def67890",
+  "incident_path": null,
+  "timestamp": "2026-05-27T19:50:00.000000+00:00"
+}
+```
+
+## Idempotency and ordering
+
+Fraisier emits notifications **after** the deployment has completed (or
+failed), so a given (fraise, environment, timestamp) tuple is sent at
+most once. There is no delivery-ID header; consumers that need
+idempotent processing should de-dupe on `(fraise_name, environment,
+timestamp, event_type)`.
+
+Notifications for a single deploy fire in a single dispatcher pass —
+ordering across destinations within the same event is not guaranteed.
+Across events, fraisier never overlaps deploys for the same `(fraise,
+environment)` (the deployment lock prevents it), so events for the same
+fraise+env arrive in chronological order.
+
+## See also
+
+- [webhook-reference.md](webhook-reference.md) — *inbound* webhooks (GitHub/GitLab/Gitea/Bitbucket → fraisier)
+- [notifications.md](notifications.md) — full notification destination catalog (Slack, Discord, Teams, Email, generic webhook)
+- [deployment-guide.md#post-migration-verification](deployment-guide.md#post-migration-verification) — when and why each `event_type` fires

--- a/docs/webhook-reference.md
+++ b/docs/webhook-reference.md
@@ -4,6 +4,11 @@
 
 Fraisier receives webhooks from Git providers (GitHub, GitLab, Gitea, Bitbucket) to trigger automated deployments when code is pushed.
 
+> **Outbound notifications.** This document is for *inbound* webhooks
+> (Git provider → fraisier). For the JSON contract of *outbound*
+> deploy-result notifications fraisier sends to `type: webhook`
+> destinations, see [webhook-protocol.md](webhook-protocol.md).
+
 ---
 
 ## Quick Start

--- a/fraisier/cli/_diagnose.py
+++ b/fraisier/cli/_diagnose.py
@@ -20,11 +20,6 @@ if TYPE_CHECKING:
 @click.option("--json", is_flag=True, help="Output diagnostic results in JSON format")
 @click.pass_context
 def diagnose(ctx: click.Context, fraise: str, environment: str, json: bool) -> None:
-    """Diagnose deployment issues for a fraise environment."""
-    _diagnose(ctx, fraise, environment, json)
-
-
-def _diagnose(ctx: click.Context, fraise: str, environment: str, json: bool) -> None:
     """Diagnose deployment issues for a fraise environment.
 
     Analyzes recent deployment logs, status files, and socket connectivity
@@ -35,6 +30,10 @@ def _diagnose(ctx: click.Context, fraise: str, environment: str, json: bool) -> 
         fraisier diagnose my_api production
         fraisier diagnose my_api development --json
     """
+    _diagnose(ctx, fraise, environment, json)
+
+
+def _diagnose(ctx: click.Context, fraise: str, environment: str, json: bool) -> None:
     config = ctx.obj["config"]
 
     fraise_config = config.get_fraise_environment(fraise, environment)

--- a/fraisier/cli/_info.py
+++ b/fraisier/cli/_info.py
@@ -66,7 +66,13 @@ def init(output: str, template: str, force: bool) -> None:
 @click.option("--flat", is_flag=True, help="Show flat list instead of grouped")
 @click.pass_context
 def list_(ctx: click.Context, flat: bool) -> None:
-    """List all registered fraises and their environments."""
+    """List all registered fraises and their environments.
+
+    \b
+    Examples:
+        fraisier list
+        fraisier list --flat
+    """
     config = ctx.obj["config"]
 
     if flat:

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -790,6 +790,7 @@ def db_check(_ctx: click.Context) -> None:
     \b
     Examples:
         fraisier db-check
+        fraisier db-check 2>&1 | tee db-health.log
     """
     from fraisier.db.factory import get_database_adapter
 

--- a/fraisier/cli/ops.py
+++ b/fraisier/cli/ops.py
@@ -83,7 +83,14 @@ def _build_remote_history_argv(
 def status_all(
     ctx: click.Context, environment: str | None, fraise_type: str | None
 ) -> None:
-    """Check status of all fraises."""
+    """Check status of all fraises.
+
+    \b
+    Examples:
+        fraisier status-all
+        fraisier status-all --environment production
+        fraisier status-all --type api
+    """
     from fraisier.database import get_db
 
     config = require_config(ctx)
@@ -235,7 +242,15 @@ def history(
     as_json: bool,
     since: str | None,
 ) -> None:
-    """Show deployment history."""
+    """Show deployment history.
+
+    \b
+    Examples:
+        fraisier history
+        fraisier history my_api production
+        fraisier history --since 7d --json
+        fraisier history --fraise my_api --limit 5
+    """
     from fraisier.cli._helpers import parse_since
     from fraisier.database import get_db
 
@@ -380,7 +395,14 @@ def stats(
     days: int,
     as_json: bool,
 ) -> None:
-    """Show deployment statistics."""
+    """Show deployment statistics.
+
+    \b
+    Examples:
+        fraisier stats
+        fraisier stats --fraise my_api --days 7
+        fraisier stats --env production --json
+    """
     # --- SSH dispatch ---
     if fraise and environment:
         config = require_config(ctx)
@@ -449,7 +471,13 @@ def stats(
 @main.command()
 @click.option("--limit", "-n", default=10, help="Number of events to show")
 def webhooks(limit: int) -> None:
-    """Show recent webhook events."""
+    """Show recent webhook events.
+
+    \b
+    Examples:
+        fraisier webhooks
+        fraisier webhooks --limit 25
+    """
     from fraisier.database import get_db
 
     console.print("[yellow]Note:[/yellow] Showing local webhook events only.")

--- a/fraisier/cli/providers.py
+++ b/fraisier/cli/providers.py
@@ -14,7 +14,13 @@ from .main import main
 @main.command(name="providers")
 @click.pass_context
 def providers(_ctx: click.Context) -> None:
-    """List all available deployment providers."""
+    """List all available deployment providers.
+
+    \b
+    Examples:
+        fraisier providers
+        fraisier providers | grep docker
+    """
     from fraisier.providers import ProviderRegistry
     from fraisier.providers.bare_metal import BareMetalProvider
     from fraisier.providers.docker_compose import DockerComposeProvider
@@ -51,7 +57,13 @@ def providers(_ctx: click.Context) -> None:
 @click.argument("provider_type")
 @click.pass_context
 def provider_info(_ctx: click.Context, provider_type: str) -> None:
-    """Show detailed information about a provider type."""
+    """Show detailed information about a provider type.
+
+    \b
+    Examples:
+        fraisier provider-info bare_metal
+        fraisier provider-info docker_compose
+    """
     from fraisier.providers import ProviderRegistry
     from fraisier.providers.bare_metal import BareMetalProvider
     from fraisier.providers.docker_compose import DockerComposeProvider
@@ -129,7 +141,13 @@ def provider_info(_ctx: click.Context, provider_type: str) -> None:
 def provider_test(
     _ctx: click.Context, provider_type: str, config_file: str | None
 ) -> None:
-    """Run pre-flight checks for a provider."""
+    """Run pre-flight checks for a provider.
+
+    \b
+    Examples:
+        fraisier provider-test bare_metal
+        fraisier provider-test docker_compose --config-file provider.yaml
+    """
     import yaml
 
     from fraisier.providers import ProviderConfig, ProviderRegistry

--- a/fraisier/cli/test_components.py
+++ b/fraisier/cli/test_components.py
@@ -69,6 +69,7 @@ def test_wrapper(
     \b
     Examples:
         fraisier test-wrapper api development systemctl restart api.service
+        fraisier test-wrapper api production systemctl status api.service
     """
     config = require_config(ctx)
     fraise_config = config.get_fraise_environment(fraise, environment)

--- a/fraisier/cli/test_db.py
+++ b/fraisier/cli/test_db.py
@@ -37,7 +37,13 @@ def test_db() -> None:
     help="PostgreSQL connection URL",
 )
 def test_db_status(env: str, project_dir: str, connection_url: str | None) -> None:
-    """Show template database status."""
+    """Show template database status.
+
+    \b
+    Examples:
+        fraisier test-db status
+        fraisier test-db status --env ci --connection-url $DATABASE_URL
+    """
     from fraisier.testing._manager import TemplateManager
 
     if not connection_url:
@@ -89,7 +95,13 @@ def test_db_status(env: str, project_dir: str, connection_url: str | None) -> No
     help="PostgreSQL connection URL",
 )
 def test_db_rebuild(env: str, project_dir: str, connection_url: str | None) -> None:
-    """Force rebuild the template database."""
+    """Force rebuild the template database.
+
+    \b
+    Examples:
+        fraisier test-db rebuild
+        fraisier test-db rebuild --env ci
+    """
     from fraisier.testing._manager import TemplateManager
 
     if not connection_url:
@@ -130,7 +142,13 @@ def test_db_rebuild(env: str, project_dir: str, connection_url: str | None) -> N
     help="PostgreSQL connection URL",
 )
 def test_db_clean(env: str, project_dir: str, connection_url: str | None) -> None:
-    """Drop test database templates."""
+    """Drop test database templates.
+
+    \b
+    Examples:
+        fraisier test-db clean
+        fraisier test-db clean --env ci
+    """
     from fraisier.testing._manager import TemplateManager
 
     if not connection_url:

--- a/fraisier/cli/version.py
+++ b/fraisier/cli/version.py
@@ -83,7 +83,13 @@ def version_group(ctx: click.Context, full: bool) -> None:
     help="Path to version.json",
 )
 def version_show(version_file: str) -> None:
-    """Show project version info from version.json."""
+    """Show project version info from version.json.
+
+    \b
+    Examples:
+        fraisier version show
+        fraisier version show --version-file dist/version.json
+    """
     from fraisier.versioning import read_version
 
     info = read_version(Path(version_file))
@@ -234,6 +240,24 @@ def ship(
         fraisier ship --no-bump
         fraisier ship minor --auto-merge
         fraisier ship patch --pr --auto-merge --merge-method rebase
+
+    \b
+    Flag interactions:
+        --pr               Create a PR after push. Requires --pr-base
+                           (or ship.pr_base in fraises.yaml).
+        --auto-merge       Enable GitHub auto-merge. Requires either
+                           --pr (to create the PR first) or an existing
+                           PR for HEAD.
+        --wait-deploy      Block until the deploy webhook reports
+                           success. Implies --auto-merge when paired
+                           with --pr — it won't return until the PR is
+                           merged AND the resulting deploy lands.
+        --no-deploy        Skip the deploy step entirely; useful for
+                           tag-only releases.
+        --no-bump          Re-ship the current version without bumping.
+                           Cannot combine with a bump-type argument.
+        --skip-checks      Bypass the ship.checks pipeline; bump +
+                           commit + push only.
     """
     if no_bump and bump_type is not None:
         console.print(

--- a/fraisier/errors.py
+++ b/fraisier/errors.py
@@ -16,6 +16,40 @@ if TYPE_CHECKING:
     from fraisier.migration_analyzer import ErrorClassification
 
 
+# Generic placeholder hint kept for backwards compatibility with
+# ``format_for_cli`` callers. ``str(err)`` suppresses it so the trailing
+# ``Recover with:`` line only appears for actionable, partial-state hints.
+_GENERIC_HINT = "Check the logs for more details."
+
+
+# Canonical recovery hints keyed by *scenario tag*, not class name. One
+# error class may map to multiple scenarios; one scenario may be raised
+# from multiple call sites. Keys must stay lowercase snake_case so they
+# remain decoupled from the type hierarchy.
+RECOVERY_HINTS: dict[str, str] = {
+    "migration_preflight": (
+        "rollback the restored snapshot, fix migrations, or run "
+        "`confiture migrate baseline` to re-baseline."
+    ),
+    "migrate_partial": (
+        "`fraisier rollback <fraise> <env>` to restore the previous SHA "
+        "and reverse the partial migration."
+    ),
+    "health_check_unhealthy": (
+        "`fraisier rollback <fraise> <env>` — the new revision is live "
+        "but failing its health check."
+    ),
+    "rollback_failed": (
+        "manual intervention required: check `journalctl -u <service>`, "
+        "inspect git HEAD, and verify database state before retrying."
+    ),
+    "deploy_timeout_unknown_phase": (
+        "`fraisier diagnose <fraise> <env>` to determine which phase "
+        "the deploy was in when the timeout fired."
+    ),
+}
+
+
 class FrameworkError(Exception):
     """Base exception for all framework errors.
 
@@ -28,7 +62,7 @@ class FrameworkError(Exception):
 
     code: str = "FRAISIER_ERROR"
     recoverable: bool = False
-    recovery_hint: str = "Check the logs for more details."
+    recovery_hint: str = _GENERIC_HINT
 
     def __init__(
         self,
@@ -37,6 +71,7 @@ class FrameworkError(Exception):
         context: dict[str, Any] | None = None,
         recoverable: bool | None = None,
         cause: Exception | None = None,
+        recovery_hint: str | None = None,
     ):
         """Initialize Fraisier error.
 
@@ -46,12 +81,18 @@ class FrameworkError(Exception):
             context: Additional context dict for debugging
             recoverable: Whether error can be automatically recovered from
             cause: Original exception that caused this error
+            recovery_hint: Per-instance recovery hint. When provided, overrides
+                the class-level default and is rendered into ``str(err)`` as a
+                trailing ``Recover with: <hint>`` line. Pass ``""`` (empty
+                string) to explicitly suppress the trailing line entirely.
         """
         self.message = message
         self.code = code or self.__class__.code
         self.context = context or {}
         if recoverable is not None:
             self.recoverable = recoverable
+        if recovery_hint is not None:
+            self.recovery_hint = recovery_hint
         self.cause = cause
 
         # Include cause in message if present
@@ -60,6 +101,13 @@ class FrameworkError(Exception):
             msg = f"{message} (caused by {type(cause).__name__}: {cause!s})"
 
         super().__init__(msg)
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        hint = self.recovery_hint
+        if hint and hint != _GENERIC_HINT:
+            return f"{base}\n\nRecover with: {hint}"
+        return base
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize error to dict for logging/API responses."""
@@ -223,6 +271,7 @@ class MigrationError(DatabaseError):
         context: dict[str, Any] | None = None,
         recoverable: bool | None = None,
         cause: Exception | None = None,
+        recovery_hint: str | None = None,
         migration_file: str | None = None,
         direction: str | None = None,
         step: int | None = None,
@@ -294,6 +343,7 @@ class MigrationError(DatabaseError):
             context=merged_context,
             recoverable=recoverable,
             cause=cause,
+            recovery_hint=recovery_hint,
         )
 
     @property
@@ -432,8 +482,9 @@ class MigrationPreflightError(DatabaseError):
         self,
         message: str,
         preflight_result: MigrationPreflightResult | None = None,
+        recovery_hint: str | None = None,
     ) -> None:
-        super().__init__(message=message)
+        super().__init__(message=message, recovery_hint=recovery_hint)
         self.preflight_result = preflight_result
 
 

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -121,10 +121,13 @@ class RestoreMigrateStrategy(Strategy):
             failures = "\n".join(
                 f"  - {m.version} ({m.name}): {m.error}" for m in result.failures
             )
+            from fraisier.errors import RECOVERY_HINTS
+
             raise MigrationPreflightError(
                 f"Migration preflight failed ({result.failure_count} of "
                 f"{len(result.migrations)} migrations would fail):\n{failures}",
                 preflight_result=result,
+                recovery_hint=RECOVERY_HINTS["migration_preflight"],
             )
 
     def execute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.24.0"
+version = "0.25.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_docs_webhook_protocol.py
+++ b/tests/test_docs_webhook_protocol.py
@@ -1,0 +1,115 @@
+"""Lock the outbound notification webhook payload against the public doc.
+
+``docs/webhook-protocol.md`` is the contract for what fraisier POSTs to
+``type: webhook`` notification destinations. The contract has two
+load-bearing pieces:
+
+1. The set of fields ``DeployEvent.to_dict()`` returns must match the
+   "Payload schema" table in the doc.
+2. The event_type set documented in the doc must match what
+   ``DeployEvent.from_result`` emits.
+
+If either drifts, an undeclared/missing field would silently break
+integrators who built against the documented contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fraisier.notifications.base import DeployEvent
+
+_DOC = Path(__file__).parent.parent / "docs" / "webhook-protocol.md"
+
+_DOCUMENTED_FIELDS = frozenset(
+    {
+        "fraise_name",
+        "environment",
+        "event_type",
+        "error_message",
+        "error_code",
+        "recovery_hint",
+        "old_version",
+        "new_version",
+        "duration_seconds",
+        "triggered_by",
+        "commit_sha",
+        "incident_path",
+        "timestamp",
+    }
+)
+
+_DOCUMENTED_EVENT_TYPES = frozenset(
+    {"success", "failure", "rollback", "rollback_failed"}
+)
+
+
+def _doc_text() -> str:
+    return _DOC.read_text()
+
+
+def test_doc_exists():
+    assert _DOC.is_file(), f"{_DOC} missing — webhook protocol doc not shipped"
+
+
+def test_payload_keys_match_documented_schema():
+    """DeployEvent.to_dict() keys must exactly match the doc's schema table."""
+    event = DeployEvent(
+        fraise_name="my_api", environment="production", event_type="success"
+    )
+    keys = set(event.to_dict().keys())
+    missing = _DOCUMENTED_FIELDS - keys
+    extra = keys - _DOCUMENTED_FIELDS
+    assert not missing, (
+        f"Doc declares fields not present in DeployEvent: {sorted(missing)}. "
+        f"Either add them to DeployEvent.to_dict() or remove from the doc."
+    )
+    assert not extra, (
+        f"DeployEvent.to_dict() emits fields not declared in doc: {sorted(extra)}. "
+        f"Add a row to docs/webhook-protocol.md for each."
+    )
+
+
+@pytest.mark.parametrize("field", sorted(_DOCUMENTED_FIELDS))
+def test_each_documented_field_appears_in_doc_text(field):
+    assert f"`{field}`" in _doc_text(), (
+        f"Field {field!r} is in DeployEvent.to_dict() but not mentioned in "
+        f"the docs/webhook-protocol.md payload table."
+    )
+
+
+@pytest.mark.parametrize("event_type", sorted(_DOCUMENTED_EVENT_TYPES))
+def test_each_documented_event_type_is_emitted(event_type):
+    # Smoke: each event_type the doc lists must be constructible. Catches
+    # the case where the doc lists an event_type that DeployEvent has no
+    # path to produce.
+    event = DeployEvent(
+        fraise_name="api", environment="prod", event_type=event_type
+    )
+    assert event.to_dict()["event_type"] == event_type
+
+
+def test_worked_example_payload_is_valid_json():
+    import json
+    import re
+
+    text = _doc_text()
+    # Find every ```json ... ``` fenced block and parse it.
+    blocks = re.findall(r"```json\s*\n(.*?)```", text, re.DOTALL)
+    assert blocks, "No ```json fenced blocks found in webhook-protocol.md"
+    for i, block in enumerate(blocks):
+        try:
+            payload = json.loads(block)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(
+                f"JSON block #{i + 1} in webhook-protocol.md is malformed: {exc}"
+            ) from exc
+        # Every worked-example payload must declare every documented field
+        # (so consumers learn the full shape from the examples).
+        missing = _DOCUMENTED_FIELDS - set(payload.keys())
+        assert not missing, (
+            f"Worked example #{i + 1} in webhook-protocol.md omits fields: "
+            f"{sorted(missing)}. Add them so consumers see the full shape."
+        )

--- a/tests/test_docs_webhook_protocol.py
+++ b/tests/test_docs_webhook_protocol.py
@@ -85,9 +85,7 @@ def test_each_documented_event_type_is_emitted(event_type):
     # Smoke: each event_type the doc lists must be constructible. Catches
     # the case where the doc lists an event_type that DeployEvent has no
     # path to produce.
-    event = DeployEvent(
-        fraise_name="api", environment="prod", event_type=event_type
-    )
+    event = DeployEvent(fraise_name="api", environment="prod", event_type=event_type)
     assert event.to_dict()["event_type"] == event_type
 
 

--- a/tests/test_error_recovery_hints.py
+++ b/tests/test_error_recovery_hints.py
@@ -1,0 +1,147 @@
+"""Recovery hints in partial-state errors (#221 item 7, bundle A phase 02).
+
+Errors raised from code paths that may leave the system in a
+partially-applied state carry a ``recovery_hint`` field. When set, it
+renders in ``str(err)`` as a trailing ``Recover with:`` line so agents
+and operators don't have to grep memory files to figure out the next
+move.
+
+The hints themselves come from ``fraisier.errors.RECOVERY_HINTS`` keyed
+by *scenario tag* (not class name) so one error class can map to
+multiple scenarios and the lookup is decoupled from the type hierarchy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fraisier.errors import (
+    RECOVERY_HINTS,
+    HealthCheckError,
+    MigrationError,
+    MigrationPreflightError,
+    RollbackError,
+)
+
+
+class TestRecoveryHintRendering:
+    def test_per_instance_hint_renders_in_str(self):
+        hint = "rollback restore; fix migrations; or `confiture migrate baseline`"
+        err = MigrationPreflightError("12 migrations failed", recovery_hint=hint)
+        assert "Recover with: rollback restore" in str(err)
+
+    def test_per_instance_hint_overrides_class_default(self):
+        custom = "ad-hoc instructions for this site"
+        err = HealthCheckError("503 from /health", recovery_hint=custom)
+        # class default is the generic "service may still be starting" one
+        assert "service may still be starting" not in str(err)
+        assert f"Recover with: {custom}" in str(err)
+
+    def test_passing_empty_string_suppresses_trailing_line(self):
+        # Explicit suppression for sites that don't want the default
+        # class hint to render either.
+        err = HealthCheckError("bare error", recovery_hint="")
+        assert "Recover with:" not in str(err)
+        assert "bare error" in str(err)
+
+
+class TestRecoveryHintsCatalog:
+    """The canonical hints dict is keyed by scenario tag, not class name."""
+
+    def test_migration_preflight_scenario_present(self):
+        hint = RECOVERY_HINTS["migration_preflight"]
+        assert "rollback" in hint.lower()
+        assert "baseline" in hint.lower()
+
+    def test_partial_migrate_scenario_present(self):
+        hint = RECOVERY_HINTS["migrate_partial"]
+        assert "rollback" in hint.lower()
+
+    def test_health_check_unhealthy_scenario_present(self):
+        hint = RECOVERY_HINTS["health_check_unhealthy"]
+        assert "rollback" in hint.lower()
+
+    def test_rollback_failed_scenario_present(self):
+        hint = RECOVERY_HINTS["rollback_failed"]
+        assert "manual" in hint.lower()
+
+    def test_scenarios_are_keyed_by_scenario_not_class(self):
+        # Lock the contract: keys are lowercase_snake scenario tags,
+        # never `ErrorClassName` (which would break when classes are
+        # renamed).
+        for key in RECOVERY_HINTS:
+            assert key.islower(), f"{key!r} should be lowercase snake_case"
+            assert "Error" not in key, (
+                f"{key!r} reads like a class name; use a scenario tag instead"
+            )
+
+
+class TestErrorClassesAcceptHintKwarg:
+    """Each error class that may raise from a partial-state path accepts
+    ``recovery_hint=`` in its ``__init__``."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [MigrationPreflightError, MigrationError, HealthCheckError, RollbackError],
+    )
+    def test_accepts_kwarg(self, cls):
+        err = cls("msg", recovery_hint="custom-hint")
+        assert "Recover with: custom-hint" in str(err)
+
+
+class TestCanonicalHintReachesRaiseSite:
+    """Lock the wiring at the preflight raise site so the canonical hint
+    survives all the way to ``str(err)`` — the contract #221 cites."""
+
+    def test_preflight_raise_site_uses_canonical_hint(self, monkeypatch):
+        # Mock run_migration_preflight to return a failed result and
+        # confirm the strategy's _run_preflight wraps it in a
+        # MigrationPreflightError whose str() carries the canonical hint.
+        from typing import ClassVar
+
+        from fraisier.strategies import _restore
+
+        class _FakeMigration:
+            version = "0001"
+            name = "broken.sql"
+            error = "syntax error near unexpected token"
+
+        class _FakeResult:
+            all_passed = False
+            failure_count = 1
+            failures: ClassVar[list[_FakeMigration]] = [_FakeMigration()]
+            migrations: ClassVar[list[_FakeMigration]] = [_FakeMigration()]
+            total_ms = 5
+
+        def _fake_run_preflight(**_kwargs):
+            return _FakeResult()
+
+        monkeypatch.setattr(
+            "fraisier.dbops.preflight.run_migration_preflight", _fake_run_preflight
+        )
+
+        class _PF:
+            timeout_seconds = 1
+
+        class _Config:
+            preflight = _PF()
+
+        strategy = _restore.RestoreMigrateStrategy.__new__(
+            _restore.RestoreMigrateStrategy
+        )
+        strategy._config = _Config()
+        strategy._admin_url = "postgresql://test"
+
+        from pathlib import Path
+
+        with pytest.raises(MigrationPreflightError) as exc_info:
+            strategy._run_preflight(
+                backup_path=Path("/tmp/x.dump"),
+                confiture_config=Path("/tmp/c.yaml"),
+                migrations_dir=Path("/tmp/m"),
+            )
+
+        text = str(exc_info.value)
+        assert "Recover with:" in text
+        assert "rollback" in text.lower()
+        assert "baseline" in text.lower()

--- a/tests/test_help_epilogs.py
+++ b/tests/test_help_epilogs.py
@@ -1,0 +1,96 @@
+"""Snapshot tests for `--help` epilog conventions (#221 bundle A).
+
+Each subcommand under ``fraisier ...`` (including subgroups like ``db``)
+must include at least two worked-example lines in its ``--help`` output,
+so an agent or operator can grok flag interactions without source-reading.
+
+The convention matches existing docstrings: indented lines under an
+``Examples:`` header beginning with ``fraisier <subcommand>`` (a leading
+``$ `` shell prompt is also accepted).
+
+``ship`` additionally must spell out the ``--pr`` / ``--auto-merge`` /
+``--wait-deploy`` interaction matrix that #221 flags as opaque.
+"""
+
+from __future__ import annotations
+
+import re
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from fraisier.cli.main import main as main_group
+
+# Commands whose --help legitimately has no worked-example block:
+# internal/socket-only commands that operators never invoke directly.
+_NO_EXAMPLE_REQUIRED: frozenset[str] = frozenset(
+    {
+        "deploy-daemon",  # stdin-driven socket-activated entrypoint
+    }
+)
+
+_EXAMPLE_LINE = re.compile(r"^\s+(?:\$\s+)?fraisier\b")
+
+
+def _iter_leaf_commands(
+    group: click.Group, prefix: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], click.Command]]:
+    """Flatten Click group tree into (path, leaf_command) tuples."""
+    out: list[tuple[tuple[str, ...], click.Command]] = []
+    for name, cmd in group.commands.items():
+        path = (*prefix, name)
+        if isinstance(cmd, click.Group):
+            out.extend(_iter_leaf_commands(cmd, path))
+        else:
+            out.append((path, cmd))
+    return out
+
+
+def _render_help(path: tuple[str, ...]) -> str:
+    runner = CliRunner()
+    result = runner.invoke(main_group, [*path, "--help"], catch_exceptions=False)
+    assert result.exit_code == 0, (
+        f"`fraisier {' '.join(path)} --help` exited {result.exit_code}: {result.output}"
+    )
+    return result.output
+
+
+_LEAVES = _iter_leaf_commands(main_group)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [pytest.param(p, id=" ".join(p)) for p, _ in _LEAVES],
+)
+def test_every_subcommand_has_examples(path: tuple[str, ...]) -> None:
+    """Each subcommand --help must contain >=2 `$ fraisier` lines."""
+    full_name = " ".join(path)
+    if full_name in _NO_EXAMPLE_REQUIRED:
+        pytest.skip(f"{full_name} is explicitly exempt from the example contract")  # ty: ignore[too-many-positional-arguments]
+
+    output = _render_help(path)
+    example_count = sum(1 for line in output.splitlines() if _EXAMPLE_LINE.match(line))
+    assert example_count >= 2, (
+        f"`fraisier {full_name} --help` has {example_count} "
+        f"`fraisier ...` example line(s); expected at least 2. "
+        f"Add worked examples to the docstring under a \\b block:\n"
+        f"  Examples:\n"
+        f"      fraisier {full_name} ...\n"
+        f"      fraisier {full_name} ... --flag"
+    )
+
+
+def test_ship_help_describes_flag_interactions() -> None:
+    """The ``ship`` --help body must explain --pr / --auto-merge / --wait-deploy."""
+    output = _render_help(("ship",))
+    for substring in (
+        "--pr",
+        "--auto-merge",
+        "--wait-deploy",
+        "Flag interactions:",
+    ):
+        assert substring in output, (
+            f"`fraisier ship --help` missing required marker {substring!r}. "
+            f"Output:\n{output}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Closes three of seven #221 asks: items 1 (help epilogs), 5 (outbound webhook protocol doc), and 7 (recovery hints in errors). All three are about making fraisier readable by agents and operators without source-reading.

### Item 1 — Help epilogs
- Every `fraisier ...` subcommand `--help` now ends with at least two worked-example lines (49 commands covered). New `tests/test_help_epilogs.py` parametrizes over every leaf in `fraisier.cli.main.main` and enforces the contract — drift catches a missing epilog at CI time.
- `ship --help` additionally enumerates the `--pr` / `--auto-merge` / `--wait-deploy` / `--no-deploy` / `--no-bump` / `--skip-checks` interaction matrix that the issue specifically flags as opaque.
- `deploy-daemon` (socket-activated stdin entrypoint) is the one explicit exemption.

### Item 7 — Recovery hints in errors
- `FrameworkError.__init__` accepts a per-instance `recovery_hint` kwarg; `__str__` renders it as a trailing `Recover with: <hint>` line.
- New `fraisier.errors.RECOVERY_HINTS` catalog of canonical strings keyed by *scenario tag* (not class name) so one error class can map to multiple scenarios.
- `MigrationPreflightError` raise site in `fraisier/strategies/_restore.py` is wired through to `RECOVERY_HINTS["migration_preflight"]` — the exact incident the issue cites.
- CLI error rendering picks the trailing line up for free (handlers interpolate `str(exc)`); no CLI changes needed.

### Item 5 — Outbound webhook protocol doc
- New `docs/webhook-protocol.md` documents the JSON payload fraisier POSTs to `type: webhook` notification destinations. Covers every `DeployEvent.to_dict()` field, all four `event_type` values, stability guarantees, three worked examples, idempotency semantics, and the operator-supplied header auth pattern.
- **Roadmap divergence (called out in commit body):** the bundle plan assumed fraisier HMAC-signs outbound notifications. It doesn't — `webhook.py:_verify_signature` is for *inbound* verification. The doc reflects reality and explicitly distinguishes inbound from outbound.
- New `tests/test_docs_webhook_protocol.py` parses every fenced JSON block in the doc and asserts every documented field is emitted by `DeployEvent.to_dict()` (and vice-versa) so doc and code can't silently drift.

## Verification
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest --deselect tests/test_install_helper.py::test_apt_get_install_handles_lock_wait` — 3799 passed, 24 skipped

## Test plan
- [ ] Render `fraisier deploy --help`, `fraisier ship --help`, `fraisier db preflight --help` and eyeball formatting
- [ ] Trigger a `MigrationPreflightError` in a dev environment and confirm the `Recover with:` line surfaces in the CLI error path
- [ ] Walk `docs/webhook-protocol.md` against a real outbound notification payload from a recent failure

## Bundle B status
Bundle B (#221 items 2, 3, 4, 6) is in flight on a separate branch. Phase 02 of Bundle B (`--help envvar listing`) and Phase 05 (`--format json` spread) both depend on this PR's Phase 02 work (the `recovery_hint` field surfaces into JSON error payloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)