### PR TITLE
release: v0.43.0 — confiture 0.35 + restore via DatabaseRestorer (deferred matview refresh) (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.0] - 2026-07-07
+
+Continues the confiture 0.33 migration shipped in 0.41.0: adopts fraiseql-confiture 0.35 and — the substantive change — moves the staging restore off a bare `pg_restore` onto confiture's three-phase `DatabaseRestorer`, so the matview-refresh fix (confiture #172) actually reaches fraisier's `restore_migrate` strategy.
+
+### Changed
+
+- **Confiture integration bumped to fraiseql-confiture 0.35.x** (pinned `>=0.35.0,<0.36`, was `>=0.33.0,<0.34`). The migrate/build/preflight surface fraisier targets is unchanged across 0.33→0.35 (`Migrator.from_config` → `MigratorSession.up/down/status/preflight`; the preflight `--against` `{ok, summary, issues[]}` JSON + exit `0`/`7` contract); 0.34 additionally defaults `Environment.name`/`include_dirs` so a migrate-only config validates directly, and 0.35 carries the restore matview fix adopted below. The upper bound still prevents silent drift onto a future schema change ([#262](https://github.com/fraiseql/fraisier/issues/262)).
+- **Staging restore now runs through confiture's three-phase `DatabaseRestorer` instead of a single `pg_restore`** ([#270](https://github.com/fraiseql/fraisier/issues/270)). `dbops/restore.restore_backup` previously shelled out to `pg_restore -d <db> --no-owner --no-acl [-j N] <dump>` directly — so confiture's restorer, and its matview fix, never touched fraisier's restore path. A backup carrying a stats-sensitive materialized view then refreshed it **inside the parallel data phase on the empty `pg_statistic` of a freshly loaded database**, replanning into a catastrophic nested loop (25 min – 2h+) that hung the deploy and left staging unusable (the printoptim_backend#1960 incident: 2h+ on `REFRESH MATERIALIZED VIEW mv_maintenance_price` under `--jobs 4`). `restore_backup` now delegates to `confiture.core.restorer.DatabaseRestorer`, which holds every matview `REFRESH` out of the restore phases, runs a database-wide `ANALYZE`, then refreshes on real statistics (confiture #172). It maps the caller's `connection_url` to confiture's discrete `-h/-p/-U` (netloc **or** socket `?host=` form) with any password threaded through as `PGPASSWORD`, keeps the post-restore `REASSIGN OWNED` ownership fix and the identifier/path validation, sets `parallel_restore` for `jobs > 1`, and leaves confiture's own min-tables check off (the strategy validates the table count itself after `migrate up`). A confiture `RestoreError` (e.g. an unsupported plain-SQL dump) is returned as a failed `RestoreResult` rather than raised, so the strategy's `.success` branch is unchanged.
+
+### Added
+
+- **The restore phase breakdown now surfaces confiture's deferred-matview accounting.** `RestoreResult` carries `matviews_deferred` / `matviews_refreshed` / `analyze_ran` (`None`/`False` when the backup had no matviews), and `RestoreMigrateStrategy` logs them after the restore step so a deploy log shows when a refresh was held past `ANALYZE` ([#270](https://github.com/fraiseql/fraisier/issues/270), ask #3).
+- **Real-PostgreSQL end-to-end regression for the deferred refresh.** `tests/integration/test_restore_matview_deferral.py` dumps a database carrying a populated matview, restores it through `restore_backup`, and asserts the matview comes out **populated** (not left `WITH NO DATA`) for both the serial (`jobs=1`) and parallel (`jobs=4`, the incident condition) paths — proving confiture and fraisier run together, not just that fraisier passes the right options. Existing restore unit tests were migrated onto the `DatabaseRestorer` seam.
+
 ## [0.42.0] - 2026-07-06
 
 ### Fixed

--- a/fraisier/dbops/restore.py
+++ b/fraisier/dbops/restore.py
@@ -1,13 +1,28 @@
-"""Staging restore: pg_restore with ownership fix and table validation.
+"""Staging restore: three-phase pg_restore (via confiture) with ownership fix
+and table validation.
 
-Restores a production backup into a staging database, fixes ownership,
-and validates the restore by checking the table count against a minimum
-threshold.
+Restores a production backup into a staging database using confiture's
+:class:`~confiture.core.restorer.DatabaseRestorer`, which runs a three-phase
+restore and — crucially — holds every materialized-view ``REFRESH`` out of the
+restore phases, runs a post-load ``ANALYZE``, then refreshes the matviews on
+real statistics.  A stats-sensitive matview otherwise replans into a
+catastrophic nested loop on the empty ``pg_statistic`` of a freshly loaded
+database, turning a restore into a multi-hour hang (confiture #172,
+printoptim_backend#1960).  Ownership is reassigned afterwards and the caller
+validates the restore by checking the table count against a minimum threshold.
 """
 
+import contextlib
+import dataclasses
+import os
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from confiture.core.restorer import DatabaseRestorer, RestoreOptions
+from confiture.exceptions import RestoreError
 
 from fraisier.dbops._validation import validate_file_path, validate_pg_identifier
 from fraisier.dbops.operations import _pg_cmd
@@ -15,11 +30,81 @@ from fraisier.dbops.operations import _pg_cmd
 
 @dataclass
 class RestoreResult:
-    """Result of a restore operation."""
+    """Result of a restore operation.
+
+    ``matviews_deferred`` / ``matviews_refreshed`` / ``analyze_ran`` surface
+    confiture's deferred-matview accounting (confiture #172) so the deploy log
+    can show the restore phase breakdown.  ``matviews_*`` are ``None`` when the
+    backup carried no materialized views — in that case confiture takes the
+    classic three-phase path and ``analyze_ran`` stays ``False``.
+    """
 
     success: bool
     error: str = ""
     duration_seconds: float = 0.0
+    matviews_deferred: int | None = None
+    matviews_refreshed: int | None = None
+    analyze_ran: bool = False
+
+
+def _connection_params(
+    connection_url: str,
+) -> tuple[str | None, int | None, str | None, dict[str, str]]:
+    """Split a PostgreSQL URL into ``(host, port, username, env)`` for confiture.
+
+    confiture's :class:`RestoreOptions` takes ``host`` / ``port`` / ``username``
+    as discrete fields and shells out with an explicit ``-h/-p/-U`` — it has no
+    connection-URL entry point.  The host may live in the netloc
+    (``postgresql://h:p/db``) or, for socket connections, in a ``?host=`` query
+    parameter (``postgresql:///db?host=/var/run/postgresql``); both are mapped,
+    mirroring :func:`operations._parse_connection_flags`.  A password rides back
+    in ``env`` as ``PGPASSWORD`` for confiture's inherited subprocess
+    environment to pick up.
+    """
+    parsed = urlparse(connection_url)
+    query = parse_qs(parsed.query)
+
+    def _q(key: str) -> str | None:
+        values = query.get(key)
+        return values[0] if values else None
+
+    host = parsed.hostname or _q("host")
+    port = parsed.port
+    if port is None:
+        raw_port = _q("port")
+        if raw_port:
+            with contextlib.suppress(ValueError):
+                port = int(raw_port)
+    username = parsed.username or _q("user")
+    env: dict[str, str] = {}
+    password = parsed.password or _q("password")
+    if password:
+        env["PGPASSWORD"] = password
+    return host, port, username, env
+
+
+@contextlib.contextmanager
+def _augmented_env(extra: dict[str, str]) -> Iterator[None]:
+    """Temporarily overlay *extra* onto ``os.environ`` for the duration of a call.
+
+    confiture's restorer inherits ``os.environ`` (it never passes ``env=`` to
+    its subprocesses), so a password parsed from the connection URL is threaded
+    through the process environment as ``PGPASSWORD`` while the restore runs and
+    then restored to its prior value.
+    """
+    if not extra:
+        yield
+        return
+    saved = {key: os.environ.get(key) for key in extra}
+    os.environ.update(extra)
+    try:
+        yield
+    finally:
+        for key, previous in saved.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
 
 
 def restore_backup(
@@ -30,26 +115,58 @@ def restore_backup(
     db_owner: str | None = None,
     jobs: int = 1,
 ) -> RestoreResult:
-    """Restore a pg_dump backup into *db_name*.
+    """Restore a pg_dump backup into *db_name* via confiture's three-phase restore.
 
-    Optionally reassigns ownership to *db_owner* after restore.
+    Materialized-view refreshes are held out of the restore phases and run after
+    a post-load ``ANALYZE`` so each matview replans on real statistics instead of
+    the empty ``pg_statistic`` of a freshly loaded database (confiture #172).
+    Optionally reassigns ownership to *db_owner* after the restore.
     """
     validate_pg_identifier(db_name, "database name")
     validate_file_path(backup_path)
     if db_owner:
         validate_pg_identifier(db_owner, "database owner")
 
-    # Run pg_restore
+    host, port, username, extra_env = _connection_params(connection_url)
+
+    options = RestoreOptions(
+        backup_path=Path(backup_path),
+        target_db=db_name,
+        username=username,
+        jobs=jobs,
+        no_owner=True,
+        no_acl=True,
+        # jobs > 1: FK violations during the parallel data phase are transient
+        # (constraints do not exist yet); parallel_restore flips confiture's
+        # exit_on_error off so they do not abort the restore. jobs == 1 keeps
+        # confiture's fail-fast default.
+        parallel_restore=jobs > 1,
+        # The RestoreMigrateStrategy validates the table count itself, after
+        # `migrate up` (step 10), so confiture skips its own min-tables check.
+        min_tables=0,
+    )
+    # confiture emits an explicit -h/-p; only override its RestoreOptions
+    # defaults for the parts the URL actually carries (a socket URL with no
+    # host falls through to confiture's default socket directory).
+    if host is not None:
+        options = dataclasses.replace(options, host=host)
+    if port is not None:
+        options = dataclasses.replace(options, port=port)
+
     t0 = time.monotonic()
-    cmd = ["pg_restore", "-d", db_name, "--no-owner", "--no-acl"]
-    if jobs > 1:
-        cmd.extend(["-j", str(jobs)])
-    cmd.append(backup_path)
-    code, _, stderr = _pg_cmd(cmd, connection_url=connection_url)
-    duration = time.monotonic() - t0
-    if code != 0:
+    try:
+        with _augmented_env(extra_env):
+            result = DatabaseRestorer().restore(options)
+    except RestoreError as exc:
         return RestoreResult(
-            success=False, error=stderr.strip(), duration_seconds=duration
+            success=False, error=str(exc), duration_seconds=time.monotonic() - t0
+        )
+
+    if not result.success:
+        return RestoreResult(
+            success=False,
+            error="; ".join(result.errors) or "pg_restore failed",
+            duration_seconds=time.monotonic() - t0,
         )
 
     # Fix ownership if requested — use psql variable binding to prevent injection
@@ -73,7 +190,13 @@ def restore_backup(
                 duration_seconds=time.monotonic() - t0,
             )
 
-    return RestoreResult(success=True, duration_seconds=time.monotonic() - t0)
+    return RestoreResult(
+        success=True,
+        duration_seconds=time.monotonic() - t0,
+        matviews_deferred=result.matviews_deferred,
+        matviews_refreshed=result.matviews_refreshed,
+        analyze_ran=result.analyze_ran,
+    )
 
 
 def validate_table_count(

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -249,6 +249,17 @@ class RestoreMigrateStrategy(Strategy):
             cfg.db_name,
             int(restore_secs * 1000),
         )
+        # Surface confiture's deferred-matview accounting (#172) so the deploy
+        # log shows when a matview refresh was held past ANALYZE. None means the
+        # backup carried no materialized views (classic three-phase restore).
+        if restore_result.matviews_deferred is not None:
+            log.info(
+                "Deferred %d matview refresh(es) past ANALYZE (analyze_ran=%s), "
+                "refreshed %s on real statistics",
+                restore_result.matviews_deferred,
+                restore_result.analyze_ran,
+                restore_result.matviews_refreshed,
+            )
 
         # Step 8: Create rollback template
         if cfg.create_template:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,18 @@ classifiers = [
   "Topic :: System :: Systems Administration"
 ]
 dependencies = [
-  # Pinned to the 0.33.x line: fraisier's confiture integration (Python API
-  # result shapes, preflight --against JSON schema {ok,summary,issues[]} + exit
-  # codes 0/7) targets it. 0.33 also fixed confiture #168 (from_config accepts a
-  # minimal config) and #169 (non-transactional migrations skipped, not failed,
-  # in preflight). The upper bound prevents silent drift onto a future schema
+  # Pinned to the 0.35.x line: fraisier's confiture integration (Migrator /
+  # Environment Python API result shapes, preflight --against JSON schema
+  # {ok,summary,issues[]} + exit codes 0/7) targets it. 0.33 fixed confiture
+  # #168 (from_config accepts a minimal config) and #169 (non-transactional
+  # migrations skipped, not failed, in preflight); 0.34 defaulted
+  # Environment.name/include_dirs so a migrate-only config validates directly;
+  # 0.35 defers restore matview REFRESH past ANALYZE (#172). That 0.35 fix lives
+  # in confiture.core.restorer, which fraisier's own dbops/restore.py does not
+  # use, so it is API-neutral here — the migrate/build/preflight surface is
+  # unchanged. The upper bound prevents silent drift onto a future schema
   # change (issue #262).
-  "fraiseql-confiture>=0.33.0,<0.34",
+  "fraiseql-confiture>=0.35.0,<0.36",
   "fastapi>=0.109.0,<1.0",
   "uvicorn>=0.27.0,<1.0",
   "pyyaml>=6.0,<7.0",
@@ -37,7 +42,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.42.0"
+version = "0.43.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -1,0 +1,144 @@
+"""End-to-end proof that fraisier's restore defers matview refresh past ANALYZE.
+
+fraisier's ``restore_backup`` delegates to confiture's three-phase
+``DatabaseRestorer``, which holds every ``REFRESH MATERIALIZED VIEW`` out of the
+restore phases, runs ``ANALYZE``, then refreshes on real statistics
+(confiture #172).  These tests exercise that seam against a *real* local
+PostgreSQL: a backup carrying a populated matview is dumped, restored through
+fraisier, and the matview must come out populated with the deferral accounting
+reported — the unit tests only prove the options handed to confiture, not that
+the two actually run together.
+
+Skipped unless a local PostgreSQL with ``createdb`` privilege and the client
+tools (``pg_dump`` / ``pg_restore``) are reachable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+psycopg = pytest.importorskip("psycopg")
+
+_SRC_DB = "fraisier_it_mv_src"
+_DST_DB = "fraisier_it_mv_dst"
+_CANDIDATE_DSNS = (
+    "postgresql:///postgres",
+    "postgresql:///postgres?host=/run/postgresql",
+    "postgresql:///postgres?host=/var/run/postgresql",
+    "postgresql:///postgres?host=/tmp",
+)
+
+
+def _discover_socket_dir() -> str | None:
+    """Return the server's unix socket directory, or None if unusable.
+
+    None is returned when the client tools are missing, no candidate DSN
+    connects, or the connecting role cannot create databases — all of which make
+    this end-to-end test inapplicable rather than failed.
+    """
+    if not all(shutil.which(tool) for tool in ("pg_dump", "pg_restore")):
+        return None
+    for dsn in _CANDIDATE_DSNS:
+        try:
+            with psycopg.connect(dsn, autocommit=True) as conn:
+                socket_dirs, can_create = conn.execute(
+                    "SELECT current_setting('unix_socket_directories'), "
+                    "(SELECT rolcreatedb OR rolsuper FROM pg_roles "
+                    " WHERE rolname = current_user)"
+                ).fetchone()
+        except Exception:
+            continue
+        if not can_create:
+            return None
+        return socket_dirs.split(",")[0].strip()
+    return None
+
+
+@pytest.fixture
+def socket_dir() -> str:
+    resolved = _discover_socket_dir()
+    if resolved is None:
+        pytest.skip("local PostgreSQL with createdb privilege not available")
+    return resolved
+
+
+def _dsn(db: str, socket_dir: str) -> str:
+    return f"postgresql:///{db}?host={socket_dir}"
+
+
+def _exec(db: str, socket_dir: str, *statements: str) -> None:
+    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+        for statement in statements:
+            conn.execute(statement)
+
+
+def _drop_databases(socket_dir: str) -> None:
+    for db in (_SRC_DB, _DST_DB):
+        with contextlib.suppress(Exception):
+            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
+
+
+@pytest.mark.parametrize("jobs", [1, 4])
+def test_restore_backup_populates_matview_end_to_end(socket_dir, tmp_path, jobs):
+    """A restored backup with a populated matview comes out populated.
+
+    Proves confiture's deferred-refresh path runs through fraisier for both the
+    serial (``jobs=1``) and parallel (``jobs=4``) restore paths — the parallel
+    case is the exact printoptim_backend#1960 incident condition (a matview
+    refresh replanning on empty stats during the ``--jobs 4`` data phase).  The
+    matview must end up filled (not left ``WITH NO DATA``) and the deferral
+    accounting is surfaced on fraisier's RestoreResult.
+    """
+    from fraisier.dbops.restore import restore_backup
+
+    dump_path = tmp_path / "src.dump"
+    _drop_databases(socket_dir)
+    try:
+        _exec("postgres", socket_dir, f"CREATE DATABASE {_SRC_DB}")
+        _exec(
+            _SRC_DB,
+            socket_dir,
+            "CREATE TABLE t (id int PRIMARY KEY, label text)",
+            "INSERT INTO t SELECT g, 'row' || g FROM generate_series(1, 500) g",
+            "CREATE MATERIALIZED VIEW mv AS "
+            "SELECT label, count(*) AS c FROM t GROUP BY label WITH DATA",
+        )
+
+        # confiture's three-phase restore requires custom (-Fc) or directory
+        # format; a plain SQL dump is rejected.
+        subprocess.run(
+            ["pg_dump", "-Fc", "-h", socket_dir, "-d", _SRC_DB, "-f", str(dump_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _exec("postgres", socket_dir, f"CREATE DATABASE {_DST_DB}")
+
+        result = restore_backup(
+            backup_path=str(dump_path),
+            db_name=_DST_DB,
+            connection_url=_dsn("postgres", socket_dir),
+            jobs=jobs,
+        )
+
+        assert result.success is True, result.error
+        # Exactly one matview in the dump → deferred out of the phases, then
+        # refreshed after ANALYZE on real statistics.
+        assert result.matviews_deferred == 1
+        assert result.matviews_refreshed == 1
+        assert result.analyze_ran is True
+
+        with psycopg.connect(_dsn(_DST_DB, socket_dir)) as conn:
+            table_rows = conn.execute("SELECT count(*) FROM t").fetchone()[0]
+            matview_rows = conn.execute("SELECT count(*) FROM mv").fetchone()[0]
+        assert table_rows == 500
+        # Populated by the deferred refresh — not left empty.
+        assert matview_rows == 500
+    finally:
+        _drop_databases(socket_dir)

--- a/tests/test_dbops.py
+++ b/tests/test_dbops.py
@@ -1,9 +1,22 @@
 """Tests for database and backup operations."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
+
+
+def _confiture_ok(**over):
+    """Stand-in for a successful confiture RestoreResult."""
+    return SimpleNamespace(
+        success=over.get("success", True),
+        errors=over.get("errors", []),
+        matviews_deferred=over.get("matviews_deferred"),
+        matviews_refreshed=over.get("matviews_refreshed"),
+        analyze_ran=over.get("analyze_ran", False),
+    )
+
 
 _TEST_URL = "postgresql://postgres:pass@localhost:5432/postgres"
 
@@ -798,13 +811,17 @@ class TestBackupSchedule:
 
 
 class TestStagingRestore:
-    """Test restore from backup with table count validation."""
+    """Test restore from backup, delegated to confiture's DatabaseRestorer."""
 
-    def test_restore_runs_pg_restore(self):
+    def test_restore_delegates_to_confiture(self):
         from fraisier.dbops.restore import restore_backup
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls,
+            patch("fraisier.dbops.restore._pg_cmd") as mock_cmd,
+        ):
+            restorer_cls.return_value.restore.return_value = _confiture_ok()
+            mock_cmd.return_value = (0, "", "")
             result = restore_backup(
                 backup_path="/backup/prod/latest.dump",
                 db_name="staging_db",
@@ -813,15 +830,21 @@ class TestStagingRestore:
             )
 
         assert result.success is True
-        calls = mock_run.call_args_list
-        cmds = [" ".join(c[0][0]) for c in calls]
-        assert any("pg_restore" in c for c in cmds)
+        restorer_cls.return_value.restore.assert_called_once()
+        opts = restorer_cls.return_value.restore.call_args[0][0]
+        assert opts.target_db == "staging_db"
+        assert opts.no_owner is True
+        assert opts.no_acl is True
 
     def test_restore_fixes_ownership(self):
         from fraisier.dbops.restore import restore_backup
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with (
+            patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls,
+            patch("fraisier.dbops.restore._pg_cmd") as mock_cmd,
+        ):
+            restorer_cls.return_value.restore.return_value = _confiture_ok()
+            mock_cmd.return_value = (0, "", "")
             restore_backup(
                 backup_path="/backup/prod/latest.dump",
                 db_name="staging_db",
@@ -829,16 +852,15 @@ class TestStagingRestore:
                 connection_url=_TEST_URL,
             )
 
-        calls = mock_run.call_args_list
-        cmds = [" ".join(c[0][0]) for c in calls]
-        assert any("REASSIGN" in c and "appuser" in c for c in cmds)
+        reassign = " ".join(mock_cmd.call_args[0][0])
+        assert "REASSIGN" in reassign and "appuser" in reassign
 
     def test_restore_failure(self):
         from fraisier.dbops.restore import restore_backup
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=1, stdout="", stderr="file not found"
+        with patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls:
+            restorer_cls.return_value.restore.return_value = _confiture_ok(
+                success=False, errors=["file not found"]
             )
             result = restore_backup(
                 backup_path="/nonexistent.dump",

--- a/tests/test_dbops_restore.py
+++ b/tests/test_dbops_restore.py
@@ -1,9 +1,12 @@
 """Tests for fraisier.dbops.restore module."""
 
+import contextlib
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from confiture.exceptions import RestoreError
 
 from fraisier.dbops.restore import (
     find_latest_backup,
@@ -14,12 +17,57 @@ from fraisier.dbops.restore import (
 _TEST_URL = "postgresql://postgres:pass@localhost:5432/postgres"
 
 
+def _confiture_result(
+    *,
+    success=True,
+    errors=None,
+    matviews_deferred=None,
+    matviews_refreshed=None,
+    analyze_ran=False,
+):
+    """Build a stand-in for confiture's ``RestoreResult``.
+
+    Mirrors the fields fraisier reads off ``DatabaseRestorer.restore``.
+    """
+    return SimpleNamespace(
+        success=success,
+        errors=errors or [],
+        warnings=[],
+        diagnostics=[],
+        phases_completed=[],
+        table_count=None,
+        matviews_deferred=matviews_deferred,
+        matviews_refreshed=matviews_refreshed,
+        analyze_ran=analyze_ran,
+    )
+
+
+@contextlib.contextmanager
+def _mock_restorer(result=None, *, raises=None):
+    """Patch ``DatabaseRestorer`` so ``.restore()`` returns *result* / *raises*.
+
+    Yields the patched class so tests can inspect the ``RestoreOptions`` passed
+    to ``DatabaseRestorer().restore(options)``.
+    """
+    with patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls:
+        restore = restorer_cls.return_value.restore
+        if raises is not None:
+            restore.side_effect = raises
+        else:
+            restore.return_value = result if result is not None else _confiture_result()
+        yield restorer_cls
+
+
+def _options_from(restorer_cls):
+    """Return the ``RestoreOptions`` passed to the mocked restore call."""
+    return restorer_cls.return_value.restore.call_args[0][0]
+
+
 class TestRestoreBackup:
-    """Test restore_backup."""
+    """restore_backup delegates to confiture's three-phase DatabaseRestorer."""
 
     def test_restore_success(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+        with _mock_restorer() as restorer_cls:
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -28,14 +76,40 @@ class TestRestoreBackup:
 
         assert result.success is True
         assert result.error == ""
-        mock_cmd.assert_called_once()
-        cmd = mock_cmd.call_args[0][0]
-        assert "pg_restore" in cmd
-        assert "staging" in cmd
-        assert "/backups/prod.dump" in cmd
-        assert "--no-owner" in cmd
-        assert "--no-acl" in cmd
-        assert mock_cmd.call_args.kwargs["connection_url"] == _TEST_URL
+        restorer_cls.return_value.restore.assert_called_once()
+        opts = _options_from(restorer_cls)
+        assert opts.target_db == "staging"
+        assert opts.backup_path == Path("/backups/prod.dump")
+        assert opts.no_owner is True
+        assert opts.no_acl is True
+        # fraisier validates the table count itself after `migrate up`.
+        assert opts.min_tables == 0
+
+    def test_restore_maps_tcp_connection_url(self):
+        """Host/port/user from a TCP URL land on RestoreOptions (confiture has
+        no connection-URL entry point, only discrete -h/-p/-U)."""
+        with _mock_restorer() as restorer_cls:
+            restore_backup(
+                backup_path="/backups/prod.dump",
+                db_name="staging",
+                connection_url=_TEST_URL,
+            )
+
+        opts = _options_from(restorer_cls)
+        assert opts.host == "localhost"
+        assert opts.port == 5432
+        assert opts.username == "postgres"
+
+    def test_restore_maps_socket_host_query(self):
+        """A socket URL carries the host in a ?host= query parameter."""
+        with _mock_restorer() as restorer_cls:
+            restore_backup(
+                backup_path="/backups/prod.dump",
+                db_name="staging",
+                connection_url="postgresql:///staging?host=/var/run/postgresql",
+            )
+
+        assert _options_from(restorer_cls).host == "/var/run/postgresql"
 
     def test_restore_requires_connection_url(self):
         with pytest.raises(TypeError):
@@ -44,8 +118,8 @@ class TestRestoreBackup:
             )
 
     def test_restore_failure(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (1, "", "pg_restore: error")
+        result_obj = _confiture_result(success=False, errors=["pg_restore: error"])
+        with _mock_restorer(result_obj):
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -55,20 +129,31 @@ class TestRestoreBackup:
         assert result.success is False
         assert "pg_restore: error" in result.error
 
-    def test_restore_backup_accepts_directory_dump_path(self, tmp_path: Path):
-        """restore_backup forwards a directory-format dump path to pg_restore unchanged.
+    def test_restore_raises_restoreerror_returns_failure(self):
+        """A RestoreError (e.g. unsupported dump format) becomes a failed result,
+        not a raised exception — the strategy expects to branch on .success."""
+        with _mock_restorer(raises=RestoreError("Unrecognised dump format")):
+            result = restore_backup(
+                backup_path="/backups/prod.dump",
+                db_name="staging",
+                connection_url=_TEST_URL,
+            )
 
-        pg_restore auto-detects ``-Fd`` from the positional path being a
-        directory. Lock-in for #202 Phase 3 — once parallel pg_dump
-        starts producing directory dumps, every existing restore caller
-        must work without further changes.
+        assert result.success is False
+        assert "dump format" in result.error
+
+    def test_restore_backup_accepts_directory_dump_path(self, tmp_path: Path):
+        """restore_backup forwards a directory-format dump path unchanged.
+
+        confiture auto-detects ``-Fd`` from the archive; fraisier passes the
+        directory path straight through as ``RestoreOptions.backup_path``.
+        Lock-in for #202 Phase 3 directory dumps.
         """
         dir_dump = tmp_path / "mydb_full_20260520_1200_zstd.dump"
         dir_dump.mkdir()
         (dir_dump / "toc.dat").write_text("stub toc")
 
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+        with _mock_restorer() as restorer_cls:
             result = restore_backup(
                 backup_path=str(dir_dump),
                 db_name="staging",
@@ -76,15 +161,10 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        cmd = mock_cmd.call_args[0][0]
-        assert cmd[0] == "pg_restore"
-        assert str(dir_dump) in cmd
-        assert not any(arg.startswith("-F") for arg in cmd), (
-            "pg_restore must auto-detect dump format; no -F flag override"
-        )
+        assert _options_from(restorer_cls).backup_path == dir_dump
 
     def test_restore_with_owner_fix(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
+        with _mock_restorer(), patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
             mock_cmd.return_value = (0, "", "")
             result = restore_backup(
                 backup_path="/backups/prod.dump",
@@ -94,21 +174,20 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        # Two calls: pg_restore + REASSIGN OWNED
-        assert mock_cmd.call_count == 2
-        reassign_cmd = mock_cmd.call_args_list[1][0][0]
+        # confiture does the restore; _pg_cmd runs only the REASSIGN OWNED step.
+        mock_cmd.assert_called_once()
+        reassign_cmd = mock_cmd.call_args[0][0]
         assert "psql" in reassign_cmd
         assert any("REASSIGN OWNED" in arg for arg in reassign_cmd)
         assert any("appuser" in arg for arg in reassign_cmd)
 
     def test_restore_owner_fix_failure_reported(self):
         """REASSIGN OWNED BY failure sets success=False with error."""
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            # pg_restore succeeds, REASSIGN fails
-            mock_cmd.side_effect = [
-                (0, "", ""),
-                (1, "", "ERROR: role does not exist"),
-            ]
+        with (
+            _mock_restorer(),
+            patch("fraisier.dbops.restore._pg_cmd") as mock_cmd,
+        ):
+            mock_cmd.return_value = (1, "", "ERROR: role does not exist")
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -119,9 +198,8 @@ class TestRestoreBackup:
         assert result.success is False
         assert "baduser" in result.error or "role" in result.error
 
-    def test_restore_with_jobs(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+    def test_restore_with_jobs_enables_parallel(self):
+        with _mock_restorer() as restorer_cls:
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -130,14 +208,13 @@ class TestRestoreBackup:
             )
 
         assert result.success is True
-        cmd = mock_cmd.call_args[0][0]
-        assert "-j" in cmd
-        j_idx = cmd.index("-j")
-        assert cmd[j_idx + 1] == "4"
+        opts = _options_from(restorer_cls)
+        assert opts.jobs == 4
+        # jobs > 1 → parallel data phase; transient FK errors must not abort.
+        assert opts.parallel_restore is True
 
-    def test_restore_jobs_1_no_flag(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+    def test_restore_jobs_1_serial(self):
+        with _mock_restorer() as restorer_cls:
             restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -145,24 +222,50 @@ class TestRestoreBackup:
                 jobs=1,
             )
 
-        cmd = mock_cmd.call_args[0][0]
-        assert "-j" not in cmd
+        opts = _options_from(restorer_cls)
+        assert opts.jobs == 1
+        assert opts.parallel_restore is False
 
-    def test_restore_default_no_j_flag(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+    def test_restore_default_serial(self):
+        with _mock_restorer() as restorer_cls:
             restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
                 connection_url=_TEST_URL,
             )
 
-        cmd = mock_cmd.call_args[0][0]
-        assert "-j" not in cmd
+        assert _options_from(restorer_cls).parallel_restore is False
+
+    def test_restore_surfaces_matview_accounting(self):
+        """confiture's deferred-matview fields flow onto fraisier's RestoreResult."""
+        result_obj = _confiture_result(
+            matviews_deferred=2, matviews_refreshed=2, analyze_ran=True
+        )
+        with _mock_restorer(result_obj):
+            result = restore_backup(
+                backup_path="/backups/prod.dump",
+                db_name="staging",
+                connection_url=_TEST_URL,
+            )
+
+        assert result.matviews_deferred == 2
+        assert result.matviews_refreshed == 2
+        assert result.analyze_ran is True
+
+    def test_restore_matview_fields_none_without_matviews(self):
+        with _mock_restorer():
+            result = restore_backup(
+                backup_path="/backups/prod.dump",
+                db_name="staging",
+                connection_url=_TEST_URL,
+            )
+
+        assert result.matviews_deferred is None
+        assert result.matviews_refreshed is None
+        assert result.analyze_ran is False
 
     def test_restore_returns_duration(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+        with _mock_restorer():
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",
@@ -172,8 +275,8 @@ class TestRestoreBackup:
         assert result.duration_seconds > 0
 
     def test_restore_failure_still_has_duration(self):
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (1, "", "pg_restore: error")
+        result_obj = _confiture_result(success=False, errors=["pg_restore: error"])
+        with _mock_restorer(result_obj):
             result = restore_backup(
                 backup_path="/backups/prod.dump",
                 db_name="staging",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -313,9 +313,17 @@ class TestBackupRestoreCycle:
             assert "audit_trail" in excluded
 
     def test_restore_runs_pg_restore(self):
-        """Restore runs pg_restore with --no-owner --no-acl."""
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
-            mock_cmd.return_value = (0, "", "")
+        """Restore delegates to confiture with --no-owner --no-acl semantics."""
+        from types import SimpleNamespace
+
+        with patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls:
+            restorer_cls.return_value.restore.return_value = SimpleNamespace(
+                success=True,
+                errors=[],
+                matviews_deferred=None,
+                matviews_refreshed=None,
+                analyze_ran=False,
+            )
 
             from fraisier.dbops.restore import restore_backup
 
@@ -326,14 +334,25 @@ class TestBackupRestoreCycle:
             )
 
             assert result.success is True
-            call_args = mock_cmd.call_args[0][0]
-            assert "pg_restore" in call_args
-            assert "--no-owner" in call_args
-            assert "--no-acl" in call_args
+            opts = restorer_cls.return_value.restore.call_args[0][0]
+            assert opts.no_owner is True
+            assert opts.no_acl is True
 
     def test_restore_with_ownership_fix(self):
         """Restore reassigns ownership when db_owner is set."""
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
+        from types import SimpleNamespace
+
+        with (
+            patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls,
+            patch("fraisier.dbops.restore._pg_cmd") as mock_cmd,
+        ):
+            restorer_cls.return_value.restore.return_value = SimpleNamespace(
+                success=True,
+                errors=[],
+                matviews_deferred=None,
+                matviews_refreshed=None,
+                analyze_ran=False,
+            )
             mock_cmd.return_value = (0, "", "")
 
             from fraisier.dbops.restore import restore_backup
@@ -346,9 +365,9 @@ class TestBackupRestoreCycle:
             )
 
             assert result.success is True
-            # Should have been called twice: restore + ownership fix
-            assert mock_cmd.call_count == 2
-            ownership_call = mock_cmd.call_args_list[1][0][0]
+            # confiture does the restore; _pg_cmd runs only the ownership fix.
+            mock_cmd.assert_called_once()
+            ownership_call = mock_cmd.call_args[0][0]
             assert any("REASSIGN" in str(a) for a in ownership_call)
 
     def test_backup_failure_returns_error(self):

--- a/tests/test_security_phase2.py
+++ b/tests/test_security_phase2.py
@@ -84,9 +84,20 @@ class TestRestoreInputValidation:
 
     def test_restore_uses_psql_variable_binding(self):
         """db_owner must not be interpolated via f-string in SQL."""
+        from types import SimpleNamespace
         from unittest.mock import patch
 
-        with patch("fraisier.dbops.restore._pg_cmd") as mock_cmd:
+        with (
+            patch("fraisier.dbops.restore.DatabaseRestorer") as restorer_cls,
+            patch("fraisier.dbops.restore._pg_cmd") as mock_cmd,
+        ):
+            restorer_cls.return_value.restore.return_value = SimpleNamespace(
+                success=True,
+                errors=[],
+                matviews_deferred=None,
+                matviews_refreshed=None,
+                analyze_ran=False,
+            )
             mock_cmd.return_value = (0, "", "")
             restore_backup(
                 backup_path="/backups/prod.dump",
@@ -95,11 +106,10 @@ class TestRestoreInputValidation:
                 connection_url=_TEST_URL,
             )
 
-        # The REASSIGN OWNED call should use psql -v variable binding,
-        # not an f-string with the owner name directly in the SQL
-        reassign_call = mock_cmd.call_args_list[1]
-        cmd_args = reassign_call[0][0]
-        # Should contain -v for variable binding
+        # confiture runs the restore; the sole _pg_cmd call is REASSIGN OWNED,
+        # which must use psql -v variable binding, not an f-string with the
+        # owner name interpolated directly into the SQL.
+        cmd_args = mock_cmd.call_args[0][0]
         assert "-v" in cmd_args, (
             "REASSIGN OWNED should use psql -v variable binding, not f-string SQL"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "fraiseql-confiture"
-version = "0.33.0"
+version = "0.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -532,23 +532,23 @@ dependencies = [
     { name = "sqlparse" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/9f/fea3cc9f84e515cf0ee8bafef6acbf1c648006e2091e68b91be21b5ec635/fraiseql_confiture-0.33.0.tar.gz", hash = "sha256:9dd88aeb0c53f27c2bda5814bc21b3b708736fb8af0fbca772804a3bb2a903f6", size = 2034697, upload-time = "2026-06-25T20:49:45.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/8a/17614b7c5ad798deb248b91d51c2924a78db52a23a0f7493c40a1e90b93d/fraiseql_confiture-0.35.0.tar.gz", hash = "sha256:490edad5d07f3ffc33135631d94a712baef6fdcfa6196bcd33d017c5ac430362", size = 2047116, upload-time = "2026-07-07T09:44:27.125Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/60/a6d6c3631f8b24e78d78ad170292b6efea2ac2053d3b519eb5f63dc11058/fraiseql_confiture-0.33.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfdccc7481fb67f8a1e5dc10d41804d6bab4973532007da523cfe9d8076596f4", size = 1034442, upload-time = "2026-06-25T20:49:30.281Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/03/3fb62babb1f4d6797aa18c055563db88882663945cc73f3e741f42be1df4/fraiseql_confiture-0.33.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:201989f9b669cf726edc3b3aaad35816ba9f75750df6b31afe7474b0b814b4f6", size = 1081424, upload-time = "2026-06-25T20:49:32.232Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/44/92365b29a9f246b2e35733dc4dc3b8c03616381a66077be379eee3684b36/fraiseql_confiture-0.33.0-cp311-cp311-win_amd64.whl", hash = "sha256:002fac8ddb5f0c6458a4454c69d935c59d3971078a2f64a2a14fa3170290cec4", size = 987322, upload-time = "2026-06-25T20:49:33.72Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/25/40596d9b0ffe5066166130554f3b0afc49da09cf347de57ba11eadd5c18f/fraiseql_confiture-0.33.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e07a133941a4a3e34464049cb86be19e932f4ce41b15c1b60a5d56d24dd250cd", size = 1034140, upload-time = "2026-06-25T20:49:35.077Z" },
-    { url = "https://files.pythonhosted.org/packages/39/45/57460e2ec1c045b4778ad41a0dda3b5e6cf6439978a88bc9ada945b72e05/fraiseql_confiture-0.33.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:102a5d6a13e9a27c50bb25dac2de3a1d62d2074a7ec28c5932fa8d24b0a6d0b1", size = 1080029, upload-time = "2026-06-25T20:49:36.404Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/fc035118581a890e9f8f1f9795b30d456efbabec43a0ececae793a7508eb/fraiseql_confiture-0.33.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c766237a230b389dcd78e4ac41d055f4ac43f1a710f34943f719a818944c938", size = 987682, upload-time = "2026-06-25T20:49:37.514Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a0/9f3078265c855144850e89f1d88399fe5fee6b1a854c7e9003f517e8bd74/fraiseql_confiture-0.33.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fbfe01386b9bf93996a118f9c43aa41e93642e4bea2cf415ae7d552dd4049ee1", size = 1034197, upload-time = "2026-06-25T20:49:38.89Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/a8/e79f3818f5ae0d51b2e12b33865a5ecfbcac7b98487d3c66d43b5771f5de/fraiseql_confiture-0.33.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:14881e7a0445f42dc2c8bd6cbcbfbc8110a56f3d08c1d5dc3e444cdc6ded52f5", size = 1079912, upload-time = "2026-06-25T20:49:40.182Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b1/2993c33653b06992b5b08286a9682b26825a465e3bc143fb6425a0f4b20f/fraiseql_confiture-0.33.0-cp313-cp313-win_amd64.whl", hash = "sha256:5398937df5f02ac650db284144fbf34f9fa1c1c4b28baf4512a0641d926d747a", size = 987653, upload-time = "2026-06-25T20:49:41.906Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/fc/0e67de94e2442a47d1062f751481d00374fb93ab93fdb3ba2beac699c48d/fraiseql_confiture-0.33.0-cp314-cp314-win_amd64.whl", hash = "sha256:b3b1cfd21ecab9ca3f4ec9b6dc6cb66c51b836f204992a9d89b1757bd02a8e3f", size = 987656, upload-time = "2026-06-25T20:49:43.489Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/95/34e74c6ad1201ec0363dba5625a1084a39e9918e4b1fdc2246f03cac6b49/fraiseql_confiture-0.35.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99567ec85b4d5788d6cc604f111ba8cd88cf7bfaa341947f564bc069ebf9bd7b", size = 1038787, upload-time = "2026-07-07T09:44:13.18Z" },
+    { url = "https://files.pythonhosted.org/packages/73/60/1386d92859cfffb11ef2bd361fa6943e86f6a5ef1138b4f44a07ee685071/fraiseql_confiture-0.35.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c9d6f9d4d97980ac828f55615e1ad45bbb95bb2b0c658586a1daa60a51da9f7f", size = 1085879, upload-time = "2026-07-07T09:44:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4a/f9cb0cc80d6e08fa2cb90c208ddf461b91ee4183a2a2fb42ea5e0880682b/fraiseql_confiture-0.35.0-cp311-cp311-win_amd64.whl", hash = "sha256:a89eb682b1c05cd2a83386f802fb9f2fb243d83b24d64303597c19340f2a5722", size = 991725, upload-time = "2026-07-07T09:44:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a8/76c6ccaf0c85ec6bb9471fb17ce9982edc279c1e789b26e887e364e43b2e/fraiseql_confiture-0.35.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e8e02c6f31b7a7ba7cc590f7705714567a8048d8717390b9cda9df9787ebaa21", size = 1038483, upload-time = "2026-07-07T09:44:17.066Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/8e821b6a38f67ee9f0f25bb9e680616364f391d69bc513a60e324258074b/fraiseql_confiture-0.35.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fbdd128c43c953fe5444ce0802ca60a3fcd8bcbdde65bc50d1a20d27d4052949", size = 1084486, upload-time = "2026-07-07T09:44:18.441Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/66/aadb7a18a97f08acfd00299c3e634ad42852c19a579954ef23063b62c486/fraiseql_confiture-0.35.0-cp312-cp312-win_amd64.whl", hash = "sha256:b69d3d4fecb7c83e86ff70468f6bb52213f3dae6bff429dc2a8e37901e803f00", size = 992092, upload-time = "2026-07-07T09:44:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/16/17/889a67de47e3ae8588158c9ceb93be696168de345f698b6ab00ac350f84b/fraiseql_confiture-0.35.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:62874c28d528d842a4a713e980af1f8b76962010252ddab375e3717b94b47993", size = 1038539, upload-time = "2026-07-07T09:44:21.367Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f3/97e3933afa1ff0ad05f36a020c19e253126be6cc013ea54399bfc5dbcc6d/fraiseql_confiture-0.35.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0f045751d8c301dea6941401e9010c5e0a6b4f6827b1c1b472c75d239e46fc6b", size = 1084387, upload-time = "2026-07-07T09:44:23.141Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/b7bdda33977a22847f3fc7804a8c73e7fe2f31b85cc881bb3a300188cd12/fraiseql_confiture-0.35.0-cp313-cp313-win_amd64.whl", hash = "sha256:3586be9b3fe8a41d64ea8c3a0fb2bfab422b96b0933140df363d30133464481c", size = 992049, upload-time = "2026-07-07T09:44:24.524Z" },
+    { url = "https://files.pythonhosted.org/packages/50/66/1fe1ac52e694ae0c3d5a96717ac7a7e44a93a16792ac10ca37981d3e7e43/fraiseql_confiture-0.35.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7e3017d42c4a532251c6b4ce8c65f5da8852758ae64c1fc55f2898404190fd4", size = 992048, upload-time = "2026-07-07T09:44:25.868Z" },
 ]
 
 [[package]]
 name = "fraisier"
-version = "0.42.0"
+version = "0.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -605,7 +605,7 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'all-databases'", specifier = ">=0.19.0,<1.0" },
     { name = "click", specifier = ">=8.1.0,<9.0" },
     { name = "fastapi", specifier = ">=0.109.0,<1.0" },
-    { name = "fraiseql-confiture", specifier = ">=0.33.0,<0.34" },
+    { name = "fraiseql-confiture", specifier = ">=0.35.0,<0.36" },
     { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0,<1.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0" },


### PR DESCRIPTION
Closes #270.

Adopts **fraiseql-confiture 0.35** and — the substantive change — moves the staging restore off a bare `pg_restore` onto confiture's three-phase **`DatabaseRestorer`**, so the matview `REFRESH`-past-`ANALYZE` fix (confiture #172) actually reaches fraisier's `restore_migrate` strategy. This continues the confiture 0.33 migration shipped in v0.41.0.

## Why this matters

The issue's premise was that a pin bump alone would deliver confiture's restore fix. It would not: `dbops/restore.restore_backup` shelled out to `pg_restore -d <db> --no-owner --no-acl [-j N] <dump>` **directly** and never touched `confiture.core.restorer` — fraisier's confiture integration was migrate/build/preflight only. So a backup carrying a stats-sensitive matview refreshed it **inside the parallel data phase on the empty `pg_statistic` of a freshly loaded database**, replanning into a catastrophic nested loop (the printoptim_backend#1960 incident: 2h+ on `REFRESH MATERIALIZED VIEW mv_maintenance_price` under `--jobs 4`). This PR routes the restore through confiture so the deferral applies.

## Changes

- **Pin** `fraiseql-confiture >=0.35.0,<0.36` (was `>=0.33.0,<0.34`). The migrate/build/preflight surface fraisier targets is unchanged across 0.33→0.35 (`Migrator.from_config` → `MigratorSession.up/down/status/preflight`; preflight `--against` `{ok, summary, issues[]}` + exit `0`/`7`), verified against 0.35.
- **`restore_backup` → confiture `DatabaseRestorer`**: matview refreshes held out of the restore phases, database-wide `ANALYZE`, then refresh on real stats. Maps `connection_url` → discrete `-h/-p/-U` (netloc **or** socket `?host=`) with `PGPASSWORD` threaded through the subprocess env; keeps `REASSIGN OWNED` + identifier/path validation; `parallel_restore` for `jobs>1`; `min_tables=0` (strategy validates count post-`migrate up`). A confiture `RestoreError` becomes a failed `RestoreResult`, so the strategy's `.success` branch is unchanged.
- **Surface the phase breakdown** (#270 ask #3): `RestoreResult` carries `matviews_deferred` / `matviews_refreshed` / `analyze_ran`, logged in `RestoreMigrateStrategy`.
- **Tests**: restore unit tests migrated onto the `DatabaseRestorer` seam; new real-PostgreSQL e2e (`tests/integration/test_restore_matview_deferral.py`) proves a populated matview survives restore for both `jobs=1` and `jobs=4`.

## Verification

- ✅ Full suite: **4216 passed, 7 skipped**
- ✅ `ruff check`, `ruff format --check`, `ty check fraisier/` clean
- ✅ e2e matview restore (serial + parallel) passes against real PostgreSQL

## Downstream (after this release, per the issue)

- Bump `fraisier==0.43.0` in printoptim_backend + re-lock → confiture 0.35 flows into the app venv.
- `uv tool install --force fraisier==0.43.0` on the deploy hosts + webhook restart so the strategy runs the new confiture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)