### PR TITLE
release: v0.35.0 — ship defers version bump until checks pass (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.35.0] - 2026-06-25
+
+### Fixed
+
+- **`fraisier ship` no longer leaves a dirty, half-bumped working tree when a check fails** ([#253](https://github.com/fraiseql/fraisier/issues/253)). `ship <bump>` wrote the version bump to `pyproject.toml` (plus its byproducts — `uv.lock`, a regenerated `detect-secrets` baseline, etc.) *before* the validation/test phases ran. When a check then failed, the ship aborted correctly — nothing pushed, no PR — but the bump was already on disk: the operator had to `git restore` several files by hand before retrying, and a naive retry would bump *again* from the already-bumped number (`X → Y → Z` instead of `X → Y`). Because `ship` auto-commits uncommitted tracked changes, a later successful ship could also silently sweep the stray bump into its commit. The bump is now **transactional with respect to the check phase**: the next version is still computed up front, but the on-disk write is deferred behind an `apply_bump` callback that `_ship_with_pipeline` invokes **only after both the fix and verify phases pass**, immediately before staging and committing. A failed check therefore leaves the working tree exactly as the user left it — no stray bump to revert, no double-bump on retry. The two `git add --update` calls collapse into a single staging point after the bump (the check phases run against the working tree, not the index, so the pre-verify stage was redundant). The `ship --no-bump` path passes no callback and is unaffected. New regression guard `tests/test_ship.py::TestShipPipelineIntegration::test_ship_check_failure_leaves_version_unbumped` lets the fix phase pass, fails the verify phase, and asserts `pyproject.toml` is still at the original version (it fails on 0.34.0 and earlier).
+
 ## [0.34.0] - 2026-06-19
 
 ### Fixed

--- a/fraisier/cli/version.py
+++ b/fraisier/cli/version.py
@@ -14,6 +14,8 @@ from ._helpers import console
 from .main import main
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from fraisier.config import ShipConfig
 
 logger = logging.getLogger(__name__)
@@ -364,11 +366,18 @@ def ship(
         return
 
     assert bump_type is not None  # guaranteed by the CLI argument validation above
-    info = bump_version(pyproject_path, bump_type)
-    success(f"Version bumped: {current_version} -> {info.version}")
+
+    # #253: defer the on-disk bump until after the check phases pass. The next
+    # version is fully determined now (``new``), but writing it before the
+    # checks means a failing check leaves a dirty, half-bumped tree the user
+    # must hand-revert. The pipeline calls ``_apply_bump`` only once all checks
+    # are green, so an aborted ship leaves the working tree exactly as it was.
+    def _apply_bump() -> None:
+        bump_version(pyproject_path, bump_type)
+        success(f"Version bumped: {current_version} -> {new}")
 
     _ship_commit_push_deploy(
-        info.version,
+        new,
         ship_config,
         create_pr,
         pr_base,
@@ -377,9 +386,10 @@ def ship(
         deploy_timeout,
         auto_merge=resolved_auto_merge,
         merge_method=resolved_merge_method,
-        label=f"v{info.version}",
+        label=f"v{new}",
         expected_base_version=current_version,
         bump_kind=bump_type,
+        apply_bump=_apply_bump,
     )
 
 
@@ -397,6 +407,7 @@ def _ship_commit_push_deploy(
     label: str,
     expected_base_version: str,
     bump_kind: str | None,
+    apply_bump: Callable[[], None] | None = None,
 ) -> None:
     """Run the commit-push-PR-deploy sequence."""
     # #232: race base is the PR target when --pr is set (origin/<pr_base> moves
@@ -406,7 +417,7 @@ def _ship_commit_push_deploy(
     race_base = resolved_pr_base if create_pr else None
 
     _ship_with_pipeline(
-        version, ship_config, expected_base_version, bump_kind, race_base
+        version, ship_config, expected_base_version, bump_kind, race_base, apply_bump
     )
 
     if create_pr:
@@ -645,6 +656,7 @@ def _ship_with_pipeline(
     expected_base_version: str,
     bump_kind: str | None,
     race_base: str | None,
+    apply_bump: Callable[[], None] | None = None,
 ) -> None:
     """Ship using the check pipeline (--no-verify commit).
 
@@ -652,6 +664,10 @@ def _ship_with_pipeline(
     at all) gets a synthetic empty config — the pipeline's check phases
     short-circuit when no checks are configured, but the
     migration-untracked check and commit/push still run.
+
+    *apply_bump*, when given, writes the version bump to disk. It is invoked
+    only after every check phase passes (issue #253), so a failed check leaves
+    a clean working tree. ``None`` for ``ship --no-bump`` (nothing to write).
     """
     import subprocess
 
@@ -669,22 +685,27 @@ def _ship_with_pipeline(
     if not migration_result.success:
         raise SystemExit(1)
 
-    # Phase 1: auto-fixers (before staging)
+    # Phase 1: auto-fixers (run against the working tree, before any staging)
     console.print("[bold]Running fix checks...[/bold]")
     fix_result = pipeline.run_fix_phase()
     if not fix_result.success:
         console.print("[red]Fix checks failed, aborting ship.[/red]")
         raise SystemExit(1)
 
-    # Stage all tracked dirty files (bump + fixer output)
-    subprocess.run(["git", "add", "--update"], check=True)
-
-    # Phase 2: validators + tests (after staging)
+    # Phase 2: validators + tests (also run against the working tree)
     console.print("[bold]Running validation and tests...[/bold]")
     verify_result = pipeline.run_verify_phase()
     if not verify_result.success:
         console.print("[red]Validation/test checks failed, aborting ship.[/red]")
         raise SystemExit(1)
+
+    # #253: every check is green — only now write the version bump. Deferring it
+    # to here means a failed check above leaves the working tree exactly as the
+    # user left it (no stray bump to revert, no double-bump on retry). The single
+    # `git add --update` then stages the bump together with any fixer output.
+    if apply_bump is not None:
+        apply_bump()
+    subprocess.run(["git", "add", "--update"], check=True)
 
     # #232: refuse to commit if origin advanced during local CI — the bump
     # we computed before CI would now produce a duplicate-version PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.34.0"
+version = "0.35.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_ship.py
+++ b/tests/test_ship.py
@@ -244,6 +244,54 @@ class TestShipPipelineIntegration:
         assert "Fix checks failed" in result.output
 
     @patch("subprocess.run")
+    @patch("fraisier.ship.pipeline.run_check")
+    def test_ship_check_failure_leaves_version_unbumped(
+        self, mock_check, mock_run, tmp_path
+    ):
+        """A failing check leaves pyproject.toml unbumped (issue #253).
+
+        The on-disk bump is deferred until *after* the check phases pass, so
+        an aborted ship leaves a clean working tree — no stray bump to revert,
+        and a retry bumps from the original version rather than the bumped one.
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        from fraisier.ship.checks import CheckResult
+
+        # Fix phase passes; the verify (test) phase fails — the latest point a
+        # check can fail, proving the bump is deferred past the whole pipeline.
+        def _check(check, _cwd):
+            return CheckResult(
+                name=check.name,
+                success=check.phase == "fix",
+                output="" if check.phase == "fix" else "boom",
+                duration_seconds=0.1,
+            )
+
+        mock_check.side_effect = _check
+        cfg = _setup_project_with_pipeline(tmp_path, version="1.0.0")
+        pp = tmp_path / "pyproject.toml"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "-c",
+                cfg,
+                "ship",
+                "patch",
+                "--no-deploy",
+                "--pyproject",
+                str(pp),
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Validation/test checks failed" in result.output
+        # Working tree must be clean: version is still 1.0.0, not bumped to 1.0.1.
+        assert 'version = "1.0.0"' in pp.read_text()
+        assert "1.0.1" not in pp.read_text()
+
+    @patch("subprocess.run")
     @patch("fraisier.ship.pr.create_pr")
     @patch("fraisier.ship.pipeline.run_check")
     def test_ship_pr_flag_creates_pr(

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #253.

## Problem

`fraisier ship <bump>` wrote the version bump to `pyproject.toml` (and its byproducts — `uv.lock`, a regenerated `detect-secrets` baseline, etc.) **before** running the validation/test check phases. When a check failed, the ship aborted correctly (nothing pushed, no PR) but the bump was already on disk:

- the working tree was left dirty with a bump that didn't ship;
- the operator had to `git restore` several files by hand before retrying;
- a naive retry bumped *again* from the already-bumped number (`X → Y → Z` instead of `X → Y`);
- because `ship` auto-commits uncommitted tracked changes, a later successful ship could silently sweep the stray bump into its commit.

## Fix

Make the bump **transactional with respect to the check phase**. The next version is still computed up front, but the on-disk write is deferred behind an `apply_bump` callback that `_ship_with_pipeline` invokes **only after both the fix and verify phases pass**, immediately before staging and committing. A failed check therefore leaves the working tree exactly as the user left it — no stray bump to revert, no double-bump on retry.

- `version.py`: compute `new` up front; defer the `bump_version` write behind an `apply_bump` callback threaded through `_ship_commit_push_deploy` → `_ship_with_pipeline`; invoke it only after `run_verify_phase` succeeds.
- Collapse the two `git add --update` calls into a single post-bump staging point (the check phases run against the working tree, not the index, so the pre-verify stage was redundant).
- `ship --no-bump` passes no callback and is unaffected.

## Tests

New regression guard `tests/test_ship.py::TestShipPipelineIntegration::test_ship_check_failure_leaves_version_unbumped`: the fix phase passes, the verify phase fails, and it asserts `pyproject.toml` is still at the original version. It fails on 0.34.0 and earlier, passes here.

## Verification

- ✅ Full suite: **4171 passed, 7 skipped** (only the known pre-existing `test_install_helper` ordering flake deselected).
- ✅ `ruff check` + `ruff format --check` clean across the whole repo; `ty check` clean.

## Not included (follow-up)

The issue's secondary note — failing-check output is truncated to the first 10 lines, so for pytest you see the startup banner but not the failure summary at the *end* — is independent of the transactional-bump fix and is tracked as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)