### PR TITLE
release: v0.40.0 — adapt to confiture 0.33 + restore-preflight replay-everything guard (#262)

### DIFF
--- a/fraisier/dbops/confiture.py
+++ b/fraisier/dbops/confiture.py
@@ -76,11 +76,25 @@ def _load_env(
     *,
     database_url: str | None = None,
 ) -> Environment:
-    """Load a confiture Environment, optionally overriding database_url."""
+    """Load a confiture Environment, optionally overriding database_url.
+
+    confiture 0.30+ makes ``name`` and ``include_dirs`` required ``Environment``
+    fields, but fraisier's migrate/preflight configs are frequently minimal
+    (a ``database_url`` only). Supply sane defaults for the build-only fields so
+    a minimal config still validates, rather than failing before a migration
+    that never touches them.
+
+    confiture #168 (0.33) defaults these in ``Migrator.from_config(path)``, but
+    fraisier builds the ``Environment`` directly via ``model_validate`` (to
+    inject the ``database_url`` override), which is still strict — so this
+    defaulting remains necessary.
+    """
     import yaml
     from confiture.config.environment import Environment
 
-    raw: dict = yaml.safe_load(Path(config_path).read_text())  # type: ignore[assignment]
+    raw: dict = yaml.safe_load(Path(config_path).read_text()) or {}  # type: ignore[assignment]
+    raw.setdefault("name", Path(config_path).stem)
+    raw.setdefault("include_dirs", [])
     if database_url:
         raw["database_url"] = database_url
     return Environment.model_validate(raw)
@@ -96,95 +110,74 @@ def _resolve_config(
     return config_path
 
 
+def _confiture_dist_version() -> str:
+    """Installed ``fraiseql-confiture`` version, or ``"unknown"``."""
+    import importlib.metadata as _md
+
+    try:
+        return _md.version("fraiseql-confiture")
+    except _md.PackageNotFoundError:
+        return "unknown"
+
+
+# fraise hook-config key → (HookPhase name, builtin config class, builtin hook
+# class). The notification hooks (slack/teams/discord/email/webhook) were
+# dropped from confiture's builtin set in the 0.30 rewrite; fraisier registers
+# whichever hooks the installed confiture still ships and skips the rest with a
+# warning rather than letting one missing class disable *all* hooks.
+_HOOK_SPECS: dict[str, tuple[str, str, str]] = {
+    "backup": ("BEFORE_EXECUTE", "BackupConfig", "BackupHook"),
+    "audit": ("AFTER_EXECUTE", "AuditConfig", "AuditHook"),
+    "slack": ("AFTER_EXECUTE", "SlackConfig", "SlackNotificationHook"),
+    "teams": ("AFTER_EXECUTE", "TeamsConfig", "TeamsNotificationHook"),
+    "discord": ("AFTER_EXECUTE", "DiscordConfig", "DiscordNotificationHook"),
+    "email": ("AFTER_EXECUTE", "EmailConfig", "EmailNotificationHook"),
+    "webhook": ("AFTER_EXECUTE", "WebhookConfig", "WebhookNotificationHook"),
+}
+
+
 def _register_migration_hooks(
     migrator: Any, hooks_config: dict[str, Any] | None
 ) -> None:
-    """Register confiture v0.8.22 hooks with the migrator.
+    """Register confiture migration hooks with the migrator.
 
     Reads the ``hooks:`` sub-section of a fraise's database config and
-    registers the corresponding confiture built-in hooks.  Gracefully
-    skips if confiture hooks are not available.
+    registers the corresponding confiture built-in hooks.  Each hook class is
+    resolved individually, so a hook type the installed confiture no longer
+    ships (e.g. the notification hooks removed in the 0.30 rewrite) is skipped
+    with a warning instead of disabling every hook.
     """
     if not hooks_config:
         return
 
     try:
-        from confiture.core.hooks import HookPhase
-        from confiture.core.hooks.builtin import (
-            AuditConfig,
-            AuditHook,
-            BackupConfig,
-            BackupHook,
-            DiscordConfig,
-            DiscordNotificationHook,
-            EmailConfig,
-            EmailNotificationHook,
-            SlackConfig,
-            SlackNotificationHook,
-            TeamsConfig,
-            TeamsNotificationHook,
-            WebhookConfig,
-            WebhookNotificationHook,
-        )
+        from confiture.core.hooks import HookPhase, builtin
     except ImportError:
         log.warning("Confiture hooks not available (requires confiture >= 0.8.22)")
         return
 
-    _HOOK_BUILDERS: dict[str, tuple] = {
-        "backup": (
-            HookPhase.BEFORE_EXECUTE,
-            BackupConfig,
-            BackupHook,
-            {"backup_dir": Path, "database_url": str},
-        ),
-        "audit": (
-            HookPhase.AFTER_EXECUTE,
-            AuditConfig,
-            AuditHook,
-            {"database_url": str, "signing_key": str},
-        ),
-        "slack": (
-            HookPhase.AFTER_EXECUTE,
-            SlackConfig,
-            SlackNotificationHook,
-            {"webhook_url": str},
-        ),
-        "teams": (
-            HookPhase.AFTER_EXECUTE,
-            TeamsConfig,
-            TeamsNotificationHook,
-            {"webhook_url": str},
-        ),
-        "discord": (
-            HookPhase.AFTER_EXECUTE,
-            DiscordConfig,
-            DiscordNotificationHook,
-            {"webhook_url": str},
-        ),
-        "email": (
-            HookPhase.AFTER_EXECUTE,
-            EmailConfig,
-            EmailNotificationHook,
-            {"smtp_server": str},
-        ),
-        "webhook": (
-            HookPhase.AFTER_EXECUTE,
-            WebhookConfig,
-            WebhookNotificationHook,
-            {"url": str},
-        ),
-    }
-
-    for hook_key, (phase, config_cls, hook_cls, _) in _HOOK_BUILDERS.items():
+    for hook_key, (phase_name, config_name, hook_name) in _HOOK_SPECS.items():
         cfg = hooks_config.get(hook_key, {})
         if not cfg.get("enabled", False):
+            continue
+        config_cls = getattr(builtin, config_name, None)
+        hook_cls = getattr(builtin, hook_name, None)
+        if config_cls is None or hook_cls is None:
+            # This confiture release does not ship this hook (notification
+            # hooks were removed in 0.30). Surface it rather than silently
+            # dropping a configured notification.
+            log.warning(
+                "Confiture %s does not provide the %s hook; skipping it",
+                _confiture_dist_version(),
+                hook_key,
+            )
             continue
         try:
             # Strip 'enabled' before passing to config dataclass
             params = {k: v for k, v in cfg.items() if k != "enabled"}
             config = config_cls(**params)
             hook = hook_cls(config)
-            migrator.register_hook(phase, hook)
+            migrator.register_hook(getattr(HookPhase, phase_name), hook)
             log.info("Registered %s hook", hook_key)
         except Exception as exc:
             # Hook registration is best-effort: a misconfigured hook (bad
@@ -466,7 +459,14 @@ class StatusResult:
     raw: str = ""
 
 
-_MIGRATION_COUNT_RE = re.compile(r"(?:Applied|Rolled back)\s+(\d+)\s+migration")
+# confiture prints the applied/rolled-back count differently across versions:
+# 0.9.x "Applied N migration(s)" / "Rolled back N migration(s)"; 0.32 a
+# "Migrations: N" summary line for `up` and a lower-cased "rolled back N
+# migration(s)" for `down`. Match all, case-insensitively.
+_MIGRATION_COUNT_RES = (
+    re.compile(r"(?:Applied|Rolled back)\s+(\d+)\s+migration", re.IGNORECASE),
+    re.compile(r"Migrations:\s+(\d+)"),
+)
 
 _SCHEMA_ERROR_PATTERNS = (
     "already exists",
@@ -490,9 +490,12 @@ _LOCK_ERROR_PATTERNS = (
 
 
 def parse_migration_count(output: str) -> int:
-    """Extract migration count from confiture stdout."""
-    m = _MIGRATION_COUNT_RE.search(output)
-    return int(m.group(1)) if m else 0
+    """Extract the applied/rolled-back migration count from confiture stdout."""
+    for rx in _MIGRATION_COUNT_RES:
+        m = rx.search(output)
+        if m:
+            return int(m.group(1))
+    return 0
 
 
 def classify_error(stderr: str) -> str:

--- a/fraisier/dbops/preflight.py
+++ b/fraisier/dbops/preflight.py
@@ -276,6 +276,48 @@ class PreflightDatabase:
         )
         return result.returncode == 0 and result.stdout.strip() == "t"
 
+    def _scalar_int(self, sql: str) -> int | None:
+        """Run *sql* expecting a single integer; ``None`` on any failure."""
+        conn_flags, run_env = self._conn_flags()
+        result = subprocess.run(
+            ["psql", *conn_flags, "-tAc", sql],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=run_env,
+        )
+        out = result.stdout.strip()
+        if result.returncode != 0 or not out.isdigit():
+            return None
+        return int(out)
+
+    def count_table_rows(self, table_name: str) -> int | None:
+        """Return the row count of *table_name*, or ``None`` if it can't be read.
+
+        Used to tell a *populated* migration ledger (the backup recorded which
+        migrations are applied) from an *empty* one — the signal the #262 guard
+        keys off.
+        """
+        if not _SAFE_IDENTIFIER.match(table_name):
+            return None
+        return self._scalar_int(f"SELECT count(*) FROM {table_name}")
+
+    def count_user_relations(self, exclude_table: str) -> int | None:
+        """Count user tables/views in this DB, excluding *exclude_table*.
+
+        A schema-only restore of a real production backup recreates the
+        application's tables and views; a brand-new (never-migrated) database
+        has none.  This distinguishes a *populated schema with an empty ledger*
+        (a failed tracking-data restore → #262) from a *genuinely fresh* backup
+        (legitimately empty ledger, nothing to collide with).
+        """
+        base = exclude_table.rsplit(".", 1)[-1].replace("'", "''")
+        return self._scalar_int(
+            "SELECT count(*) FROM information_schema.tables "
+            "WHERE table_schema NOT IN ('pg_catalog', 'information_schema') "
+            f"AND table_name <> '{base}'"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Phase 2: Result types + confiture integration
@@ -318,6 +360,7 @@ class MigrationPreflightResult:
     migrations: list[MigrationCheck]
     schema_extraction_ms: int = 0
     total_ms: int = 0
+    migrations_checked: int = 0
 
     @property
     def all_passed(self) -> bool:
@@ -441,9 +484,9 @@ _SKIP_PREFLIGHT_HINT = (
 def _extract_preflight_issues(stdout: str) -> str | None:
     """Pull human-readable issue lines from confiture's JSON preflight output.
 
-    Tolerant of both the 0.9.x (``{"against": {"migrations": [...]}}``) and the
-    0.30+ (``{"issues": [...]}``) schemas. Returns ``None`` when *stdout* is not
-    the expected JSON or carries no surfaced issues.
+    Reads confiture's 0.30+ ``{"issues": [...]}`` schema (an array of
+    ``{severity, code, message, migration, details.error}``). Returns ``None``
+    when *stdout* is not the expected JSON or carries no surfaced issues.
     """
     try:
         data = json.loads(stdout)
@@ -453,29 +496,19 @@ def _extract_preflight_issues(stdout: str) -> str | None:
         return None
 
     lines: list[str] = []
-    # 0.30+ schema: a top-level "issues" array of {code, message, migration,
-    # details.error}.
     for issue in data.get("issues") or []:
+        severity = issue.get("severity", "")
         code = issue.get("code", "")
         message = issue.get("message", "")
         migration = issue.get("migration")
         error = (issue.get("details") or {}).get("error")
-        text = " ".join(p for p in (code, message) if p)
+        text = " ".join(p for p in (severity, code, message) if p)
         if migration:
             text = f"{text} [migration {migration}]"
         if error:
             text = f"{text} — {error}"
         if text:
             lines.append(f"  - {text}")
-    # 0.9.x schema: per-migration success/error under against.migrations.
-    against = data.get("against", data)
-    if isinstance(against, dict):
-        lines.extend(
-            f"  - migration {m.get('version', '?')} "
-            f"({m.get('name', '?')}) failed: {m.get('error', '')}"
-            for m in (against.get("migrations") or [])
-            if not m.get("success", True) and not m.get("skipped", False)
-        )
     return "\n".join(lines) if lines else None
 
 
@@ -511,6 +544,83 @@ def _confiture_version() -> str | None:
         return None
 
 
+# A non-transactional statement (CREATE INDEX CONCURRENTLY, ALTER TYPE … ADD
+# VALUE, …) cannot run inside the SAVEPOINT confiture's preflight uses, so it is
+# skipped rather than replayed (`migrate up` runs it for real in autocommit).
+# confiture 0.33 surfaces such a migration as a PFLIGHT_NON_TRANSACTIONAL
+# warning and skips it (exit 0, confiture #169) — fraisier records the skip so a
+# later dependent failure reads as a possible false positive, not a hard block.
+_NON_TXN_CODE = "PFLIGHT_NON_TRANSACTIONAL"
+_MIGRATION_NAME_RE = re.compile(r"Migration \S+ \(([^)]+)\)")
+
+
+def _name_from_issue_message(message: str) -> str:
+    """Extract the migration name from a confiture issue message.
+
+    0.32 issue messages read ``"Migration <version> (<name>) …"``; returns the
+    captured name, or ``"?"`` when the message does not match.
+    """
+    m = _MIGRATION_NAME_RE.search(message or "")
+    return m.group(1) if m else "?"
+
+
+def _parse_against_issues(data: dict) -> MigrationPreflightResult | None:
+    """Map confiture 0.33 ``preflight --against`` JSON to a structured result.
+
+    confiture emits ``{"ok", "summary": {"migrations_checked": N}, "issues":
+    [...]}``. A ``PFLIGHT_NON_TRANSACTIONAL`` warning records a *skipped*
+    migration; every other error-severity issue becomes a failed
+    ``MigrationCheck``.
+
+    Returns ``None`` when an error-severity issue cannot be tied to a migration
+    (a structural/config error), signalling the caller to raise full diagnostics
+    rather than report a bare, unmappable failure.
+    """
+    summary = data.get("summary") or {}
+    checked = summary.get("migrations_checked", 0)
+    issues = data.get("issues") or []
+
+    checks: list[MigrationCheck] = []
+    skipped_versions: set[str] = set()
+
+    # Pass 1: non-transactional migrations are skipped during preflight.
+    for issue in issues:
+        version = issue.get("migration")
+        if issue.get("code") == _NON_TXN_CODE and version:
+            if version not in skipped_versions:
+                checks.append(
+                    MigrationCheck(
+                        version=version,
+                        name=_name_from_issue_message(issue.get("message", "")),
+                        passed=True,
+                        skipped=True,
+                        skipped_reason=issue.get("message"),
+                    )
+                )
+                skipped_versions.add(version)
+
+    # Pass 2: error-severity issues are real failures.
+    for issue in issues:
+        if issue.get("severity") != "error":
+            continue
+        version = issue.get("migration")
+        if version in skipped_versions:
+            continue
+        if not version:
+            return None
+        error = (issue.get("details") or {}).get("error") or issue.get("message", "")
+        checks.append(
+            MigrationCheck(
+                version=version,
+                name=_name_from_issue_message(issue.get("message", "")),
+                passed=False,
+                error=error,
+            )
+        )
+
+    return MigrationPreflightResult(migrations=checks, migrations_checked=checked)
+
+
 def _run_confiture_preflight(
     confiture_config: Path | None,
     migrations_dir: Path,
@@ -522,9 +632,10 @@ def _run_confiture_preflight(
     """Run ``confiture migrate preflight --against`` via subprocess.
 
     Invokes the confiture CLI with ``--format json`` so the output can be
-    parsed into a structured ``MigrationPreflightResult``.  Exit code 0 means
-    all passed; exit code 1 means failures were detected — both are valid
-    preflight outcomes.  Any other exit code indicates a fatal error.
+    parsed into a structured ``MigrationPreflightResult``.  With ``--against``,
+    confiture 0.32 exits 0 when all replays pass and 7 when one or more fail —
+    both valid outcomes that are parsed.  Any other exit code (validation,
+    connection, config) indicates a fatal error.
 
     Args:
         confiture_config: Config file used to resolve the pending set (its
@@ -570,10 +681,11 @@ def _run_confiture_preflight(
         timeout=timeout_seconds,
     )
 
-    # 0 = all passed, 1 = failures detected — both are valid preflight outcomes.
-    # Any other code (e.g. confiture's exit 7 = PFLIGHT_REPLAY_FAILED) is fatal:
-    # surface confiture's own diagnostics, which it writes to *stdout* (#259).
-    if result.returncode not in (0, 1):
+    # With --against, confiture 0.32 exits 0 = all replays passed, 7 = one or
+    # more replay failures — both valid, structured outcomes to parse. Any other
+    # code (2 validation, 3 connection, 5 config, …) is a fatal crash: surface
+    # confiture's own diagnostics, which it writes to *stdout* (#259).
+    if result.returncode not in (0, 7):
         raise DatabaseError(
             _format_preflight_failure(result.returncode, result.stdout, result.stderr)
         )
@@ -585,39 +697,68 @@ def _run_confiture_preflight(
             _format_preflight_failure(result.returncode, result.stdout, result.stderr)
         ) from exc
 
-    # Output format: {"static": {...}, "against": {...}} when --against is used.
-    against_data: dict = data.get("against", data)
-
-    # A recognized result carries a per-migration "migrations" array (0.9.x).
-    # Newer confiture (0.30+) emits {"ok", "issues": [...]} with no such array:
-    # fraisier cannot map it and must NOT silently treat it as "no failures",
-    # which would hide real preflight failures under a skewed confiture (#259).
-    if not isinstance(against_data, dict) or "migrations" not in against_data:
+    # 0.32 schema: {"ok", "summary", "issues": [...]}. A missing summary/issues
+    # means a skewed confiture (e.g. the old 0.9.x against.migrations format):
+    # fraisier must NOT silently treat it as "no failures", which would hide real
+    # preflight failures under a version skew (#259, #262).
+    if not isinstance(data, dict) or "summary" not in data or "issues" not in data:
         detail = (
-            _extract_preflight_issues(result.stdout) or (result.stdout.strip()[:2000])
+            _extract_preflight_issues(result.stdout) or result.stdout.strip()[:2000]
         )
         raise DatabaseError(
             "confiture preflight returned an unrecognized output schema "
             f"(fraiseql-confiture {_confiture_version() or 'unknown'}); fraisier "
-            "expects the confiture 0.9.x preflight format. This is a version "
-            "skew — pin fraiseql-confiture to a supported version.\n"
-            f"{detail}\n{_SKIP_PREFLIGHT_HINT}"
+            "expects the confiture 0.30+ preflight format ({ok, summary, issues}). "
+            "This is a version skew — pin fraiseql-confiture to a supported "
+            f"version.\n{detail}\n{_SKIP_PREFLIGHT_HINT}"
         )
 
-    migrations = [
-        MigrationCheck(
-            version=m["version"],
-            name=m["name"],
-            passed=m["success"],
-            error=m.get("error"),
-            time_ms=m.get("execution_time_ms", 0),
-            skipped=m.get("skipped", False),
-            skipped_reason=m.get("skipped_reason"),
+    parsed = _parse_against_issues(data)
+    if parsed is None:
+        # exit 7 carried an error-severity issue not tied to a migration
+        # (structural/config): not representable per-migration — surface the
+        # raw diagnostics rather than report a bare, unmappable failure.
+        raise DatabaseError(
+            _format_preflight_failure(result.returncode, result.stdout, result.stderr)
         )
-        for m in against_data.get("migrations", [])
-    ]
 
-    return MigrationPreflightResult(migrations=migrations)
+    return parsed
+
+
+def _guard_against_empty_ledger(
+    preflight_db: PreflightDatabase, tracking_table: str
+) -> None:
+    """Refuse to preflight a populated schema whose ledger restored empty (#262).
+
+    The preflight DB is a schema-only restore of the backup plus a data-only
+    restore of *tracking_table*.  When the table exists (the backup was
+    confiture-managed) and the restored schema already holds application
+    objects, but the tracking ledger is empty, confiture would treat the entire
+    history as pending and replay every already-applied migration against the
+    already-populated schema — a cascade of false ``already exists`` /
+    dependency failures (issue #262).  That is a failed tracking-data restore,
+    not a real preflight failure, so surface it precisely instead.
+
+    No-ops when the ledger has rows (the #250 happy path), when the schema is
+    genuinely empty (a fresh, never-migrated backup — replaying all is safe),
+    or when either count cannot be read (stay out of the way).
+    """
+    from fraisier.errors import DatabaseError
+
+    if preflight_db.count_table_rows(tracking_table) != 0:
+        return
+    if (preflight_db.count_user_relations(tracking_table) or 0) == 0:
+        return
+    raise DatabaseError(
+        "Migration preflight aborted: the backup's confiture tracking table "
+        f"({tracking_table}) restored with 0 rows, but the restored schema "
+        "already contains application objects. Replaying the full migration "
+        "history against it would produce false 'already exists' failures "
+        "(issue #262) — the backup's migration ledger did not restore. Verify "
+        "the backup contains tracking-table data and that the bundled confiture "
+        "matches the source database. If this backup genuinely has no applied "
+        "migrations, re-run the restore with --skip-preflight."
+    )
 
 
 def run_migration_preflight(
@@ -689,7 +830,20 @@ def run_migration_preflight(
             preflight_db.restore_schema(schema_path)
             preflight_db.restore_tracking_data(backup_path, tracking_table)
 
-            if preflight_db.has_table(tracking_table):
+            if not preflight_db.has_table(tracking_table):
+                # Backup predates/omits confiture tracking → no migration is
+                # recorded as applied, and with no tracking table there are no
+                # migration-managed objects to collide with, so every migration
+                # is genuinely pending.
+                result = _run_confiture_preflight(
+                    confiture_config=None,
+                    migrations_dir=migrations_dir,
+                    against_url=preflight_db.url,
+                    since="00000000000000",
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                _guard_against_empty_ledger(preflight_db, tracking_table)
                 # Backup carries confiture tracking → resolve pending from the
                 # self-consistent preflight DB, matching a real restore (#250).
                 preflight_cfg = _write_preflight_config(
@@ -701,22 +855,13 @@ def run_migration_preflight(
                     against_url=preflight_db.url,
                     timeout_seconds=timeout_seconds,
                 )
-            else:
-                # Backup predates/omits confiture tracking → no migration is
-                # recorded as applied, so every migration is pending.
-                result = _run_confiture_preflight(
-                    confiture_config=None,
-                    migrations_dir=migrations_dir,
-                    against_url=preflight_db.url,
-                    since="00000000000000",
-                    timeout_seconds=timeout_seconds,
-                )
 
         total_ms = int((time.monotonic() - start) * 1000)
         return MigrationPreflightResult(
             migrations=result.migrations,
             schema_extraction_ms=schema_ms,
             total_ms=total_ms,
+            migrations_checked=result.migrations_checked,
         )
     finally:
         # Clean up temp files (preflight config first — it lives in the schema

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -114,7 +114,7 @@ class RestoreMigrateStrategy(Strategy):
         if result.all_passed:
             log.info(
                 "Preflight passed: %d migrations validated in %dms",
-                len(result.migrations),
+                result.migrations_checked or len(result.migrations),
                 result.total_ms,
             )
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,13 @@ classifiers = [
   "Topic :: System :: Systems Administration"
 ]
 dependencies = [
-  # Floor 0.9.4: `migrate preflight --against` applies pending migrations
-  # cumulatively (RELEASE SAVEPOINT on success), so inter-dependent pending
-  # migrations preflight green — verified on 0.9.4/0.18.0/0.30.0 (issue #250).
-  "fraiseql-confiture>=0.9.4,<1.0",
+  # Pinned to the 0.33.x line: fraisier's confiture integration (Python API
+  # result shapes, preflight --against JSON schema {ok,summary,issues[]} + exit
+  # codes 0/7) targets it. 0.33 also fixed confiture #168 (from_config accepts a
+  # minimal config) and #169 (non-transactional migrations skipped, not failed,
+  # in preflight). The upper bound prevents silent drift onto a future schema
+  # change (issue #262).
+  "fraiseql-confiture>=0.33.0,<0.34",
   "fastapi>=0.109.0,<1.0",
   "uvicorn>=0.27.0,<1.0",
   "pyyaml>=6.0,<7.0",
@@ -34,7 +37,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.39.0"
+version = "0.40.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_dbops.py
+++ b/tests/test_dbops.py
@@ -350,10 +350,22 @@ class TestParseConfitureOutput:
     def test_parse_migration_count_from_stdout(self):
         from fraisier.dbops.confiture import parse_migration_count
 
+        # 0.9.x phrasing
         assert parse_migration_count("Applied 5 migrations\n") == 5
         assert parse_migration_count("Applied 1 migration\n") == 1
         assert parse_migration_count("Nothing to do\n") == 0
         assert parse_migration_count("Rolled back 3 migrations\n") == 3
+        # confiture 0.32 phrasing: "Migrations: N" summary for up, lower-cased
+        # "rolled back N migration(s)" for down.
+        assert (
+            parse_migration_count(
+                "✅ Successfully applied migrations!\nMigrations: 2\n"
+            )
+            == 2
+        )
+        assert (
+            parse_migration_count("✅ Successfully rolled back 1 migration(s)!\n") == 1
+        )
 
     def test_classify_confiture_error(self):
         from fraisier.dbops.confiture import classify_error
@@ -458,7 +470,13 @@ class TestHookIntegration:
         not _has_confiture_hooks(),
         reason="confiture >= 0.8.22 hooks not installed",
     )
-    def test_register_slack_hook(self):
+    def test_notification_hook_skipped_when_unavailable(self):
+        """Notification hooks were removed from confiture's builtins in 0.30.
+
+        A configured slack/notification hook must degrade gracefully — skipped
+        with a warning, never registered, and never raising — rather than
+        disabling every other hook.
+        """
         from fraisier.dbops.confiture import _register_migration_hooks
 
         mock_migrator = MagicMock()
@@ -470,13 +488,18 @@ class TestHookIntegration:
         }
         _register_migration_hooks(mock_migrator, hooks_config)
 
-        mock_migrator.register_hook.assert_called_once()
+        mock_migrator.register_hook.assert_not_called()
 
     @pytest.mark.skipif(
         not _has_confiture_hooks(),
         reason="confiture >= 0.8.22 hooks not installed",
     )
     def test_register_multiple_hooks(self):
+        """Available hooks register; a removed notification hook is skipped.
+
+        With confiture 0.30+, backup is registered but the slack notification
+        hook no longer exists — so exactly one hook (backup) registers.
+        """
         from fraisier.dbops.confiture import _register_migration_hooks
 
         mock_migrator = MagicMock()
@@ -493,7 +516,34 @@ class TestHookIntegration:
         }
         _register_migration_hooks(mock_migrator, hooks_config)
 
-        assert mock_migrator.register_hook.call_count == 2
+        assert mock_migrator.register_hook.call_count == 1
+
+
+class TestLoadEnv:
+    """confiture 0.30+ Environment validation (name/include_dirs required)."""
+
+    def test_minimal_config_validates(self, tmp_path):
+        """A minimal database_url-only config must still load — fraisier supplies
+        defaults for confiture's now-required build-only fields."""
+        from fraisier.dbops.confiture import _load_env
+
+        cfg = tmp_path / "confiture.yaml"
+        cfg.write_text("database_url: postgresql://u@localhost/db\n")
+
+        env = _load_env(cfg)
+
+        assert env.database_url == "postgresql://u@localhost/db"
+        assert env.name  # defaulted, non-empty
+
+    def test_database_url_override_wins(self, tmp_path):
+        from fraisier.dbops.confiture import _load_env
+
+        cfg = tmp_path / "confiture.yaml"
+        cfg.write_text("database_url: postgresql://u@localhost/original\n")
+
+        env = _load_env(cfg, database_url="postgresql://u@localhost/override")
+
+        assert env.database_url == "postgresql://u@localhost/override"
 
 
 class TestSchemaHash:

--- a/tests/test_preflight_e2e.py
+++ b/tests/test_preflight_e2e.py
@@ -319,8 +319,88 @@ class TestPreflightBackupBehindTracking:
             f"{[(m.version, m.error) for m in result.failures]}"
         )
         # V0 is already applied in the backup → not pending; only V1, V2 run.
-        versions = {m.version for m in result.migrations}
-        assert versions == {"20260102000000", "20260103000000"}
+        # confiture 0.32 reports the count of checked migrations (it does not
+        # enumerate passing ones): exactly 2 means V0 was excluded, not replayed.
+        assert result.migrations_checked == 2
+
+
+@pytest.mark.integration
+class TestPreflightEmptyLedgerGuard:
+    """Issue #262: a populated schema whose tracking ledger restored empty.
+
+    When the backup's ``tb_confiture`` data fails to restore, the preflight DB
+    has the full schema but an empty applied-migration ledger.  confiture would
+    then treat the entire history as pending and replay every already-applied
+    migration against the already-populated schema, failing en masse with false
+    ``already exists`` errors.  The preflight must refuse with a precise error
+    rather than emit that cascade — the already-applied migrations must NOT be
+    replayed.
+    """
+
+    def test_empty_ledger_populated_schema_aborts(
+        self, admin_url, confiture_config, tmp_path
+    ):
+        from fraisier.errors import DatabaseError
+
+        # Source DB with V0 applied via confiture (creates `widgets` + a
+        # tb_confiture row), then strip the ledger rows to mimic a backup whose
+        # tracking data won't restore. The dump keeps the `widgets` table but an
+        # empty tb_confiture — exactly the #262 shape.
+        src = f"fraisier_test_emptyledger_{uuid.uuid4().hex[:8]}"
+        _run_psql(admin_url, f"CREATE DATABASE {src}")
+        src_url = _replace_db_in_url(admin_url, src)
+        try:
+            v0 = tmp_path / "v0"
+            v0.mkdir()
+            (v0 / "20260101000000_widgets.up.sql").write_text(
+                "CREATE TABLE public.widgets (id BIGINT PRIMARY KEY);\n"
+            )
+            (v0 / "20260101000000_widgets.down.sql").write_text(
+                "DROP TABLE public.widgets;\n"
+            )
+            src_cfg = tmp_path / "src.yaml"
+            src_cfg.write_text(f"database_url: {src_url}\n")
+            subprocess.run(
+                [
+                    "confiture",
+                    "migrate",
+                    "up",
+                    "--config",
+                    str(src_cfg),
+                    "--migrations-dir",
+                    str(v0),
+                ],
+                check=True,
+                capture_output=True,
+            )
+            _run_psql(src_url, "DELETE FROM tb_confiture")  # ledger lost
+            backup = tmp_path / "emptyledger.dump"
+            subprocess.run(
+                ["pg_dump", "-Fc", "-f", str(backup), src_url],
+                check=True,
+                capture_output=True,
+            )
+        finally:
+            _run_psql(admin_url, f"DROP DATABASE IF EXISTS {src}")
+
+        # Migration set still contains V0, whose object already exists in the
+        # restored schema. With an empty ledger it would be wrongly replayed.
+        migrations_dir = tmp_path / "migrations"
+        migrations_dir.mkdir()
+        (migrations_dir / "20260101000000_widgets.up.sql").write_text(
+            "CREATE TABLE public.widgets (id BIGINT PRIMARY KEY);\n"
+        )
+        (migrations_dir / "20260101000000_widgets.down.sql").write_text(
+            "DROP TABLE public.widgets;\n"
+        )
+
+        with pytest.raises(DatabaseError, match=r"262|0 rows|did not restore"):
+            run_migration_preflight(
+                backup_path=backup,
+                admin_url=admin_url,
+                confiture_config=confiture_config,
+                migrations_dir=migrations_dir,
+            )
 
 
 @pytest.mark.integration
@@ -359,8 +439,7 @@ class TestPreflightE2EInterdependent:
 
         assert result.all_passed is True
         assert result.failure_count == 0
-        versions = {m.version for m in result.migrations}
-        assert versions == {"20260429130000", "20260429140000"}
+        assert result.migrations_checked == 2
 
     def test_interdependent_python_pending_passes(
         self, admin_url, sample_backup, confiture_config, tmp_path
@@ -407,8 +486,7 @@ class TestPreflightE2EInterdependent:
             f"green; got failures: {[(m.version, m.error) for m in result.failures]}"
         )
         assert result.failure_count == 0
-        versions = {m.version for m in result.migrations}
-        assert versions == {"20260429130000", "20260429140000"}
+        assert result.migrations_checked == 2
 
 
 @pytest.mark.integration

--- a/tests/test_preflight_run.py
+++ b/tests/test_preflight_run.py
@@ -28,42 +28,61 @@ def _proc(
     return subprocess.CompletedProcess([], returncode, stdout, stderr)
 
 
-def _against_json(migrations: list[dict]) -> str:
-    """Build the JSON envelope confiture emits when --against is used."""
+def _pf_json(
+    issues: list[dict] | None = None, *, ok: bool | None = None, checked: int = 0
+) -> str:
+    """Build the JSON confiture 0.32 emits for ``migrate preflight --against``.
+
+    Shape: ``{ok, window_safe, summary, issues[]}``. ``ok`` defaults to "no
+    error-severity issues"; ``checked`` is ``summary.migrations_checked``.
+    """
+    issues = issues or []
+    errors = sum(1 for i in issues if i.get("severity") == "error")
+    warnings = sum(1 for i in issues if i.get("severity") == "warning")
     return json.dumps(
         {
-            "static": {},
-            "against": {
-                "against_url": "postgresql://admin@localhost/fraisier_preflight_abc",
-                "migrations": migrations,
+            "ok": (errors == 0) if ok is None else ok,
+            "window_safe": True,
+            "summary": {
+                "errors": errors,
+                "warnings": warnings,
+                "info": 0,
+                "migrations_checked": checked,
+                "db_consumed": False,
             },
+            "issues": issues,
         }
     )
 
 
-def _mig(
-    version: str,
-    name: str,
-    success: bool,
-    *,
-    error: str | None = None,
-    skipped: bool = False,
-    skipped_reason: str | None = None,
-    time_ms: int = 50,
-) -> dict:
-    m: dict = {
-        "version": version,
-        "name": name,
-        "success": success,
-        "execution_time_ms": time_ms,
+def _replay_failed(version: str, name: str, error: str) -> dict:
+    """A confiture 0.32 PFLIGHT_REPLAY_FAILED error issue."""
+    return {
+        "severity": "error",
+        "code": "PFLIGHT_REPLAY_FAILED",
+        "message": (
+            f"Migration {version} ({name}) failed to replay against the preflight DB."
+        ),
+        "migration": version,
+        "file": None,
+        "line": None,
+        "details": {"error": error},
     }
-    if error is not None:
-        m["error"] = error
-    if skipped:
-        m["skipped"] = True
-    if skipped_reason is not None:
-        m["skipped_reason"] = skipped_reason
-    return m
+
+
+def _non_txn_warning(
+    version: str, name: str, stmt: str = "CREATE INDEX CONCURRENTLY: idx"
+) -> dict:
+    """A confiture 0.32 PFLIGHT_NON_TRANSACTIONAL warning issue."""
+    return {
+        "severity": "warning",
+        "code": "PFLIGHT_NON_TRANSACTIONAL",
+        "message": (
+            f"Migration {version} ({name}) has non-transactional statement(s): {stmt}."
+        ),
+        "migration": version,
+        "details": {"statements": [stmt]},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -77,22 +96,25 @@ class TestRunConfiturePreflight:
     _URL = "postgresql://admin@localhost/fraisier_preflight_abc"
 
     def test_exit_0_all_passed(self):
-        stdout = _against_json([_mig("001", "ok", True)])
+        # 0.32 enumerates only issues, not passing migrations; success is an
+        # empty issue list with the count in summary.migrations_checked.
+        stdout = _pf_json([], checked=1)
         with patch("subprocess.run", return_value=_proc(0, stdout)):
             result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         assert result.all_passed is True
-        assert len(result.migrations) == 1
-        assert result.migrations[0].version == "001"
-        assert result.migrations[0].passed is True
+        assert result.failure_count == 0
+        assert result.migrations_checked == 1
 
-    def test_exit_1_failures_recorded(self):
-        stdout = _against_json(
-            [_mig("001", "bad", False, error="column does not exist")]
+    def test_exit_7_failures_recorded(self):
+        stdout = _pf_json(
+            [_replay_failed("001", "bad", "column does not exist")], checked=1
         )
-        with patch("subprocess.run", return_value=_proc(1, stdout)):
+        with patch("subprocess.run", return_value=_proc(7, stdout)):
             result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         assert result.all_passed is False
         assert result.failure_count == 1
+        assert result.failures[0].version == "001"
+        assert result.failures[0].name == "bad"
         assert result.failures[0].error == "column does not exist"
 
     def test_exit_2_raises_database_error(self):
@@ -109,73 +131,47 @@ class TestRunConfiturePreflight:
         ):
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
 
-    def test_against_envelope_key_extracted(self):
-        """Output with "against" key uses the against sub-object."""
-        migrations = [_mig("001", "ok", True)]
-        stdout = json.dumps({"static": {}, "against": {"migrations": migrations}})
+    def test_non_transactional_recorded_as_skipped(self):
+        """confiture 0.33 skips a non-transactional migration in preflight — a
+        PFLIGHT_NON_TRANSACTIONAL warning and exit 0, not a replay failure
+        (#169). fraisier records it as a skipped check, never a block."""
+        stdout = _pf_json([_non_txn_warning("001", "conc_idx")], checked=1)
         with patch("subprocess.run", return_value=_proc(0, stdout)):
             result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
-        assert len(result.migrations) == 1
-
-    def test_flat_envelope_fallback(self):
-        """Output without "against" key falls back to root data."""
-        migrations = [_mig("001", "ok", True)]
-        stdout = json.dumps({"migrations": migrations})
-        with patch("subprocess.run", return_value=_proc(0, stdout)):
-            result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
-        assert len(result.migrations) == 1
-
-    def test_skipped_migration_recorded(self):
-        migrations = [
-            _mig(
-                "001",
-                "skip_me",
-                True,
-                skipped=True,
-                skipped_reason="non-transactional",
-            )
-        ]
-        stdout = _against_json(migrations)
-        with patch("subprocess.run", return_value=_proc(0, stdout)):
-            result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
-        assert result.migrations[0].skipped is True
-        assert result.migrations[0].skipped_reason == "non-transactional"
+        assert result.all_passed is True
+        assert result.failure_count == 0
+        assert any(m.skipped for m in result.migrations)
 
     def test_executable_resolved_from_venv(self):
         """confiture is resolved relative to sys.executable, not as a bare name."""
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         cmd = mock_run.call_args[0][0]
         expected_exe = str(Path(sys.executable).parent / "confiture")
         assert cmd[0] == expected_exe
 
     def test_command_includes_against_flag(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         cmd = mock_run.call_args[0][0]
         assert "--against" in cmd
         assert self._URL in cmd
 
     def test_command_includes_config_flag(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(Path("custom.yaml"), self._MIGRATIONS, self._URL)
         cmd = mock_run.call_args[0][0]
         assert "--config" in cmd
         assert "custom.yaml" in cmd
 
     def test_command_omits_config_when_none(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(None, self._MIGRATIONS, self._URL)
         cmd = mock_run.call_args[0][0]
         assert "--config" not in cmd
 
     def test_command_includes_since_when_set(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(
                 None, self._MIGRATIONS, self._URL, since="00000000000000"
             )
@@ -184,48 +180,45 @@ class TestRunConfiturePreflight:
         assert "00000000000000" in cmd
 
     def test_command_includes_migrations_dir(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(self._CFG, Path("custom/migrations"), self._URL)
         cmd = mock_run.call_args[0][0]
         assert "--migrations-dir" in cmd
         assert "custom/migrations" in cmd
 
     def test_command_includes_format_json(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         cmd = mock_run.call_args[0][0]
         assert "--format" in cmd
         assert "json" in cmd
 
     def test_empty_migrations_list(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)):
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())):
             result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         assert result.all_passed is True
         assert result.migrations == []
 
     def test_timeout_seconds_passed_to_subprocess(self):
-        stdout = _against_json([])
-        with patch("subprocess.run", return_value=_proc(0, stdout)) as mock_run:
+        with patch("subprocess.run", return_value=_proc(0, _pf_json())) as mock_run:
             _run_confiture_preflight(
                 self._CFG, self._MIGRATIONS, self._URL, timeout_seconds=60
             )
         assert mock_run.call_args.kwargs.get("timeout") == 60
 
-    def test_multiple_migrations_mixed_results(self):
-        migrations = [
-            _mig("001", "ok", True),
-            _mig("002", "bad", False, error="table missing"),
-            _mig("003", "also_ok", True),
-        ]
-        stdout = _against_json(migrations)
-        with patch("subprocess.run", return_value=_proc(1, stdout)):
+    def test_multiple_failures_recorded(self):
+        stdout = _pf_json(
+            [
+                _replay_failed("002", "bad", "table missing"),
+                _replay_failed("004", "worse", "syntax error"),
+            ],
+            checked=3,
+        )
+        with patch("subprocess.run", return_value=_proc(7, stdout)):
             result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
-        assert result.failure_count == 1
-        assert len(result.migrations) == 3
-        assert result.failures[0].version == "002"
+        assert result.failure_count == 2
+        assert result.migrations_checked == 3
+        assert {m.version for m in result.failures} == {"002", "004"}
 
     # -- #259: a fatal exit must surface confiture's *stdout* diagnostics --
     # confiture writes its structured failure report (issue code, offending
@@ -237,50 +230,55 @@ class TestRunConfiturePreflight:
             "ok": False,
             "summary": {"errors": 1, "warnings": 0, "migrations_checked": 1},
             "issues": [
-                {
-                    "severity": "error",
-                    "code": "PFLIGHT_REPLAY_FAILED",
-                    "message": (
-                        "Migration 0001 (recreate_widget) failed to replay "
-                        "against the preflight DB."
-                    ),
-                    "migration": "0001",
-                    "details": {
-                        "error": (
-                            "[Errno 2] No such file or directory: "
-                            "'/app/db/0_schema/funcs/widget.sql'"
-                        )
-                    },
-                }
+                _replay_failed(
+                    "0001",
+                    "recreate_widget",
+                    "[Errno 2] No such file or directory: "
+                    "'/app/db/0_schema/funcs/widget.sql'",
+                )
             ],
         }
     )
 
-    def test_fatal_exit_surfaces_confiture_stdout_diagnostics(self):
+    def test_replay_failure_surfaces_error_detail(self):
+        """An exit-7 replay failure becomes a structured failure carrying the
+        offending migration + underlying error (the #259 diagnostic), rather
+        than a fatal raise — exit 7 is a valid preflight outcome in 0.32."""
+        with patch(
+            "subprocess.run",
+            return_value=_proc(7, self._REPLAY_FAILED_STDOUT, ""),
+        ):
+            result = _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
+        assert result.failure_count == 1
+        failure = result.failures[0]
+        assert failure.version == "0001"
+        assert "0_schema/funcs/widget.sql" in (failure.error or "")
+
+    def test_exit_7_without_mappable_migration_raises(self):
+        """An exit-7 error-severity issue not tied to a migration cannot be
+        represented per-migration → surface the raw diagnostics + skip hint
+        rather than silently report 'no failures'."""
+        stdout = json.dumps(
+            {
+                "ok": False,
+                "summary": {"errors": 1, "migrations_checked": 0},
+                "issues": [
+                    {
+                        "severity": "error",
+                        "code": "PFLIGHT_CONFIG_INVALID",
+                        "message": "boom",
+                    }
+                ],
+            }
+        )
         with (
-            patch(
-                "subprocess.run",
-                return_value=_proc(7, self._REPLAY_FAILED_STDOUT, ""),
-            ),
+            patch("subprocess.run", return_value=_proc(7, stdout)),
             pytest.raises(DatabaseError) as exc_info,
         ):
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         msg = str(exc_info.value)
-        assert "exit 7" in msg
-        assert "PFLIGHT_REPLAY_FAILED" in msg
-        assert "0001" in msg
-        assert "0_schema/funcs/widget.sql" in msg
-
-    def test_fatal_exit_includes_skip_preflight_hint(self):
-        with (
-            patch(
-                "subprocess.run",
-                return_value=_proc(7, self._REPLAY_FAILED_STDOUT, ""),
-            ),
-            pytest.raises(DatabaseError) as exc_info,
-        ):
-            _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
-        assert "--skip-preflight" in str(exc_info.value)
+        assert "PFLIGHT_CONFIG_INVALID" in msg
+        assert "--skip-preflight" in msg
 
     def test_fatal_exit_falls_back_to_stderr_when_stdout_empty(self):
         with (
@@ -291,30 +289,16 @@ class TestRunConfiturePreflight:
         assert "boom on stderr" in str(exc_info.value)
 
     def test_unrecognized_schema_raises_instead_of_silent_pass(self):
-        """An exit-1 result whose schema lacks per-migration data must not be
-        silently treated as 'no failures' — that hides real failures under a
-        newer confiture (version skew, #259)."""
-        stdout = json.dumps(
-            {
-                "ok": False,
-                "summary": {"errors": 1},
-                "issues": [
-                    {
-                        "code": "PFLIGHT_REPLAY_FAILED",
-                        "message": "boom",
-                        "migration": "002",
-                    }
-                ],
-            }
-        )
+        """A result whose schema isn't the 0.30+ {ok,summary,issues} shape (e.g.
+        an old 0.9.x against.migrations envelope from a skewed confiture) must
+        not be silently treated as 'no failures' — surface the version skew."""
+        stdout = json.dumps({"static": {}, "against": {"migrations": []}})
         with (
-            patch("subprocess.run", return_value=_proc(1, stdout)),
+            patch("subprocess.run", return_value=_proc(0, stdout)),
             pytest.raises(DatabaseError) as exc_info,
         ):
             _run_confiture_preflight(self._CFG, self._MIGRATIONS, self._URL)
         msg = str(exc_info.value)
-        assert "PFLIGHT_REPLAY_FAILED" in msg
-        # surfaces the version-skew nature so the operator can act
         assert "schema" in msg.lower() or "version" in msg.lower()
 
 
@@ -474,6 +458,58 @@ class TestRunMigrationPreflightOrchestration:
 
         assert result.all_passed is True
         assert result.migrations == []
+
+    def test_empty_ledger_with_populated_schema_aborts(self, tmp_path):
+        """#262: tracking table present but its restored ledger is empty, while
+        the restored schema already holds application objects → abort, and never
+        invoke confiture to replay the already-applied history."""
+        schema_file = tmp_path / "schema.sql"
+        schema_file.write_text("")
+        mock_db = self._mock_preflight_db()
+        mock_db.has_table.return_value = True
+        mock_db.count_table_rows.return_value = 0  # empty ledger
+        mock_db.count_user_relations.return_value = 7  # populated schema
+
+        with (
+            patch(self._P_EXTRACT, return_value=schema_file),
+            patch(self._P_PREFLIGHT_DB, return_value=mock_db),
+            patch(self._P_CONFITURE) as mock_confiture,
+            pytest.raises(DatabaseError, match=r"262|0 rows"),
+        ):
+            run_migration_preflight(
+                backup_path=_BACKUP,
+                admin_url=_ADMIN_URL,
+                confiture_config=Path("confiture.yaml"),
+                migrations_dir=Path("db/migrations"),
+            )
+
+        # The already-applied migrations must NOT be replayed.
+        mock_confiture.assert_not_called()
+
+    def test_empty_ledger_with_empty_schema_proceeds(self, tmp_path):
+        """A genuinely fresh backup (empty ledger AND no application objects) is
+        not a #262 case — replaying all is safe, so the guard stays out of the
+        way and confiture runs."""
+        schema_file = tmp_path / "schema.sql"
+        schema_file.write_text("")
+        mock_db = self._mock_preflight_db()
+        mock_db.has_table.return_value = True
+        mock_db.count_table_rows.return_value = 0  # empty ledger
+        mock_db.count_user_relations.return_value = 0  # nothing to collide with
+
+        with (
+            patch(self._P_EXTRACT, return_value=schema_file),
+            patch(self._P_PREFLIGHT_DB, return_value=mock_db),
+            patch(self._P_CONFITURE, return_value=_make_passing_result()) as mock_cf,
+        ):
+            run_migration_preflight(
+                backup_path=_BACKUP,
+                admin_url=_ADMIN_URL,
+                confiture_config=Path("confiture.yaml"),
+                migrations_dir=Path("db/migrations"),
+            )
+
+        mock_cf.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.9.4"
+version = "0.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -532,23 +532,23 @@ dependencies = [
     { name = "sqlparse" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/03/4499e8c1a7d1b810574d9998199dc43440b33e11d3b9d287484c3c281c22/fraiseql_confiture-0.9.4.tar.gz", hash = "sha256:5f73489780d40b3e0d726cc01e48dac0cd7a27fe7e5d62c9829026642b0cb309", size = 1548482, upload-time = "2026-04-29T20:00:46.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/9f/fea3cc9f84e515cf0ee8bafef6acbf1c648006e2091e68b91be21b5ec635/fraiseql_confiture-0.33.0.tar.gz", hash = "sha256:9dd88aeb0c53f27c2bda5814bc21b3b708736fb8af0fbca772804a3bb2a903f6", size = 2034697, upload-time = "2026-06-25T20:49:45.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/91/173bdf23153aeb3e2fa86fa48f947f9f2b6449a8a4c4969becb9e353964d/fraiseql_confiture-0.9.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab01ea5e3ae80c8daeab738994ec45ceb21f2cc0c145cb5e17762d3c0232e40", size = 841823, upload-time = "2026-04-29T20:00:43.143Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/e2/235ed7138ad4c7dc1e256a61a32ea7b359b05a221ba04af24a47fc427538/fraiseql_confiture-0.9.4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:106a17ae1319a851e269ee8a1d408948680c25e2deac61f2ce14aa9e0ed7f87c", size = 888624, upload-time = "2026-04-29T20:00:47.167Z" },
-    { url = "https://files.pythonhosted.org/packages/30/7a/665990091e84308d15d462beeca7f4a58fe4bda29f7bb81c1aae404ee51a/fraiseql_confiture-0.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:fba4ab8db8b3445495e016781cdc52551cc3077c3585ead342362070d6a8232a", size = 794170, upload-time = "2026-04-29T20:00:50.071Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/45/591687cb6ddee173cbcaa755eb86f52548ef1723710121901b49d21bced1/fraiseql_confiture-0.9.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:30adb49d2a156189950970455d21503c790711cbb0b55e1ea6a4d785edeeb122", size = 841502, upload-time = "2026-04-29T20:00:41.711Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/58/ec2034c99c3cda2c80594addbf67f3fad052df0a3be1318eb43a49152fc9/fraiseql_confiture-0.9.4-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:84a4045d55bfd5984d5dbb016e27c3aae46ac8338f2d4b0d26aba486ff0ce878", size = 887196, upload-time = "2026-04-29T20:00:44.438Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a5/114ae0156410f98f9921952fca6947da099da58d781350bb54f00aa781c3/fraiseql_confiture-0.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:fef3cb017d7ef39d8305fa94c7c55305a13a3ec48bf73add425d5f6e5155d93e", size = 794397, upload-time = "2026-04-29T20:00:55.38Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9c/86f32bcf7a2f7b3252fce4f1aad199f34310e95d08066809359cc7f7ab59/fraiseql_confiture-0.9.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9543f27eef51a9617622da3a49b91ed6e6d354cbb951a3fc079600c0d570ea87", size = 841533, upload-time = "2026-04-29T20:00:51.306Z" },
-    { url = "https://files.pythonhosted.org/packages/82/98/20cfadc8c0498105b67904cd476308048ac060106f7aff9dbe8d3b43dec0/fraiseql_confiture-0.9.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d5296d6fbba226210d4e8180e32ccd2e83176a6e71cb104828fcb37c3fcf8acf", size = 887067, upload-time = "2026-04-29T20:00:52.57Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/e5/0840c7498f0a41a88e34d9b724da8e5b4d82851ae14a21f794821c2448fb/fraiseql_confiture-0.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:b38bcbbc75e86fd3c175905c06eceb86b82184baaa2c97406a4424f9c7f7d096", size = 794303, upload-time = "2026-04-29T20:00:54.055Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/39/6a1a7274d11d27f38f033f31157380ed336c5e58a2edd2eb022111b97006/fraiseql_confiture-0.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:da9d6294f119ac45660f6ba6c2386005f25c23bd0189699721739113e7ff94ae", size = 794301, upload-time = "2026-04-29T20:00:48.338Z" },
+    { url = "https://files.pythonhosted.org/packages/68/60/a6d6c3631f8b24e78d78ad170292b6efea2ac2053d3b519eb5f63dc11058/fraiseql_confiture-0.33.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfdccc7481fb67f8a1e5dc10d41804d6bab4973532007da523cfe9d8076596f4", size = 1034442, upload-time = "2026-06-25T20:49:30.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/03/3fb62babb1f4d6797aa18c055563db88882663945cc73f3e741f42be1df4/fraiseql_confiture-0.33.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:201989f9b669cf726edc3b3aaad35816ba9f75750df6b31afe7474b0b814b4f6", size = 1081424, upload-time = "2026-06-25T20:49:32.232Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/44/92365b29a9f246b2e35733dc4dc3b8c03616381a66077be379eee3684b36/fraiseql_confiture-0.33.0-cp311-cp311-win_amd64.whl", hash = "sha256:002fac8ddb5f0c6458a4454c69d935c59d3971078a2f64a2a14fa3170290cec4", size = 987322, upload-time = "2026-06-25T20:49:33.72Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/40596d9b0ffe5066166130554f3b0afc49da09cf347de57ba11eadd5c18f/fraiseql_confiture-0.33.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e07a133941a4a3e34464049cb86be19e932f4ce41b15c1b60a5d56d24dd250cd", size = 1034140, upload-time = "2026-06-25T20:49:35.077Z" },
+    { url = "https://files.pythonhosted.org/packages/39/45/57460e2ec1c045b4778ad41a0dda3b5e6cf6439978a88bc9ada945b72e05/fraiseql_confiture-0.33.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:102a5d6a13e9a27c50bb25dac2de3a1d62d2074a7ec28c5932fa8d24b0a6d0b1", size = 1080029, upload-time = "2026-06-25T20:49:36.404Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/22/fc035118581a890e9f8f1f9795b30d456efbabec43a0ececae793a7508eb/fraiseql_confiture-0.33.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c766237a230b389dcd78e4ac41d055f4ac43f1a710f34943f719a818944c938", size = 987682, upload-time = "2026-06-25T20:49:37.514Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a0/9f3078265c855144850e89f1d88399fe5fee6b1a854c7e9003f517e8bd74/fraiseql_confiture-0.33.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fbfe01386b9bf93996a118f9c43aa41e93642e4bea2cf415ae7d552dd4049ee1", size = 1034197, upload-time = "2026-06-25T20:49:38.89Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a8/e79f3818f5ae0d51b2e12b33865a5ecfbcac7b98487d3c66d43b5771f5de/fraiseql_confiture-0.33.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:14881e7a0445f42dc2c8bd6cbcbfbc8110a56f3d08c1d5dc3e444cdc6ded52f5", size = 1079912, upload-time = "2026-06-25T20:49:40.182Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b1/2993c33653b06992b5b08286a9682b26825a465e3bc143fb6425a0f4b20f/fraiseql_confiture-0.33.0-cp313-cp313-win_amd64.whl", hash = "sha256:5398937df5f02ac650db284144fbf34f9fa1c1c4b28baf4512a0641d926d747a", size = 987653, upload-time = "2026-06-25T20:49:41.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/fc/0e67de94e2442a47d1062f751481d00374fb93ab93fdb3ba2beac699c48d/fraiseql_confiture-0.33.0-cp314-cp314-win_amd64.whl", hash = "sha256:b3b1cfd21ecab9ca3f4ec9b6dc6cb66c51b836f204992a9d89b1757bd02a8e3f", size = 987656, upload-time = "2026-06-25T20:49:43.489Z" },
 ]
 
 [[package]]
 name = "fraisier"
-version = "0.39.0"
+version = "0.40.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -605,7 +605,7 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'all-databases'", specifier = ">=0.19.0,<1.0" },
     { name = "click", specifier = ">=8.1.0,<9.0" },
     { name = "fastapi", specifier = ">=0.109.0,<1.0" },
-    { name = "fraiseql-confiture", specifier = ">=0.9.4,<1.0" },
+    { name = "fraiseql-confiture", specifier = ">=0.33.0,<0.34" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0,<1.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0" },


### PR DESCRIPTION
Migrates fraisier's confiture integration to **fraiseql-confiture 0.33.x** and fixes **#262** — the restore-based migration preflight replaying the *entire* history (mass false-positive `already exists` failures, exit 7).

> Retargeted from 0.32 → **0.33** after confiture v0.33.0 shipped fixes for the two upstream issues this work surfaced — **confiture#168** (`from_config` accepts a minimal config) and **confiture#169** (non-transactional migrations are skipped, not failed, in preflight). The fraisier-side workarounds are correspondingly minimal now.

## Root cause (#262)
A schema-only restore recreates `tb_confiture` but not its rows. When the data-only restore loads zero rows, the preflight DB has the full schema but an **empty applied-migration ledger** → confiture treats the whole history as pending and replays every already-applied migration against the populated schema. Reproduced empirically: populated ledger → exit 0 (only genuine pending); empty ledger → exit 7 cascade. The loose pin also let production drift onto a confiture whose preflight JSON + exit codes fraisier couldn't parse.

## Changes
- **#262 guard**: `run_migration_preflight` branches on `tb_confiture` **row count**, not table existence. Empty ledger + populated schema → precise abort instead of a replay-everything cascade (a fresh/empty backup still replays-all safely).
- **Preflight parser** for confiture's `{ok, summary, issues[]}` schema. Exit **0 = all passed, 7 = replay failures (a valid, parsed outcome)**; 2/3/5 fatal. Added `migrations_checked`.
- **Non-transactional migrations** recorded as *skipped* — confiture 0.33 skips them in preflight (warning + exit 0, confiture#169).
- **`_load_env`** defaults `name`/`include_dirs` — `Environment.model_validate` is still strict (confiture#168 fixed `from_config`, but fraisier builds the Environment directly to inject the `database_url` override).
- **Hooks** resolve each class individually; backup/audit register. Notification hooks were *relocated* in confiture (new `notifications` module) — they degrade with a warning here; re-wiring is a separate enhancement.
- **`parse_migration_count`** handles confiture's `Migrations: N` / lower-cased phrasing.
- **Pin** `>=0.33.0,<0.34`; `uv.lock` → 0.33.0.

## Verification
- ✅ `4192 passed, 7 skipped` — incl. new #262 empty-ledger regression tests (1 integration repro + 2 unit)
- ✅ `ruff check`, `ruff format --check .`, `ty check fraisier/` all clean

Closes #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)