### PR TITLE
release: v0.39.1 — preflight loads tracking ledger (split schema-qualified --table, #262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.1] - 2026-06-29
+
+### Fixed
+
+- **Restore-based migration preflight no longer replays the entire migration history against a populated schema** ([#262](https://github.com/fraiseql/fraisier/issues/262)). `PreflightDatabase.restore_tracking_data` makes the schema-only preflight DB *self-consistent* by loading the backup's migration-ledger rows, so the preflight replays only genuinely-pending migrations. It built that loader as `pg_restore --data-only --table={tracking_table}`, passing the configured tracking table **verbatim** — but the common configured value is schema-qualified (`public.tb_confiture`), and `pg_restore --table=` matches an *unqualified* relation name, so `public.tb_confiture` matched nothing and **silently loaded zero rows**. The ledger stayed empty, confiture saw nothing applied, and the preflight replayed the whole history (from the project baseline) against a DB that already had the full schema — failing en masse with `relation … already exists` / `cannot change name of view column …` and aborting the deploy on a false positive (exit 7) **before the real restore ever ran**, leaving the target DB untouched while the app version still advanced. (The 0.40.0 `count_user_relations` guard *detects* this populated-schema-but-empty-ledger state; this fixes the cause so the ledger actually loads.) `restore_tracking_data` now splits a schema-qualified value into `--schema=<schema> --table=<table>`. Verified empirically: `--table=public.tb_confiture` loads 0 rows; `--schema=public --table=tb_confiture` loads all. New regression guards in `tests/test_preflight_core.py` cover the qualified (split) and unqualified (passthrough, no `--schema`) cases.
+
 ## [0.39.0] - 2026-06-25
 
 ### Fixed

--- a/fraisier/dbops/preflight.py
+++ b/fraisier/dbops/preflight.py
@@ -244,13 +244,23 @@ class PreflightDatabase:
         migration is treated as pending by the caller.
         """
         conn_flags, run_env = self._conn_flags()
+        # ``pg_restore --table=`` matches an *unqualified* relation name; a
+        # schema-qualified value like ``public.tb_confiture`` matches nothing
+        # and silently loads zero rows (leaving the ledger empty → every
+        # migration looks pending). Split the qualifier into --schema/--table.
+        schema, _, table = tracking_table.rpartition(".")
+        table_flags = (
+            [f"--schema={schema}", f"--table={table}"]
+            if schema
+            else [f"--table={tracking_table}"]
+        )
         subprocess.run(
             [
                 "pg_restore",
                 *conn_flags,
                 "--data-only",
                 "--no-owner",
-                f"--table={tracking_table}",
+                *table_flags,
                 str(backup_path),
             ],
             check=False,  # missing tracking table / no rows is not an error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.39.0"
+version = "0.39.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_preflight_core.py
+++ b/tests/test_preflight_core.py
@@ -222,6 +222,47 @@ class TestPreflightDatabase:
         ):
             db.restore_schema(schema_path)
 
+    def test_restore_tracking_data_splits_schema_qualified_table(self, tmp_path):
+        """A schema-qualified tracking table must become --schema + --table.
+
+        ``pg_restore --table=`` matches an *unqualified* name, so passing
+        ``public.tb_confiture`` matches nothing → zero rows load → the preflight
+        ledger stays empty and every migration looks pending, aborting the
+        restore_migrate deploy on a false positive. Regression guard for the
+        staging preflight self-consistency bug (issue #250 follow-up).
+        """
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "public.tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "pg_restore" in cmd
+        assert "--schema=public" in cmd
+        assert "--table=tb_confiture" in cmd
+        assert "--table=public.tb_confiture" not in cmd
+
+    def test_restore_tracking_data_unqualified_table_has_no_schema_flag(self, tmp_path):
+        """A bare tracking table is passed through as --table with no --schema."""
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "--table=tb_confiture" in cmd
+        assert not any(str(arg).startswith("--schema=") for arg in cmd)
+
 
 # ---------------------------------------------------------------------------
 # MigrationCheck + MigrationPreflightResult


### PR DESCRIPTION
Root-cause fix for #262 (the restore-preflight replay-everything failure that silently no-ops migration-bearing staging deploys).

## Problem
`PreflightDatabase.restore_tracking_data` loads the backup's `tb_confiture` rows into the schema-only preflight DB so only genuinely-pending migrations replay. It ran `pg_restore --data-only --table={tracking_table}` with the configured tracking table verbatim — but the common value is schema-qualified (`public.tb_confiture`), and `pg_restore --table=` matches an **unqualified** name, so it matched nothing and loaded **0 rows**. Empty ledger → confiture treats the whole history as pending → replays it against an already-complete schema → mass `already exists` / view-column errors → exit 7, deploy aborts **before the restore runs**, target DB untouched while the app version advances (false-success).

The 0.40.0 `count_user_relations` guard *detects* this state; this fixes the cause so the ledger actually loads.

## Fix
Split a schema-qualified tracking table into `--schema=<schema> --table=<table>`.

## Verification
- 2 new regression tests in `tests/test_preflight_core.py` (qualified → split; unqualified → passthrough, no `--schema`) — RED→GREEN.
- Full non-integration suite: 4161 passed; ruff + ty clean.
- Empirically: `--table=public.tb_confiture` → 0 rows; `--schema=public --table=tb_confiture` → all rows.

Observed live: staging deploy of printoptim_backend 1.188.0 false-succeeded — webhook (fraisier 0.39.0) aborted at `PFLIGHT_REPLAY_FAILED` from the March baseline; staging DB stayed at its old migration head while `/health` reported the new version.

**Follow-up:** the 0.40/0.41 line still has the unfixed `--table=` (separate PR onto the feature branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)