### PR TITLE
release: v0.27.1 — bring-your-own release-please docs + --wait-deploy honesty note (#234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-05-29
+
+### Added
+
+- **Documented "bring-your-own batched releases" workflow** ([#234](https://github.com/fraiseql/fraisier/issues/234)). New [`docs/release-strategies.md`](docs/release-strategies.md) explains how to pair fraisier with [release-please](https://github.com/googleapis/release-please) (or any equivalent batcher) so feature PRs land code only via `fraisier ship --no-bump`, and a single release PR accumulates the version bump and CHANGELOG. Includes a working release-please GitHub Actions example, a trade-off table against the default per-PR workflow, and notes on how `--wait-deploy` and `fraisier sync` behave in each. No `release_strategy` yaml field is added; the design memo for that proposal (#234) is summarised in the doc page itself — the existing `--no-bump` flag plus a release-please workflow file is sufficient, and committing the schema surface is premature without adoption data.
+- **`fraisier ship --no-bump --wait-deploy` now prints an explanatory note** before the health poll: `--no-bump: no version change — polling vX.Y.Z to confirm the current redeploy stays healthy. A later release-PR merge (if any) produces a separate deploy.` Operators running a bring-your-own release-please workflow could otherwise mistake the immediate health-poll success for the release-PR-triggered deploy they were expecting; the note makes the semantics explicit. `_trigger_deploy_for_current_branch` gained a keyword-only `no_bump` parameter; default `False` preserves the per-PR path's output verbatim.
+
 ## [0.27.0] - 2026-05-28
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@
 ## Operations
 
 - [Deployment Guide](deployment-guide.md) — production setup
+- [Release Strategies](release-strategies.md) — per-PR (default) vs bring-your-own batched (release-please)
 - [Doctor](doctor.md) — `fraisier doctor` host-wide health checks
 - [Testing](testing.md)
 

--- a/docs/release-strategies.md
+++ b/docs/release-strategies.md
@@ -1,0 +1,208 @@
+# Release Strategies
+
+Fraisier supports two release-cadence workflows out of the box. There is no
+config flag to pick between them — the difference is purely in how you invoke
+`fraisier ship` and (optionally) what other tooling you wire alongside it.
+
+## At a glance
+
+| | Per-PR releases (default) | Bring-your-own batched (release-please) |
+|---|---|---|
+| Each shipped PR bumps the version | yes | no |
+| Changelog cadence | one entry per shipped PR | one entry per release-PR merge |
+| Webhook deploy fires on | every merged PR (version changes) | release-PR merge (version changes) |
+| Tooling needed | none beyond fraisier | release-please workflow on the release branch |
+| `fraisier ship` invocation | `fraisier ship patch \| minor \| major` | `fraisier ship --no-bump` |
+| Best when | small team, fast cadence, every PR is shippable | many small PRs per release, you want one cohesive changelog entry |
+
+Both workflows use the same webhook, the same health checks, the same
+restore strategies, the same `fraisier sync`. The difference is only who
+owns the version bump and when it lands.
+
+---
+
+## Default: per-PR releases
+
+This is fraisier's out-of-the-box behavior. Every shipped PR contains the
+code change *and* a version bump. The merge triggers the webhook, the
+webhook deploys, every PR is its own release.
+
+```bash
+# After committing your code change on a feature branch:
+fraisier ship patch
+```
+
+`fraisier ship` runs your check pipeline, bumps `pyproject.toml`, commits
+the bump, pushes, optionally opens a PR with auto-merge. The merged version
+bump triggers the deploy.
+
+No additional tooling required.
+
+### When this works well
+
+- You ship small, frequent PRs and each one is a sensible "release."
+- You don't mind a CHANGELOG with one entry per PR.
+- You'd rather have N small reverts than one big one when something breaks.
+
+### Where it strains
+
+- Many tiny PRs land in close succession, producing changelog noise.
+- Two operators run `fraisier ship` concurrently from the same base —
+  both compute the same next version, the second silently produces a
+  duplicate-version PR. (As of v0.27.0 fraisier detects this case at push
+  time and refuses to push; see [#232](https://github.com/fraiseql/fraisier/issues/232).)
+
+Many fraisier users address the second strain by **bundling**: open a
+single PR that lands several fixes together with one version bump
+(`release: vX.Y.Z — desc (#N, #M)`). That's a human-driven batched
+workflow already; the bring-your-own option below automates the same idea.
+
+---
+
+## Bring-your-own batched releases (release-please)
+
+If you want one CHANGELOG entry per release rather than one per merged
+code change, run [release-please](https://github.com/googleapis/release-please)
+alongside fraisier. The split is clean:
+
+- **Feature PRs** land code only — no version bump.
+  Use `fraisier ship --no-bump`. The webhook does not fire on these
+  merges (no version change to detect), so no deploy happens at
+  feature-PR merge time.
+- **release-please** maintains a single open "release PR" on your release
+  branch. It accumulates the next version bump and a generated CHANGELOG
+  section based on the conventional commits since the last release.
+- **When the release PR merges**, the version bump lands, the webhook
+  fires, fraisier deploys.
+
+Fraisier does not need to know which mode you're in. `--no-bump` is a
+pre-existing flag; you simply use it on every ship.
+
+### Example release-please workflow
+
+Drop this into `.github/workflows/release-please.yml` in your application
+repo (adjust `release-type` and `target-branch` to match your setup):
+
+```yaml
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: python
+          target-branch: main
+          # release-please writes pyproject.toml; fraisier's webhook
+          # picks the version change up automatically.
+```
+
+Per-fraise conventions to keep in mind:
+
+- Write conventional commits (`feat:`, `fix:`, `chore:` …) on your feature
+  PRs. release-please reads these to decide patch/minor/major.
+- Your feature PRs target the same `target-branch` as release-please.
+- `fraisier ship --no-bump` on every feature PR.
+
+### When this works well
+
+- You ship many small PRs per release and the per-PR changelog feels noisy.
+- You want a single PR to land all the changes that constitute a release
+  (easier to revert as a group, easier to release-note).
+- You're already using conventional commits.
+
+### Where it strains
+
+- Hotfixes have a slower path: either you cut a release PR by hand for the
+  one fix, or you temporarily run `fraisier ship patch` to bypass the
+  batched workflow for one PR. The latter is a footgun (release-please
+  reconciles it on the next release PR, but the bump is now out of
+  sequence with the batched CHANGELOG).
+- Rollback semantics: rolling back to the previous version reverts a
+  *batch* of code changes, not a single PR.
+
+---
+
+## Interaction with `--wait-deploy`
+
+`fraisier ship --wait-deploy` polls your health endpoint after the deploy.
+Behavior differs by workflow:
+
+**Per-PR**: polls for the bumped version. When the deployed service
+reports the new version, the poll succeeds.
+
+**Bring-your-own batched** (`--no-bump --wait-deploy`): the deployer still
+runs (the working tree is redeployed), but no version label changed.
+fraisier prints an explicit note:
+
+```
+--no-bump: no version change — polling v1.2.3 to confirm the current
+redeploy stays healthy. A later release-PR merge (if any) produces a
+separate deploy.
+```
+
+The poll then verifies that the redeployed service continues to answer
+healthily at its existing version. If you were expecting the wait to
+block until release-please's PR merges and produces a *new* deploy, it
+won't — that deploy happens separately when its PR merges.
+
+---
+
+## Interaction with `fraisier sync`
+
+`fraisier sync` propagates changes between environment branches
+(typically `dev → staging → main`). It auto-resolves a small set of
+fraisier-owned files (`pyproject.toml`, `version.json`, `uv.lock`,
+`.secrets.baseline`, `fraises.yaml`, `scripts/generated`) by taking the
+source branch's version on conflict.
+
+Under both workflows this is the right behavior in practice:
+
+- **Per-PR**: the source branch always contains the freshest bump.
+  Auto-resolving from source moves the bump forward.
+- **Bring-your-own batched**: source-side feature PRs don't modify
+  `pyproject.toml` at all. When you sync the bumped release-PR-merged
+  state from target back into source's history, three-way merge
+  semantics handle it without ever entering the auto-resolve path
+  (git keeps the target-side bump because source didn't touch the file).
+
+If you do hit a divergent both-bumped case (rare; typically caused by
+direct hotfix bumps on the target branch), the sync auto-resolve takes
+source. Inspect the resulting sync PR before merging.
+
+---
+
+## Switching workflows
+
+Switching is a one-time operation, not a config flag:
+
+**Per-PR → bring-your-own batched.** Land any in-flight `fraisier ship`
+PRs first, then merge a release-please workflow file. From the next
+feature PR onwards, use `fraisier ship --no-bump`.
+
+**Bring-your-own → per-PR.** Disable or delete the release-please
+workflow. Resume using `fraisier ship patch | minor | major` directly.
+The next bump will be computed against the current `pyproject.toml`
+version, so any release-please-managed version stays the floor.
+
+---
+
+## Why no `release_strategy` config field
+
+Fraisier deliberately does not gate this on a `release_strategy` yaml
+field. The two workflows are distinguishable by ship invocation
+(`patch|minor|major` vs `--no-bump`) and by whether you've wired up
+release-please. Adding a config knob would commit a public-API surface
+to a distinction that the existing flags already express. See
+the [#234 design memo](https://github.com/fraiseql/fraisier/issues/234)
+for the longer reasoning.

--- a/fraisier/cli/version.py
+++ b/fraisier/cli/version.py
@@ -434,7 +434,9 @@ def _ship_commit_push_deploy(
     console.print(f"[green]Shipped {label}[/green]")
 
     if not no_deploy:
-        _trigger_deploy_for_current_branch(wait_deploy, deploy_timeout)
+        _trigger_deploy_for_current_branch(
+            wait_deploy, deploy_timeout, no_bump=bump_kind is None
+        )
 
 
 def _read_current_version(pyproject_path: Path) -> str:
@@ -853,7 +855,10 @@ def _resolve_bare_repo_skip() -> Path | None:
 
 
 def _trigger_deploy_for_current_branch(
-    wait_deploy: bool = False, deploy_timeout: int = 300
+    wait_deploy: bool = False,
+    deploy_timeout: int = 300,
+    *,
+    no_bump: bool = False,
 ) -> None:
     """Deploy all fraises mapped to the current git branch."""
     import subprocess as sp
@@ -935,6 +940,17 @@ def _trigger_deploy_for_current_branch(
             health_config = fraise_config.get("health_check")
             if health_config and "url" in health_config:
                 health_url = health_config["url"]
+                if no_bump:
+                    # Operators running a bring-your-own release-please workflow
+                    # can mistake the immediate-success health poll for the
+                    # release-PR-triggered deploy they were expecting. Be
+                    # explicit: this wait is for the current redeploy only.
+                    console.print(
+                        f"[cyan]--no-bump: no version change — polling "
+                        f"v{result.new_version} to confirm the current "
+                        f"redeploy stays healthy. A later release-PR merge "
+                        f"(if any) produces a separate deploy.[/cyan]"
+                    )
                 console.print(f"[cyan]Verifying deployment at {health_url}...[/cyan]")
 
                 from fraisier.ship.health_poll import poll_health_for_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.27.0"
+version = "0.27.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -978,6 +978,73 @@ class TestShipDeploy:
         # Should show health verification
         assert "Verifying deployment" in result.output
 
+    @patch(
+        "fraisier.locking.deployment_lock",
+        return_value=contextlib.nullcontext(),
+    )
+    @patch("fraisier.ship.health_poll.poll_health_for_version")
+    @patch("fraisier.cli._helpers._get_deployer")
+    @patch("subprocess.run")
+    def test_ship_no_bump_wait_deploy_prints_unchanged_version_note(
+        self, mock_run, mock_get_deployer, mock_poll, _mock_lock, tmp_path
+    ):
+        """ship --no-bump --wait-deploy clarifies that polling is for the
+        re-deployed (unchanged) version, not a future release-PR deploy.
+
+        Without the note, an operator using a bring-your-own release-please
+        workflow could mistake the immediate health-poll success for the
+        release-PR deploy they were expecting. See #234 design memo (§5).
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="main")
+        cfg = _setup_project(tmp_path, "1.0.0")
+
+        # Wire health_check + branch mapping so the deploy path runs.
+        fraises_file = tmp_path / "fraises.yaml"
+        config_data = yaml.safe_load(fraises_file.read_text())
+        config_data["fraises"]["my_api"]["environments"]["production"][
+            "health_check"
+        ] = {"url": "http://example.com/health"}
+        config_data["branch_mapping"] = {
+            "main": {"fraise": "my_api", "environment": "production"}
+        }
+        fraises_file.write_text(yaml.dump(config_data))
+
+        # Deployer returns equal old/new — that's the --no-bump invariant.
+        mock_deployer = MagicMock()
+        mock_deployer.execute.return_value = MagicMock(
+            success=True, old_version="1.0.0", new_version="1.0.0"
+        )
+        mock_get_deployer.return_value = mock_deployer
+
+        mock_poll.return_value = MagicMock(
+            success=True, final_version="1.0.0", elapsed_seconds=0.1
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "-c",
+                cfg,
+                "ship",
+                "--no-bump",
+                "--wait-deploy",
+                "--pyproject",
+                str(tmp_path / "pyproject.toml"),
+            ],
+        )
+
+        assert result.exit_code == 0
+        # The honesty note: must mention no-bump context AND that this is
+        # the current redeploy, not a future release-PR deploy.
+        assert "no version change" in result.output.lower()
+        assert "release" in result.output.lower()
+        # And it must precede the standard "Verifying deployment" line so
+        # the operator reads the explanation first.
+        assert result.output.lower().index("no version change") < result.output.index(
+            "Verifying deployment"
+        )
+
     @patch("subprocess.run")
     def test_ship_skips_deploy_when_bare_repo_missing(self, mock_run, tmp_path):
         """ship skips local deploy gracefully when bare repo does not exist."""

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Context

Issue #234 proposed a `release_strategy: per_pr | batched_external | batched_internal` yaml field. The design review concluded the schema commitment is premature: the two structural concerns the issue cites — version races and per-PR changelog noise — are already addressed by v0.27.0 (#232) and by the maintainer's de-facto bundled `release: vX.Y.Z — desc (#N, #M)` PR practice respectively. The "per-PR-as-release" identity claim is empirically softer than the issue assumes; recent releases (`v0.26.1 (#233, #235)`, `v0.16.6 (#152, #161, #164)`, `v0.25.0/v0.26.0 #221 bundles`) already batch multiple issues per release.

This PR ships the smaller "outsource + document" path from the memo. It does not close #234 — that's left to the maintainer.

## Summary

- **New `docs/release-strategies.md`** — side-by-side comparison of the per-PR (default) workflow and a bring-your-own release-please workflow that uses the pre-existing `fraisier ship --no-bump` flag. Includes a working `release-please-action` v4 GitHub Actions example, a trade-off table, and explicit sections on how `--wait-deploy` and `fraisier sync` behave under each. Linked from `docs/index.md` under Operations.
- **`fraisier ship --no-bump --wait-deploy` honesty note** — before the health poll, ship now prints `--no-bump: no version change — polling vX.Y.Z to confirm the current redeploy stays healthy. A later release-PR merge (if any) produces a separate deploy.` Without it, an operator running a release-please workflow could mistake the immediate-success poll for the release-PR-driven deploy they were waiting for. `_trigger_deploy_for_current_branch` gained a keyword-only `no_bump` parameter; default `False` preserves the per-PR path's output verbatim.
- **No `release_strategy` yaml field.** The memo's reasoning: distinguishing the two workflows by `ship` invocation (`patch|minor|major` vs `--no-bump`) is sufficient, and committing public-API surface ahead of adoption data is the more expensive direction to revert. See the doc page's last section for the operator-facing summary of why.
- **No conventional-commit parser (`batched_internal`).** Out of scope per memo; release-please owns that capability.

## What I considered and dropped

The memo also proposed a defensive guard in `fraisier sync`: skip auto-resolve of `pyproject.toml`/`version.json`/`uv.lock` when the source side didn't modify them since merge-base. On closer reading of the resolver, that branch only runs on files git marks as `UU` (both sides modified), and three-way merge semantics never reach the resolver in the source-unchanged-target-changed case. The proposed check would be unreachable code. Dropped before any of it was written — see commit message for the trace.

## Test plan

- [x] `uv run pytest tests/test_ship.py tests/test_version.py tests/test_sync.py` — 171 passed
- [x] `uv run pytest --ignore=tests/test_install_helper.py --ignore=tests/test_e2e_deployments.py` — 3855 passed, 7 skipped (install_helper deselected per known flake)
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check fraisier/ tests/test_ship.py` — clean
- [x] `uv run ty check fraisier/cli/version.py` — clean
- [x] CHANGELOG entry under 0.27.1 with linked context
- [ ] Manual: verify `--no-bump --wait-deploy` note renders correctly with a real fraise (not exercised in CI; the test asserts on captured output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)