### PR TITLE
release: v0.36.0 — ship surfaces failing-check output tail + full log (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.0] - 2026-06-25
+
+### Fixed
+
+- **`fraisier ship` now shows *why* a check failed — the output tail, not the head** ([#255](https://github.com/fraiseql/fraisier/issues/255)). On a failed ship check, the pipeline printed only the **first 10 lines** of the captured output. Tools like pytest, ruff, and mypy print their verdict at the **end** (the failure summary, assertion diffs, the error list), so the ship log showed the startup banner / collection noise but not the actual cause — operators had to re-run the failing lane by hand to diagnose it (surfaced while fixing [#253](https://github.com/fraiseql/fraisier/issues/253)). `ShipPipeline._print_result` now prints the **last 30 lines** instead. When the output is longer than that window, it appends a `... N earlier line(s) hidden` note **and** writes the *full* captured output to a `0o600` log file under the XDG logs dir (`$XDG_DATA_HOME/fraisier/logs/ship-check-<name>-<stamp>.log`, shared with the existing `fraisier._output` tee layer), printing the path so nothing is lost. Output that fits the window is shown whole with no note and no log file (re-runs on a converged tree stay quiet). Log writes are best-effort — an `OSError` creating the directory or file degrades to "tail only" rather than masking the check failure. New regression guards in `tests/test_ship_pipeline.py::TestPrintFailureOutput` cover the tail-vs-head selection, the truncation note + full-log capture (including the `0o600` mode), and the short-output no-log path.
+
 ## [0.35.0] - 2026-06-25
 
 ### Fixed

--- a/fraisier/ship/pipeline.py
+++ b/fraisier/ship/pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import fnmatch
+import os
+import re
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -17,6 +19,10 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from fraisier.config import ShipCheckConfig, ShipConfig
+
+# Failed checks print their last N output lines — tools (pytest, ruff, mypy)
+# put the verdict at the end, so the tail is what diagnoses the failure (#255).
+_FAILURE_TAIL_LINES = 30
 
 
 @dataclass
@@ -179,5 +185,50 @@ class ShipPipeline:
             f"  {status} {result.name} ({result.duration_seconds:.1f}s)"
         )
         if not result.success and result.output:
-            for line in result.output.strip().split("\n")[:10]:
-                self._console.print(f"    {line}")
+            self._print_failure_output(result)
+
+    def _print_failure_output(self, result: CheckResult) -> None:
+        """Surface *why* a check failed (issue #255).
+
+        Tools like pytest and ruff print their verdict at the **end** of
+        their output, so the console shows the **tail** (not the head, which
+        is startup/collection noise). When the tail hides earlier lines, the
+        *full* output is written to a log file and its path is printed so
+        nothing is lost.
+        """
+        lines = result.output.strip().split("\n")
+        tail = lines[-_FAILURE_TAIL_LINES:]
+        hidden = len(lines) - len(tail)
+        if hidden > 0:
+            note = f"... {hidden} earlier line(s) hidden"
+            log_path = self._write_failure_log(result)
+            if log_path is not None:
+                note += f"; full output: {log_path}"
+            self._console.print(f"    [dim]{note}[/dim]")
+        for line in tail:
+            self._console.print(f"    {line}")
+
+    def _write_failure_log(self, result: CheckResult) -> Path | None:
+        """Write a failed check's full output to a 0o600 log file; return its path.
+
+        Best-effort: reuses the XDG-compliant log directory shared with the
+        ``fraisier._output`` tee layer. Returns ``None`` if the directory or
+        file cannot be created so a logging hiccup never masks the failure.
+        """
+        from fraisier._output import _log_dir, _now_stamp
+
+        safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", result.name).strip("-") or "check"
+        try:
+            log_dir = _log_dir()
+            log_dir.mkdir(parents=True, exist_ok=True)
+            log_path = log_dir / f"ship-check-{safe_name}-{_now_stamp()}.log"
+            fd = os.open(
+                str(log_path),
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as log_file:
+                log_file.write(result.output)
+        except OSError:
+            return None
+        return log_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.35.0"
+version = "0.36.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_ship_pipeline.py
+++ b/tests/test_ship_pipeline.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
-import pytest
 from rich.console import Console
 
 from fraisier.config import ShipCheckConfig, ShipConfig
 from fraisier.ship.checks import CheckResult, run_check
 from fraisier.ship.pipeline import ShipPipeline
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _make_check(
@@ -272,3 +276,96 @@ class TestCheckUntrackedMigrations:
             "--exclude-standard",
             "db/migrations",
         ]
+
+
+class TestPrintFailureOutput:
+    """Failing-check output shows the tail (the verdict) and keeps a full log (#255)."""
+
+    def _make_pipeline(self) -> tuple[ShipPipeline, Console]:
+        console = Console(file=io.StringIO(), width=500)
+        pipeline = ShipPipeline(
+            config=ShipConfig(checks=[]),
+            cwd=Path(),
+            console=console,
+        )
+        return pipeline, console
+
+    @staticmethod
+    def _text(console: Console) -> str:
+        assert isinstance(console.file, io.StringIO)
+        return console.file.getvalue()
+
+    def test_passing_check_prints_no_output(self) -> None:
+        """A passing check prints only its status line, never its output."""
+        pipeline, console = self._make_pipeline()
+        pipeline._print_result(
+            CheckResult(
+                name="pytest", success=True, output="noise", duration_seconds=0.1
+            )
+        )
+        text = self._text(console)
+        assert "pass pytest" in text
+        assert "noise" not in text
+
+    def test_failure_shows_tail_not_head(self) -> None:
+        """The verdict at the *end* of the output is shown; the head is dropped."""
+        pipeline, console = self._make_pipeline()
+        body = "\n".join(["STARTUP-BANNER", *[f"noise-{i}" for i in range(45)]])
+        output = body + "\nFAILED-VERDICT: assert 1 == 2"
+        pipeline._print_result(
+            CheckResult(
+                name="pytest", success=False, output=output, duration_seconds=2.0
+            )
+        )
+        text = self._text(console)
+        # The failure summary (tail) is what the operator needs — show it.
+        assert "FAILED-VERDICT: assert 1 == 2" in text
+        # The startup banner (head) is collection noise — drop it.
+        assert "STARTUP-BANNER" not in text
+
+    def test_truncation_note_and_full_log_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Long output is truncated in the console but preserved in full on disk."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        pipeline, console = self._make_pipeline()
+        body = "\n".join(["STARTUP-BANNER", *[f"noise-{i}" for i in range(45)]])
+        output = body + "\nFAILED-VERDICT: assert 1 == 2"
+        pipeline._print_result(
+            CheckResult(
+                name="pytest", success=False, output=output, duration_seconds=2.0
+            )
+        )
+        text = self._text(console)
+
+        # A note tells the operator some lines were hidden and where to find them.
+        assert "hidden" in text
+        logs = list((tmp_path / "fraisier" / "logs").glob("*.log"))
+        assert len(logs) == 1
+        log_path = logs[0]
+        # The console points at the full log...
+        assert str(log_path) in text
+        # ...and the log holds the *complete* output, head included.
+        contents = log_path.read_text()
+        assert "STARTUP-BANNER" in contents
+        assert "FAILED-VERDICT: assert 1 == 2" in contents
+        # 0o600 so a leaked token in the output isn't world-readable.
+        assert (log_path.stat().st_mode & 0o777) == 0o600
+
+    def test_short_output_shown_in_full_without_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Output that fits the window is shown whole — no note, no log file."""
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        pipeline, console = self._make_pipeline()
+        output = "first line\nsecond line\nthird line"
+        pipeline._print_result(
+            CheckResult(name="ruff", success=False, output=output, duration_seconds=0.3)
+        )
+        text = self._text(console)
+        assert "first line" in text
+        assert "third line" in text
+        assert "hidden" not in text
+        assert not (tmp_path / "fraisier" / "logs").exists() or not list(
+            (tmp_path / "fraisier" / "logs").glob("*.log")
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.35.0"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #255. Split out from the secondary note in #253.

## Problem

On a failed `ship` check, `ShipPipeline._print_result` printed only the **first 10 lines** of the captured output. Tools like pytest, ruff, and mypy print their verdict at the **end** (failure summary, assertion diffs, error list), so the ship log showed the startup banner / collection noise but not *why* the check failed — the failing lane had to be reproduced by hand to diagnose.

## Fix

- **Show the tail, not the head.** `_print_result` now prints the **last 30 lines** of a failed check's output.
- **Preserve the full output.** When the output exceeds the window, a `... N earlier line(s) hidden` note is printed **and** the complete output is written to a `0o600` log file under the XDG logs dir (`$XDG_DATA_HOME/fraisier/logs/ship-check-<name>-<stamp>.log`, the same dir the `fraisier._output` tee layer uses), with the path printed so nothing is lost.
- **Quiet on the happy path.** Output that fits the window is shown whole — no note, no log file.
- **Best-effort logging.** An `OSError` creating the directory/file degrades to tail-only rather than masking the check failure.

## Tests

New `tests/test_ship_pipeline.py::TestPrintFailureOutput`:
- `test_failure_shows_tail_not_head` — the end-of-output verdict is shown, the head banner is dropped (fails on the old head-slice behaviour).
- `test_truncation_note_and_full_log_written` — note printed, full output written to a `0o600` log, path surfaced in the console.
- `test_short_output_shown_in_full_without_log` — short output shown whole, no note, no log file.
- `test_passing_check_prints_no_output` — passing checks stay silent.

## Verification

- ✅ Full suite: **4175 passed, 7 skipped** (only the known `test_install_helper` ordering flake deselected).
- ✅ `ruff check` + `ruff format --check` clean across the whole repo; `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)