### PR TITLE
fix(preflight): split schema-qualified tracking table (root cause behind the #262 guard)

### DIFF
--- a/fraisier/dbops/preflight.py
+++ b/fraisier/dbops/preflight.py
@@ -244,13 +244,23 @@ class PreflightDatabase:
         migration is treated as pending by the caller.
         """
         conn_flags, run_env = self._conn_flags()
+        # ``pg_restore --table=`` matches an *unqualified* relation name; a
+        # schema-qualified value like ``public.tb_confiture`` matches nothing
+        # and silently loads zero rows (leaving the ledger empty → every
+        # migration looks pending). Split the qualifier into --schema/--table.
+        schema, _, table = tracking_table.rpartition(".")
+        table_flags = (
+            [f"--schema={schema}", f"--table={table}"]
+            if schema
+            else [f"--table={tracking_table}"]
+        )
         subprocess.run(
             [
                 "pg_restore",
                 *conn_flags,
                 "--data-only",
                 "--no-owner",
-                f"--table={tracking_table}",
+                *table_flags,
                 str(backup_path),
             ],
             check=False,  # missing tracking table / no rows is not an error

--- a/tests/test_preflight_core.py
+++ b/tests/test_preflight_core.py
@@ -222,6 +222,47 @@ class TestPreflightDatabase:
         ):
             db.restore_schema(schema_path)
 
+    def test_restore_tracking_data_splits_schema_qualified_table(self, tmp_path):
+        """A schema-qualified tracking table must become --schema + --table.
+
+        ``pg_restore --table=`` matches an *unqualified* name, so passing
+        ``public.tb_confiture`` matches nothing → zero rows load → the preflight
+        ledger stays empty and every migration looks pending, aborting the
+        restore_migrate deploy on a false positive. Regression guard for the
+        staging preflight self-consistency bug (issue #250 follow-up).
+        """
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "public.tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "pg_restore" in cmd
+        assert "--schema=public" in cmd
+        assert "--table=tb_confiture" in cmd
+        assert "--table=public.tb_confiture" not in cmd
+
+    def test_restore_tracking_data_unqualified_table_has_no_schema_flag(self, tmp_path):
+        """A bare tracking table is passed through as --table with no --schema."""
+        backup = tmp_path / "prod.dump"
+        backup.write_bytes(b"")
+
+        db = self._make_db()
+        db.url = "postgresql://admin@localhost/fraisier_preflight_abc"
+
+        ok = subprocess.CompletedProcess([], 0, "", "")
+        with patch("subprocess.run", return_value=ok) as mock_run:
+            db.restore_tracking_data(backup, "tb_confiture")
+
+        cmd = mock_run.call_args[0][0]
+        assert "--table=tb_confiture" in cmd
+        assert not any(str(arg).startswith("--schema=") for arg in cmd)
+
 
 # ---------------------------------------------------------------------------
 # MigrationCheck + MigrationPreflightResult


### PR DESCRIPTION
Carries the #262 root-cause fix onto the 0.41 line (`feat/worktree-self-heal-escalate`), which still has the unfixed `--table=` and only added the *detection* guard (`count_user_relations`).

`restore_tracking_data` ran `pg_restore --data-only --table={tracking_table}` with the schema-qualified `public.tb_confiture`; `pg_restore --table=` matches an unqualified name only, so it loaded 0 ledger rows → the preflight replayed the full history → exit 7 / false-success deploy. This splits a schema-qualified value into `--schema=<schema> --table=<table>` so the ledger actually loads — making the 0.40.0 `count_user_relations` guard's sad path unnecessary (the guard stays as belt-and-suspenders).

Same change as the v0.39.1 hotfix (#265, off `main`); cherry-picked here without the version bump so the 0.41 release isn't a regression.

## Verification
- 2 regression tests in `tests/test_preflight_core.py` (qualified → split; unqualified → passthrough).
- `tests/test_preflight_core.py` + `tests/test_dbops.py`: 99 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)