### PR TITLE
release: v0.41.0 — bounded worktree self-heal (heal-once-then-escalate) (#261)

### DIFF
--- a/fraisier/dbops/preflight.py
+++ b/fraisier/dbops/preflight.py
@@ -244,13 +244,23 @@ class PreflightDatabase:
         migration is treated as pending by the caller.
         """
         conn_flags, run_env = self._conn_flags()
+        # ``pg_restore --table=`` matches an *unqualified* relation name; a
+        # schema-qualified value like ``public.tb_confiture`` matches nothing
+        # and silently loads zero rows (leaving the ledger empty → every
+        # migration looks pending). Split the qualifier into --schema/--table.
+        schema, _, table = tracking_table.rpartition(".")
+        table_flags = (
+            [f"--schema={schema}", f"--table={table}"]
+            if schema
+            else [f"--table={tracking_table}"]
+        )
         subprocess.run(
             [
                 "pg_restore",
                 *conn_flags,
                 "--data-only",
                 "--no-owner",
-                f"--table={tracking_table}",
+                *table_flags,
                 str(backup_path),
             ],
             check=False,  # missing tracking table / no rows is not an error

--- a/fraisier/git/__init__.py
+++ b/fraisier/git/__init__.py
@@ -7,6 +7,7 @@ from .base import GitProvider, WebhookEvent
 from .operations import (
     clone_bare_repo,
     fetch_and_checkout,
+    force_repopulate_worktree,
     get_worktree_sha,
     verify_worktree_at_sha,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "WebhookEvent",
     "clone_bare_repo",
     "fetch_and_checkout",
+    "force_repopulate_worktree",
     "get_provider",
     "get_worktree_sha",
     "list_providers",

--- a/fraisier/git/operations.py
+++ b/fraisier/git/operations.py
@@ -5,6 +5,7 @@ to update a worktree without keeping a full .git directory in the
 deployment path.
 """
 
+import json
 import logging
 import subprocess
 from pathlib import Path
@@ -12,6 +13,16 @@ from pathlib import Path
 from fraisier.errors import DeploymentError
 
 logger = logging.getLogger("fraisier")
+
+# Self-heal policy: a worktree that the porcelain checkout leaves stale is
+# force-repopulated once. But a self-heal can mask a recurring environmental
+# cause (a read-only filesystem, wrong permissions, a flapping mount) behind a
+# green deploy — the exact silent-recovery masking that the version-stamp
+# rollback work (#257) set out to remove. So the recovery is bounded: if the
+# *same* worktree mismatches again within this many deploys of its last heal,
+# the deploy fails hard and alerts instead of healing again.
+_SELFHEAL_ESCALATE_WITHIN_DEPLOYS = 3
+_SELFHEAL_STATE_FILE = "fraisier_selfheal_state.json"
 
 
 def get_worktree_sha(worktree: Path) -> str | None:
@@ -130,9 +141,162 @@ def fetch_and_checkout(
     # records it as the deployed version. A checkout that exits 0 without
     # populating the worktree would otherwise advance the recorded version
     # over stale code (the frozen-worktree failure mode).
-    verify_worktree_at_sha(bare_repo, worktree, new_sha)
+    _verify_or_self_heal(bare_repo, worktree, new_sha)
 
     return old_sha, new_sha
+
+
+def _verify_or_self_heal(bare_repo: Path, worktree: Path, new_sha: str) -> None:
+    """Verify the worktree matches ``new_sha``; self-heal once, then escalate.
+
+    On a mismatch the worktree is force-repopulated from the tree and
+    re-verified — recovering a worktree the porcelain checkout left stale. The
+    recovery is bounded (heal-once-then-escalate): if the *same* worktree
+    mismatched again within ``_SELFHEAL_ESCALATE_WITHIN_DEPLOYS`` deploys of its
+    last heal, the deploy fails hard and alerts instead of healing again, so a
+    recurring environmental cause is not masked behind a green deploy (#257).
+
+    Raises:
+        DeploymentError: if the worktree still mismatches after a heal, or if a
+            recurring mismatch trips the escalation window.
+    """
+    state = _read_selfheal_state(bare_repo)
+    key = str(worktree)
+    entry = state.setdefault(key, {"deploys": 0, "last_heal_deploy": None})
+    entry["deploys"] += 1
+    deploy_no = entry["deploys"]
+
+    try:
+        verify_worktree_at_sha(bare_repo, worktree, new_sha)
+        _write_selfheal_state(bare_repo, state)
+        return
+    except DeploymentError as mismatch:
+        last_heal = entry.get("last_heal_deploy")
+        if _should_escalate(deploy_no, last_heal, _SELFHEAL_ESCALATE_WITHIN_DEPLOYS):
+            since = deploy_no - last_heal  # type: ignore[operator]
+            logger.critical(
+                "Worktree %s mismatched again at deploy %d, only %d deploy(s) "
+                "after a self-heal (deploy %d) — refusing to mask a recurring "
+                "cause; failing the deploy.",
+                worktree,
+                deploy_no,
+                since,
+                last_heal,
+            )
+            _write_selfheal_state(bare_repo, state)
+            raise DeploymentError(
+                f"Worktree at {worktree} mismatched commit {new_sha[:8]} again "
+                f"only {since} deploy(s) after a self-heal. A forced repopulate "
+                "recovered it once but the mismatch recurred — this points to a "
+                "persistent environmental cause (read-only filesystem, bad "
+                "permissions, a flapping mount), not a one-off bad checkout. "
+                "Failing hard rather than silently self-healing every deploy.",
+                context={
+                    "worktree": str(worktree),
+                    "bare_repo": str(bare_repo),
+                    "expected_sha": new_sha,
+                    "deploy_number": deploy_no,
+                    "last_heal_deploy": last_heal,
+                    "escalate_within_deploys": _SELFHEAL_ESCALATE_WITHIN_DEPLOYS,
+                },
+                recovery_hint=(
+                    "Investigate the worktree host: check filesystem mount "
+                    "options (read-only?), ownership/permissions on "
+                    f"{worktree}, and disk health. Recreate the worktree once "
+                    "the underlying cause is fixed."
+                ),
+            ) from mismatch
+
+        # Heal once: force a clean repopulate straight from the tree, then
+        # re-verify. A still-stale worktree re-raises (the loud abort stands).
+        logger.warning(
+            "Worktree %s did not match %s after checkout; forcing repopulate "
+            "(self-heal, deploy %d)",
+            worktree,
+            new_sha[:8],
+            deploy_no,
+        )
+        force_repopulate_worktree(bare_repo, worktree, new_sha)
+        verify_worktree_at_sha(bare_repo, worktree, new_sha)
+        entry["last_heal_deploy"] = deploy_no
+        _write_selfheal_state(bare_repo, state)
+        logger.warning(
+            "Worktree %s recovered to %s via forced repopulate at deploy %d",
+            worktree,
+            new_sha[:8],
+            deploy_no,
+        )
+
+
+def _should_escalate(deploy_no: int, last_heal_deploy: int | None, within: int) -> bool:
+    """Whether a mismatch should fail hard instead of self-healing again.
+
+    ``True`` when this worktree was self-healed within the last ``within``
+    deploys — a recurrence the bounded recovery must not keep papering over.
+    """
+    return last_heal_deploy is not None and (deploy_no - last_heal_deploy) <= within
+
+
+def _selfheal_state_path(bare_repo: Path) -> Path:
+    return bare_repo / _SELFHEAL_STATE_FILE
+
+
+def _read_selfheal_state(bare_repo: Path) -> dict:
+    """Read the per-worktree self-heal state, or ``{}`` if absent/unreadable."""
+    try:
+        data = json.loads(_selfheal_state_path(bare_repo).read_text())
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_selfheal_state(bare_repo: Path, state: dict) -> None:
+    """Persist the self-heal state. Best-effort — a write failure only weakens
+    the escalation bound, it must not fail an otherwise-healthy deploy."""
+    try:
+        _selfheal_state_path(bare_repo).write_text(json.dumps(state))
+    except OSError as exc:
+        logger.warning("Could not persist self-heal state in %s: %s", bare_repo, exc)
+
+
+def force_repopulate_worktree(bare_repo: Path, worktree: Path, sha: str) -> None:
+    """Forcibly rewrite the worktree's tracked files to match ``sha``.
+
+    Stronger and more deterministic than ``git checkout``: ``read-tree --reset
+    -u`` discards whatever index and working-tree state is present and writes
+    the tree directly, then HEAD is moved explicitly with ``update-ref``. This
+    recovers a worktree the normal checkout path left stale or partially
+    updated.
+
+    Like the rest of this module it only touches tracked files: untracked
+    generated files (``version.json``), virtualenvs, and build output are left
+    in place. It does not delete a worktree or remove untracked data.
+
+    Args:
+        bare_repo: Path to the bare repository.
+        worktree: Path to the deployed worktree.
+        sha: The commit to materialize into the worktree.
+    """
+    subprocess.run(
+        [
+            "git",
+            f"--work-tree={worktree}",
+            f"--git-dir={bare_repo}",
+            "read-tree",
+            "--reset",
+            "-u",
+            sha,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", f"--git-dir={bare_repo}", "update-ref", "--no-deref", "HEAD", sha],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def verify_worktree_at_sha(bare_repo: Path, worktree: Path, sha: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.40.0"
+version = "0.41.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -1,5 +1,6 @@
 """Tests for bare repo + worktree git operations."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -8,8 +9,10 @@ import pytest
 
 from fraisier.errors import DeploymentError
 from fraisier.git.operations import (
+    _should_escalate,
     clone_bare_repo,
     fetch_and_checkout,
+    force_repopulate_worktree,
     get_worktree_sha,
     verify_worktree_at_sha,
 )
@@ -317,3 +320,116 @@ class TestVerifyWorktreeAtSha:
             git_deploy_env.worktree,
             git_deploy_env.sha_v2,
         )
+
+    def test_force_repopulate_recovers_stale_worktree(self, git_deploy_env: DeployEnv):
+        """The self-heal mechanism: read-tree --reset -u rewrites the tracked
+        files to the target commit, recovering a worktree the porcelain checkout
+        left stale. Worktree is at v1; force-repopulate to v2 → verify passes."""
+        force_repopulate_worktree(
+            git_deploy_env.bare_repo,
+            git_deploy_env.worktree,
+            git_deploy_env.sha_v2,
+        )
+
+        verify_worktree_at_sha(
+            git_deploy_env.bare_repo,
+            git_deploy_env.worktree,
+            git_deploy_env.sha_v2,
+        )
+
+
+class TestShouldEscalate:
+    """The bounded-recovery decision: re-mismatch within N deploys → fail hard."""
+
+    def test_never_healed_does_not_escalate(self):
+        assert _should_escalate(deploy_no=1, last_heal_deploy=None, within=3) is False
+
+    def test_recurrence_within_window_escalates(self):
+        # healed at deploy 1, mismatch again at deploy 2 → within 3 → escalate
+        assert _should_escalate(deploy_no=2, last_heal_deploy=1, within=3) is True
+
+    def test_window_boundary_escalates(self):
+        # exactly N deploys later still counts as "within"
+        assert _should_escalate(deploy_no=4, last_heal_deploy=1, within=3) is True
+
+    def test_aged_out_heals_again(self):
+        # more than N deploys since the heal → treat as a fresh incident
+        assert _should_escalate(deploy_no=5, last_heal_deploy=1, within=3) is False
+
+
+class TestSelfHealEscalation:
+    """fetch_and_checkout heals a stale worktree once, then escalates if the
+    same worktree mismatches again within the escalation window."""
+
+    branch = "main"
+
+    def _env(self, tmp_path):
+        bare = tmp_path / "bare.git"
+        bare.mkdir()
+        return bare, tmp_path / "wt"
+
+    def _side_effect(self, worktree, diff_quiet_codes, *, new="bbb2222", old="aaa1111"):
+        """subprocess mock: drives `git diff --quiet` returncodes from a shared
+        queue so a sequence of deploys can be simulated across calls."""
+        codes = iter(diff_quiet_codes)
+
+        def se(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd == ["git", "-C", str(worktree), "rev-parse", "HEAD"]:
+                r.stdout = f"{old}\n"
+            if "rev-parse" in cmd and any(a.startswith("origin/") for a in cmd):
+                r.stdout = f"{new}\n"
+            if "diff" in cmd and "--quiet" in cmd:
+                r.returncode = next(codes)
+            if "diff" in cmd and "--name-only" in cmd:
+                r.stdout = "app.py\n"
+            return r
+
+        return se
+
+    def _state(self, bare, worktree):
+        data = json.loads((bare / "fraisier_selfheal_state.json").read_text())
+        return data[str(worktree)]
+
+    def test_heals_once_on_first_mismatch(self, tmp_path):
+        bare, wt = self._env(tmp_path)
+        # deploy 1: first verify mismatches, post-repopulate verify passes.
+        se = self._side_effect(wt, [1, 0])
+        with patch("subprocess.run", side_effect=se) as mock_run:
+            old, new = fetch_and_checkout(bare, wt, self.branch)
+
+        assert (old, new) == ("aaa1111", "bbb2222")
+        # the forced repopulate ran (read-tree --reset -u)
+        assert any("read-tree" in c.args[0] for c in mock_run.call_args_list if c.args)
+        # the heal was recorded against this deploy
+        assert self._state(bare, wt)["last_heal_deploy"] == 1
+
+    def test_escalates_on_recurring_mismatch_within_window(self, tmp_path):
+        bare, wt = self._env(tmp_path)
+        # d1: [1,0] heal; d2: [1] mismatch again → escalate (no repopulate).
+        se = self._side_effect(wt, [1, 0, 1])
+        with patch("subprocess.run", side_effect=se):
+            fetch_and_checkout(bare, wt, self.branch)  # heals
+            with pytest.raises(DeploymentError) as exc_info:
+                fetch_and_checkout(bare, wt, self.branch)  # escalates
+
+        err = exc_info.value
+        assert err.context["deploy_number"] == 2
+        assert err.context["last_heal_deploy"] == 1
+        assert "recur" in str(err).lower() or "again" in str(err).lower()
+
+    def test_heals_again_after_escalation_window_passes(self, tmp_path):
+        bare, wt = self._env(tmp_path)
+        # d1 heal [1,0]; d2-d4 clean [0,0,0]; d5 mismatch [1,0] → heal again
+        # (5 - 1 = 4 > 3, so the prior heal has aged out).
+        se = self._side_effect(wt, [1, 0, 0, 0, 0, 1, 0])
+        with patch("subprocess.run", side_effect=se):
+            for _ in range(5):
+                fetch_and_checkout(bare, wt, self.branch)
+
+        entry = self._state(bare, wt)
+        assert entry["deploys"] == 5
+        assert entry["last_heal_deploy"] == 5

--- a/tests/test_preflight_core.py
+++ b/tests/test_preflight_core.py
@@ -222,6 +222,47 @@ class TestPreflightDatabase:
         ):
             db.restore_schema(schema_path)
 
+    def test_restore_tracking_data_splits_schema_qualified_table(self, tmp_path):
+        """A schema-qualified tracking table must become --schema + --table.
+
+        ``pg_restore --table=`` matches an *unqualified* name, so passing
+        ``public.tb_confiture`` matches nothing → zero rows load → the preflight
+        ledger stays empty and every migration looks pending, aborting the
+        restore_migrate deploy on a false positive. Regression guard for the
+        staging preflight self-consistency bug (issue #250 follow-up).
+        """
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "public.tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "pg_restore" in cmd
+        assert "--schema=public" in cmd
+        assert "--table=tb_confiture" in cmd
+        assert "--table=public.tb_confiture" not in cmd
+
+    def test_restore_tracking_data_unqualified_table_has_no_schema_flag(self, tmp_path):
+        """A bare tracking table is passed through as --table with no --schema."""
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "--table=tb_confiture" in cmd
+        assert not any(str(arg).startswith("--schema=") for arg in cmd)
+
 
 # ---------------------------------------------------------------------------
 # MigrationCheck + MigrationPreflightResult


### PR DESCRIPTION
Builds on the worktree verification shipped in v0.39 (#261). That change **failed hard** when the worktree didn't match the deployed SHA after checkout. This adds a **bounded self-heal**: recover the stale worktree once, but escalate (fail hard + alert) if the same worktree keeps mismatching — so a recurring environmental cause is never masked behind a green deploy (the #257 silent-recovery lesson).

> ⚠️ Stacked on #263 (confiture 0.32 migration). GitHub will retarget this to `main` once #263 merges.

## Behavior
- After `checkout -f` + `reset --soft`, verify the worktree matches `new_sha`.
- **On mismatch:** `force_repopulate_worktree` rewrites tracked files straight from the tree (`read-tree --reset -u` + `update-ref --no-deref HEAD`) and re-verifies. Only **tracked** files are touched — untracked `version.json`, virtualenvs, and build output are preserved.
- **Bounded recovery:** per-worktree deploy/heal counters persist in the bare repo. If the *same* worktree mismatches again within `_SELFHEAL_ESCALATE_WITHIN_DEPLOYS` (3) deploys of its last heal, the deploy **fails hard** with a `DeploymentError` + `CRITICAL` log pointing at the likely cause (read-only FS, bad perms, flapping mount). After the window passes, a fresh mismatch heals again.
- A worktree still stale *after* a forced repopulate re-raises — the loud abort stands; the version never advances over stale code.

## Tests
- `force_repopulate_worktree` recovers a real stale worktree (real git via `DeployEnv`).
- heal-once on first mismatch; escalate on recurrence within the window; heal again after the window ages out.
- `_should_escalate` boundary logic.

## Verification
- ✅ `4200 passed, 7 skipped`; `ruff check`, `ruff format --check .`, `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)