### PR TITLE
release: v0.32.0 — fraisier/* branch namespace + orphan sync branch reclaim (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2026-05-30
+
+### Fixed
+
+- **`fraisier sync` no longer aborts when a prior squash-merged PR left an orphan remote head branch behind** ([#248](https://github.com/fraiseql/fraisier/issues/248)). When a prior sync PR was squash-merged without `--delete-branch` (the GitHub Web UI default and the natural shape of `gh pr merge --auto --squash`), the remote head branch kept its pre-squash commits. The next sync run created a fresh local branch from `origin/<source>`, tried to push, and was rejected with `! [rejected] (fetch first)` — the whole sync aborted with `subprocess.CalledProcessError` and the operator had to `git push origin --delete <branch>` by hand and re-run. The push path now runs through a new `_push_sync_branch(...)` helper that pre-flights the orphan check (delete the remote branch when its most recent PR is MERGED or CLOSED, skip when OPEN) and retries once on the canonical non-fast-forward shape if the race window between pre-flight and push elected a PR merge in the gap. The retry uses plain push when the orphan can be reclaimed, and `--force-with-lease` only when a live OPEN PR is still using the branch — and only inside the new `fraisier/**` namespace. The push subprocess runs with `LC_ALL=C` so the English-only stderr sniffer (`"non-fast-forward"`, `"fetch first"`) is locale-stable regardless of operator environment. Reclaim deletes use `subprocess.run(..., check=False)` so a branch that vanishes between the exists-check and the `--delete` (concurrent fraisier run, manual cleanup) is treated as the desired end state rather than a fresh failure.
+
+### Changed
+
+- **BREAKING (operational, not API): sync branches moved into the `fraisier/**` namespace.** `fraisier sync` now creates `fraisier/sync/<target>-from-<source>` instead of `sync/<target>-from-<source>`. The new namespace is declared **fraisier-owned** in `README.md` — any branch under `fraisier/**` may be created, updated, deleted, or force-pushed by fraisier without warning. This contract is what makes the orphan-reclaim and the live-PR-race `--force-with-lease` retry above safe in principle, not just in practice. The previous flat `sync/*` namespace is no longer touched by 0.32; the rename has no fallback shim. **Upgrade note:** merge or close any in-flight pre-0.32 sync PRs **before** upgrading. After upgrade, a new sync run will not find the old PR via `_find_existing_pr` (it looks for the new branch name) and will open a fresh PR alongside the stale one — you will end up with two open PRs into the same target if the old one is still around. Old `sync/*` branches left in the remote are not auto-cleaned; delete them by hand (`git push origin --delete sync/<target>-from-<source>`) once their PRs are closed.
+
+### Added
+
+- **`fraisier/**` reserved as the tool-owned branch namespace.** Future fraisier commands will colocate their throwaway branches under this prefix (`fraisier/<command>/...`). Hand-authored work pushed under this prefix will be reclaimed on the next fraisier run — keep your branches outside it. See the new README "Branch namespace" section.
+
 ## [0.31.0] - 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ fraisier provider-test <type>                    Test provider connectivity
 
 ---
 
+## Branch namespace
+
+fraisier owns the `fraisier/**` git branch namespace. Branches under
+this prefix (currently `fraisier/sync/*`, more in future releases) may
+be created, updated, deleted, or force-pushed by fraisier without
+warning. **Do not push hand-authored work to `fraisier/**`** — it will
+be reclaimed on the next fraisier run.
+
+The flat `sync/*` namespace used by `fraisier sync` prior to 0.32 is no
+longer touched. Merge or close any in-flight pre-0.32 sync PRs before
+upgrading; the new sync run will not discover or update them.
+
+---
+
 ## Deployment targets
 
 Fraisier supports different deployment environments:

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from typing import TYPE_CHECKING
@@ -161,6 +162,128 @@ def _enable_auto_merge_or_merge_now(pr_url: str) -> None:
         output=result.stdout,
         stderr=result.stderr,
     )
+
+
+# fraisier owns the `fraisier/**` branch namespace. Any branch under
+# this prefix may be created, updated, or deleted by fraisier without
+# warning — see README "Branch namespace". Code outside `fraisier/**`
+# is treated as user-owned and never touched here.
+FRAISIER_NS = "fraisier/"
+
+
+def _sync_branch_name(target: str, source: str) -> str:
+    return f"{FRAISIER_NS}sync/{target}-from-{source}"
+
+
+def _remote_branch_exists(branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--exit-code", "--heads", "origin", branch],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _is_non_fast_forward_rejection(exc: subprocess.CalledProcessError) -> bool:
+    """True for git's 'fetch first' / non-fast-forward push rejection shape.
+
+    The push subprocess runs under ``LC_ALL=C`` so this English match is
+    reliable regardless of operator locale.
+    """
+    blob = (exc.stderr or "") + (exc.output or "")
+    return "non-fast-forward" in blob or "fetch first" in blob
+
+
+def _reclaim_orphan_branch_if_safe(branch: str) -> bool:
+    """Delete ``origin/<branch>`` if its most recent PR is merged/closed.
+
+    Returns True if the remote branch was deleted or never existed.
+    Returns False if a live OPEN PR is still using it — caller should
+    fall back to the "update existing PR" path.
+
+    Refuses to operate outside ``FRAISIER_NS``: the namespace contract
+    in the README is the only thing making unconditional deletion safe.
+    """
+    if not branch.startswith(FRAISIER_NS):
+        raise ValueError(f"refusing to reclaim non-fraisier branch: {branch}")
+
+    if not _remote_branch_exists(branch):
+        return True
+
+    existing = _find_existing_pr(branch)
+    if existing is not None and existing["state"] == "OPEN":
+        return False
+
+    if existing is not None:
+        console.print(
+            f"  Reclaiming orphan {branch} "
+            f"(prior PR {existing['state'].lower()}: {existing['url']})"
+        )
+
+    # check=False: the branch may have vanished between the exists-check
+    # above and this delete (concurrent fraisier run, manual cleanup).
+    # "Already gone" is the desired end state, not a failure.
+    result = subprocess.run(
+        ["git", "push", "origin", "--delete", branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 and "remote ref does not exist" not in (
+        result.stderr or ""
+    ):
+        console.print(
+            f"  [yellow]Warning: could not delete {branch}: "
+            f"{(result.stderr or '').strip()}[/yellow]"
+        )
+    return True
+
+
+def _push_sync_branch(sync_branch: str) -> None:
+    """Push ``sync_branch`` to origin, recovering from #248 orphan branches.
+
+    Flow:
+      1. Pre-flight: if origin holds an orphan ``sync_branch`` whose most
+         recent PR is MERGED/CLOSED, delete it first.
+      2. Push. ``LC_ALL=C`` so the non-FF sniffer matches English stderr
+         regardless of operator locale.
+      3. On non-FF rejection, retry once: reclaim again (a PR may have
+         merged in the gap), then either re-push or fall back to
+         ``--force-with-lease`` if a live OPEN PR is still using the
+         branch. Force-with-lease is safe here only because the branch
+         lives in ``FRAISIER_NS`` (declared tool-owned in README).
+      4. Any other failure (auth, network, etc.) propagates.
+    """
+    _reclaim_orphan_branch_if_safe(sync_branch)
+
+    push_argv = ["git", "push", "origin", sync_branch]
+    env = {**os.environ, "LC_ALL": "C"}
+    result = subprocess.run(
+        push_argv, capture_output=True, text=True, env=env, check=False
+    )
+    if result.returncode == 0:
+        return
+
+    exc = subprocess.CalledProcessError(
+        result.returncode, push_argv, output=result.stdout, stderr=result.stderr
+    )
+    if not _is_non_fast_forward_rejection(exc):
+        raise exc
+
+    # Race window between pre-flight and push, or live OPEN PR.
+    reclaimed = _reclaim_orphan_branch_if_safe(sync_branch)
+    retry_argv = (
+        push_argv
+        if reclaimed
+        else ["git", "push", "--force-with-lease", "origin", sync_branch]
+    )
+    retry = subprocess.run(
+        retry_argv, capture_output=True, text=True, env=env, check=False
+    )
+    if retry.returncode != 0:
+        raise subprocess.CalledProcessError(
+            retry.returncode, retry_argv, output=retry.stdout, stderr=retry.stderr
+        )
 
 
 def _find_existing_pr(sync_branch: str) -> dict | None:
@@ -425,7 +548,7 @@ def sync_cmd(
     pair = _resolve_pair(target, pairs)
     source = pair.source
     tgt = pair.target
-    sync_branch = f"sync/{tgt}-from-{source}"
+    sync_branch = _sync_branch_name(tgt, source)
 
     if dry_run:
         _print_dry_run_plan(source, tgt, sync_branch)
@@ -565,7 +688,7 @@ def sync_cmd(
         _assert_merge_finalized()
 
         console.print(f"  Pushing [bold]{sync_branch}[/bold]")
-        _run(["git", "push", "origin", sync_branch])
+        _push_sync_branch(sync_branch)
 
         existing = _find_existing_pr(sync_branch)
         if existing and existing["state"] == "OPEN":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.31.0"
+version = "0.32.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -509,6 +509,7 @@ class TestSyncHappyPath:
             _in_merge(),  # rev-parse MERGE_HEAD (in merge)
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),  # pre-push merge-commit invariant check
+            _mk(returncode=2),  # ls-remote: orphan branch absent
             _mk(),  # git push
             _mk(returncode=1),  # gh pr view (no existing PR)
             _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -570,6 +571,7 @@ class TestSyncHappyPath:
                 _in_merge(),  # MERGE_HEAD set → commit unconditionally
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),
@@ -649,6 +651,7 @@ class TestSyncAutoMergeFallback:
                 "MERGE_HEAD",
                 returncode=1,
             )
+            .queue("git", "ls-remote", returncode=2)  # orphan absent
             .queue("git", "push")
             .queue("gh", "pr", "view", returncode=1)  # no existing PR
             .queue("gh", "pr", "create", stdout=self.PR_URL + "\n")
@@ -775,6 +778,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set → commit unconditionally
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -807,6 +811,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set → commit unconditionally
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -852,6 +857,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set → commit unconditionally
                 _mk(),  # git commit (merge commit, even with no tree diff)
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -899,6 +905,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -966,7 +973,7 @@ class TestSyncConflicts:
         commands = [c[0][0] for c in m.call_args_list]
         deletes = [c for c in commands if "branch" in c and "-D" in c]
         assert len(deletes) == 1
-        assert "sync/staging-from-dev" in deletes[0]
+        assert "fraisier/sync/staging-from-dev" in deletes[0]
 
     def test_auto_resolves_target_behind_source(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -992,6 +999,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -1030,6 +1038,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -1069,6 +1078,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -1106,6 +1116,7 @@ class TestSyncConflicts:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -1161,6 +1172,7 @@ class TestSyncConfirmation:
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
+                _mk(returncode=2),  # ls-remote: orphan branch absent
                 _mk(),  # git push
                 _mk(returncode=1),  # gh pr view (no existing PR)
                 _mk(stdout=pr_url + "\n"),  # gh pr create
@@ -1241,7 +1253,9 @@ class TestSyncDryRun:
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
         with patch(_PATCH):
             result = CliRunner().invoke(main, ["-c", cfg, "sync", "--dry-run"])
-        assert "git checkout -B sync/staging-from-dev origin/dev" in result.output
+        assert (
+            "git checkout -B fraisier/sync/staging-from-dev origin/dev" in result.output
+        )
 
     def test_dry_run_shows_merge(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -1253,7 +1267,7 @@ class TestSyncDryRun:
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
         with patch(_PATCH):
             result = CliRunner().invoke(main, ["-c", cfg, "sync", "--dry-run"])
-        assert "git push origin sync/staging-from-dev" in result.output
+        assert "git push origin fraisier/sync/staging-from-dev" in result.output
 
     def test_dry_run_shows_pr_create(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -1261,7 +1275,7 @@ class TestSyncDryRun:
             result = CliRunner().invoke(main, ["-c", cfg, "sync", "--dry-run"])
         assert "gh pr create" in result.output
         assert "--base staging" in result.output
-        assert "--head sync/staging-from-dev" in result.output
+        assert "--head fraisier/sync/staging-from-dev" in result.output
 
     def test_dry_run_shows_pr_merge(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -1312,6 +1326,7 @@ class TestSyncBranchForceCreate:
             _in_merge(),  # MERGE_HEAD set
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),
+            _mk(returncode=2),  # ls-remote: orphan branch absent
             _mk(),  # git push
             _mk(returncode=1),  # gh pr view (no existing PR)
             _mk(stdout=self.PR_URL + "\n"),  # gh pr create
@@ -1386,6 +1401,7 @@ class TestSyncExistingPR:
             _in_merge(),  # MERGE_HEAD set
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),
+            _mk(returncode=2),  # ls-remote: orphan branch absent
             _mk(),  # git push
         ]
 
@@ -1681,6 +1697,7 @@ class TestSyncPropagatesSourceDeletions:
                 "MERGE_HEAD",
                 returncode=1,
             )
+            .queue("git", "ls-remote", returncode=2)  # orphan absent
         )
         with patch(_PATCH, side_effect=mg):
             result = CliRunner().invoke(
@@ -1724,6 +1741,7 @@ class TestSyncPropagatesSourceDeletions:
                 "MERGE_HEAD",
                 returncode=1,
             )
+            .queue("git", "ls-remote", returncode=2)  # orphan absent
         )
         with patch(_PATCH, side_effect=mg):
             result = CliRunner().invoke(
@@ -1773,6 +1791,7 @@ class TestSyncPropagatesSourceDeletions:
                 "MERGE_HEAD",
                 returncode=1,
             )
+            .queue("git", "ls-remote", returncode=2)  # orphan absent
         )
         with patch(_PATCH, side_effect=mg):
             result = CliRunner().invoke(
@@ -1906,3 +1925,261 @@ class TestCommitMergeOrStaged:
             _commit_merge_or_staged("msg")
         commands = [c[0][0] for c in m.call_args_list]
         assert any("commit" in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# Issue #248: fraisier/* namespace + orphan-branch reclaim
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBranchName:
+    def test_returns_branch_under_fraisier_namespace(self):
+        from fraisier.cli.sync import _sync_branch_name
+
+        assert _sync_branch_name("staging", "dev") == "fraisier/sync/staging-from-dev"
+
+
+class TestReclaimOrphanBranch:
+    def test_deletes_when_prior_pr_merged(self):
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with (
+            patch("fraisier.cli.sync._remote_branch_exists", return_value=True),
+            patch(
+                "fraisier.cli.sync._find_existing_pr",
+                return_value={"state": "MERGED", "url": "https://x/pr/1"},
+            ),
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.return_value = _mk()
+            result = _reclaim_orphan_branch_if_safe("fraisier/sync/staging-from-dev")
+
+        assert result is True
+        delete_calls = [
+            c.args[0] for c in run_mock.call_args_list if "--delete" in c.args[0]
+        ]
+        assert delete_calls == [
+            [
+                "git",
+                "push",
+                "origin",
+                "--delete",
+                "fraisier/sync/staging-from-dev",
+            ]
+        ]
+
+    def test_skips_when_prior_pr_open(self):
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with (
+            patch("fraisier.cli.sync._remote_branch_exists", return_value=True),
+            patch(
+                "fraisier.cli.sync._find_existing_pr",
+                return_value={"state": "OPEN", "url": "https://x/pr/2"},
+            ),
+            patch(_PATCH) as run_mock,
+        ):
+            result = _reclaim_orphan_branch_if_safe("fraisier/sync/staging-from-dev")
+
+        assert result is False
+        delete_calls = [c for c in run_mock.call_args_list if "--delete" in c.args[0]]
+        assert delete_calls == []
+
+    def test_noop_when_no_remote_branch(self):
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with (
+            patch("fraisier.cli.sync._remote_branch_exists", return_value=False),
+            patch("fraisier.cli.sync._find_existing_pr") as pr_mock,
+            patch(_PATCH) as run_mock,
+        ):
+            result = _reclaim_orphan_branch_if_safe("fraisier/sync/staging-from-dev")
+
+        assert result is True
+        pr_mock.assert_not_called()
+        assert run_mock.call_args_list == []
+
+    def test_deletes_orphan_with_no_pr_history(self):
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with (
+            patch("fraisier.cli.sync._remote_branch_exists", return_value=True),
+            patch("fraisier.cli.sync._find_existing_pr", return_value=None),
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.return_value = _mk()
+            result = _reclaim_orphan_branch_if_safe("fraisier/sync/staging-from-dev")
+
+        assert result is True
+        delete_calls = [
+            c.args[0] for c in run_mock.call_args_list if "--delete" in c.args[0]
+        ]
+        assert len(delete_calls) == 1
+
+    def test_refuses_non_fraisier_namespace(self):
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with pytest.raises(ValueError, match="refusing to reclaim"):
+            _reclaim_orphan_branch_if_safe("sync/staging-from-dev")
+
+    def test_delete_failure_does_not_raise(self):
+        """Race: branch vanishes between exists-check and --delete.
+
+        Plan resolution #1: subprocess.run(..., check=False) on the delete.
+        """
+        from fraisier.cli.sync import _reclaim_orphan_branch_if_safe
+
+        with (
+            patch("fraisier.cli.sync._remote_branch_exists", return_value=True),
+            patch("fraisier.cli.sync._find_existing_pr", return_value=None),
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.return_value = _mk(
+                returncode=1, stderr="remote ref does not exist"
+            )
+            result = _reclaim_orphan_branch_if_safe("fraisier/sync/staging-from-dev")
+
+        assert result is True
+
+
+class TestNonFastForwardSniffer:
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "! [rejected] foo (non-fast-forward)\n",
+            "hint: Updates were rejected ... fetch first\n",
+        ],
+    )
+    def test_matches_canonical_git_wordings(self, stderr):
+        from fraisier.cli.sync import _is_non_fast_forward_rejection
+
+        exc = subprocess.CalledProcessError(
+            1, ["git", "push"], output="", stderr=stderr
+        )
+        assert _is_non_fast_forward_rejection(exc) is True
+
+    def test_does_not_match_unrelated_failures(self):
+        from fraisier.cli.sync import _is_non_fast_forward_rejection
+
+        exc = subprocess.CalledProcessError(
+            1, ["git", "push"], output="", stderr="fatal: Authentication failed"
+        )
+        assert _is_non_fast_forward_rejection(exc) is False
+
+
+class TestPushSyncBranch:
+    """Cycle 2: pre-flight + retry behaviour around `git push`."""
+
+    def test_clean_push_after_preflight_reclaim(self):
+        """Pre-flight reclaim runs first; push then succeeds without retry."""
+        from fraisier.cli.sync import _push_sync_branch
+
+        with (
+            patch(
+                "fraisier.cli.sync._reclaim_orphan_branch_if_safe",
+                return_value=True,
+            ) as reclaim_mock,
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.return_value = _mk(returncode=0)
+            _push_sync_branch("fraisier/sync/staging-from-dev")
+
+        reclaim_mock.assert_called_once_with("fraisier/sync/staging-from-dev")
+        push_calls = [c.args[0] for c in run_mock.call_args_list]
+        assert push_calls == [
+            ["git", "push", "origin", "fraisier/sync/staging-from-dev"]
+        ]
+        # LC_ALL=C set so the sniffer can rely on English stderr.
+        env = run_mock.call_args_list[0].kwargs.get("env") or {}
+        assert env.get("LC_ALL") == "C"
+
+    def test_retries_after_non_fast_forward_when_pr_now_merged(self):
+        """Race: PR was OPEN at pre-flight, merged before push, push rejects.
+
+        The retry path re-runs the reclaim (now sees MERGED), deletes the
+        branch, and pushes a second time. This anchors specifically on the
+        retry — pre-flight returns False (live PR), so the reclaim only
+        bites on the second call.
+        """
+        from fraisier.cli.sync import _push_sync_branch
+
+        with (
+            patch(
+                "fraisier.cli.sync._reclaim_orphan_branch_if_safe",
+                side_effect=[False, True],
+            ) as reclaim_mock,
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.side_effect = [
+                _mk(
+                    returncode=1,
+                    stderr="! [rejected] foo (non-fast-forward)\n",
+                ),
+                _mk(returncode=0),
+            ]
+            _push_sync_branch("fraisier/sync/staging-from-dev")
+
+        assert reclaim_mock.call_count == 2
+        push_argvs = [c.args[0] for c in run_mock.call_args_list]
+        assert push_argvs == [
+            ["git", "push", "origin", "fraisier/sync/staging-from-dev"],
+            ["git", "push", "origin", "fraisier/sync/staging-from-dev"],
+        ]
+        # No force-with-lease on this path — orphan reclaim cleared the way.
+        assert not any("--force-with-lease" in argv for argv in push_argvs)
+
+    def test_force_with_lease_only_when_live_pr_blocks_retry(self):
+        """If the PR stays OPEN on retry, fall back to --force-with-lease.
+
+        Force-push is scoped to the fraisier-owned namespace and only fires
+        on the live-PR-race case — per plan §2.2.
+        """
+        from fraisier.cli.sync import _push_sync_branch
+
+        with (
+            patch(
+                "fraisier.cli.sync._reclaim_orphan_branch_if_safe",
+                side_effect=[False, False],
+            ),
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.side_effect = [
+                _mk(returncode=1, stderr="hint: fetch first\n"),
+                _mk(returncode=0),
+            ]
+            _push_sync_branch("fraisier/sync/staging-from-dev")
+
+        push_argvs = [c.args[0] for c in run_mock.call_args_list]
+        assert push_argvs[0] == [
+            "git",
+            "push",
+            "origin",
+            "fraisier/sync/staging-from-dev",
+        ]
+        assert push_argvs[1] == [
+            "git",
+            "push",
+            "--force-with-lease",
+            "origin",
+            "fraisier/sync/staging-from-dev",
+        ]
+
+    def test_does_not_retry_on_unrelated_failure(self):
+        """Permission denied / auth failure must propagate, never retry."""
+        from fraisier.cli.sync import _push_sync_branch
+
+        with (
+            patch(
+                "fraisier.cli.sync._reclaim_orphan_branch_if_safe",
+                return_value=True,
+            ),
+            patch(_PATCH) as run_mock,
+        ):
+            run_mock.return_value = _mk(
+                returncode=1, stderr="fatal: Authentication failed"
+            )
+            with pytest.raises(subprocess.CalledProcessError):
+                _push_sync_branch("fraisier/sync/staging-from-dev")
+
+        # Single push attempt, no retry.
+        assert run_mock.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Fixes #248**: `fraisier sync` no longer aborts when a prior squash-merged PR left an orphan remote head branch behind. New `_push_sync_branch(...)` helper pre-flights an orphan-reclaim before push and retries once on the canonical non-fast-forward shape if a PR merges in the race window.
- **Breaking (operational, not API)**: sync branches move into the new fraisier-owned `fraisier/**` namespace. New shape is `fraisier/sync/<target>-from-<source>`. The namespace is declared fraisier-owned in `README.md` so the reclaim and the live-PR-race `--force-with-lease` retry are safe in principle, not just in practice.
- **Hardening**: push subprocess uses `LC_ALL=C` so the English-only non-FF stderr sniffer is locale-stable; reclaim delete uses `check=False` so a branch that vanishes between exists-check and `--delete` is treated as the desired end state.
- **Bump**: `pyproject.toml` 0.31.0 → 0.32.0.

## Upgrade note

Merge or close any in-flight pre-0.32 sync PRs **before** upgrading. After upgrade, a new sync run will not discover the old PR via `_find_existing_pr` and will open a fresh PR alongside the stale one — you'll end up with two open PRs into the same target if the old one is still around. Old `sync/*` branches are not auto-cleaned; `git push origin --delete sync/<target>-from-<source>` by hand once their PRs close.

## Test plan

- [x] `uv run pytest tests/test_sync.py` — 100 passed (10 new helper + sniffer tests, 4 new push-integration tests, 13 existing tests updated for the new branch name + the new pre-flight ls-remote)
- [x] `uv run pytest` (full suite) — 4146 passed, 7 skipped
- [x] `uv run ruff check fraisier/cli/sync.py tests/test_sync.py` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] Manual smoke: trigger a `fraisier sync` against a repo with a known orphan `fraisier/sync/*` branch, confirm pre-flight reclaim + push succeed in a single run

🤖 Generated with [Claude Code](https://claude.com/claude-code)