### PR TITLE
release: v0.44.0 — db restore CLI re-applies post_migrate grants (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2026-07-16
+
+Closes the standalone-restore tail of the ACL-stripping bug first fixed for the deploy path in printoptim_backend#1681: `fraisier db restore` now re-applies the configured grant scripts, so a database refreshed outside a full deploy is no longer left grantless.
+
+### Fixed
+
+- **`fraisier db restore <fraise> <env>` now re-applies the configured `database.post_migrate` grant scripts after a successful restore** ([#273](https://github.com/fraiseql/fraisier/issues/273)). The `restore_migrate` strategy restores with `pg_restore --no-owner --no-acl` and, by design, applies no grants — re-applying `database.post_migrate` was the deployer's responsibility (`_run_post_migrate`). The webhook deploy path ran it; the standalone `db restore` CLI called `strategy.execute(...)` and returned on success **without** it. Any environment refreshed via the CLI — e.g. a nightly "restore staging from production backup" timer — therefore came back with every non-`public` schema stripped of `USAGE`, and any application/ETL/reporting role that isn't the schema owner could no longer connect. Real incident: a staging DB refreshed nightly by `restore-staging-from-production-backup.timer` wiped `printoptim_etl`'s grants every night at 00:00 UTC, yielding ~615 failed ETL runs over 7 days (`permission denied for schema tenant`) — each restore re-wiping the grants a human had manually replayed. `db_restore` now runs the post_migrate hooks after a successful restore and exits non-zero if a `halt` step fails.
+
+### Changed
+
+- **`post_migrate` load-and-run is now a single shared seam.** `deployers/api.py::_run_post_migrate` and the `db restore` CLI both delegate to `post_migrate.run_configured_post_migrate(database_config, *, app_path, runner)`, which resolves `database_url`, loads the configured steps, and runs them — a no-op when there is no `database_url` or no configured steps, and a `halt` step still raises `DeploymentError`. This keeps the deploy and CLI paths from drifting rather than duplicating the load-and-run logic in two places.
+
 ## [0.43.0] - 2026-07-07
 
 Continues the confiture 0.33 migration shipped in 0.41.0: adopts fraiseql-confiture 0.35 and — the substantive change — moves the staging restore off a bare `pg_restore` onto confiture's three-phase `DatabaseRestorer`, so the matview-refresh fix (confiture #172) actually reaches fraisier's `restore_migrate` strategy.

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -674,19 +674,36 @@ def db_restore(
         console.print(f"[red]Restore failed:[/red] {exc}")
         raise SystemExit(1) from exc
 
-    if result.success:
-        msg = f"{result.migrations_applied} migration(s) applied"
-        console.print(f"[green]Restore complete:[/green] {msg}")
-        if result.total_duration_seconds > 0:
-            console.print(
-                f"  Restore: {result.restore_duration_seconds:.1f}s"
-                f" | Migration: {result.migration_duration_seconds:.1f}s"
-                f" | Total: {result.total_duration_seconds:.1f}s"
-            )
-    else:
+    if not result.success:
         errors = ", ".join(result.errors)
         console.print(f"[red]Restore failed:[/red] {errors}")
         raise SystemExit(1)
+
+    msg = f"{result.migrations_applied} migration(s) applied"
+    console.print(f"[green]Restore complete:[/green] {msg}")
+    if result.total_duration_seconds > 0:
+        console.print(
+            f"  Restore: {result.restore_duration_seconds:.1f}s"
+            f" | Migration: {result.migration_duration_seconds:.1f}s"
+            f" | Total: {result.total_duration_seconds:.1f}s"
+        )
+
+    # Re-apply configured grant scripts. The restore strategy restores with
+    # pg_restore --no-owner --no-acl, so without this the restored DB is
+    # grantless for every non-owner role — the deploy path already does this
+    # via _run_post_migrate, the standalone CLI path did not (issue #273).
+    from fraisier import post_migrate
+    from fraisier.errors import DeploymentError
+
+    try:
+        post_migrate.run_configured_post_migrate(
+            db_cfg,
+            app_path=app_path,
+            runner=runner,
+        )
+    except DeploymentError as exc:
+        console.print(f"[red]post_migrate failed:[/red] {exc}")
+        raise SystemExit(1) from exc
 
 
 @main.command(name="backup")

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -357,20 +357,11 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         ``post_migrate`` list is empty or ``database_url`` is missing —
         no app DB to connect to.
         """
-        database_url = self.database_config.get("database_url")
-        if not database_url:
-            return
         from fraisier import post_migrate
 
-        steps = post_migrate.load_post_migrate_steps(
+        post_migrate.run_configured_post_migrate(
             self.database_config,
             app_path=Path(self.app_path) if self.app_path else Path(),
-        )
-        if not steps:
-            return
-        post_migrate.run_post_migrate_steps(
-            steps,
-            database_url=database_url,
             runner=self.runner,
         )
 

--- a/fraisier/post_migrate.py
+++ b/fraisier/post_migrate.py
@@ -130,3 +130,32 @@ def run_post_migrate_steps(
                     sql_file,
                     exc.stderr or exc,
                 )
+
+
+def run_configured_post_migrate(
+    database_config: dict,
+    *,
+    app_path: Path,
+    runner: CommandRunner,
+    database_url: str | None = None,
+) -> None:
+    """Load and run the configured ``database.post_migrate`` hooks.
+
+    Single orchestration seam shared by the webhook deploy path
+    (``deployers/api.py``) and the standalone ``fraisier db restore`` CLI
+    (``cli/db.py``). The ``restore_migrate`` strategy restores with
+    ``pg_restore --no-owner --no-acl``, so re-applying the configured grant
+    scripts is what makes a restored database usable by non-owner roles
+    (issue #273); before this seam only the deploy path re-applied them.
+
+    A no-op when *database_url* cannot be resolved (no app DB to connect to)
+    or the ``post_migrate`` list is empty. A ``halt`` step that fails raises
+    ``DeploymentError``; a ``warn`` step logs and continues.
+    """
+    database_url = database_url or database_config.get("database_url")
+    if not database_url:
+        return
+    steps = load_post_migrate_steps(database_config, app_path=app_path)
+    if not steps:
+        return
+    run_post_migrate_steps(steps, database_url=database_url, runner=runner)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.43.0"
+version = "0.44.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_cli_db.py
+++ b/tests/test_cli_db.py
@@ -676,3 +676,106 @@ class TestDbRestore:
         call_args = mock_execute.call_args
         confiture_arg = call_args[0][0]
         assert confiture_arg == _Path("/var/www/api/confiture.yaml")
+
+    def test_db_restore_runs_post_migrate_after_success(self, runner, restore_config):
+        """A successful restore re-applies configured post_migrate grants (#273).
+
+        The restore strategy strips ACLs (pg_restore --no-owner --no-acl), so
+        the CLI must run the configured grant scripts exactly as the deploy
+        path does — otherwise every non-owner role is left grantless.
+        """
+        env = restore_config.get_fraise_environment.return_value
+        env["database"]["database_url"] = _APP_URL
+        env["database"]["post_migrate"] = [{"sql_file": "db/7_grant/grant.sql"}]
+        result_mock = MagicMock(
+            success=True,
+            migrations_applied=1,
+            total_duration_seconds=0.0,
+            restore_duration_seconds=0.0,
+            migration_duration_seconds=0.0,
+        )
+        with (
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch(
+                "fraisier.strategies.RestoreMigrateStrategy.execute",
+                return_value=result_mock,
+            ),
+            patch(
+                "fraisier.service_managers.get_service_manager",
+                return_value=MagicMock(),
+            ),
+            patch("fraisier.runners.LocalRunner"),
+            patch("fraisier.post_migrate.run_post_migrate_steps") as mock_run,
+        ):
+            result = runner.invoke(main, ["db", "restore", "my_api", "staging"])
+
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["database_url"] == _APP_URL
+
+    def test_db_restore_without_post_migrate_is_noop(self, runner, restore_config):
+        """Restore with no post_migrate config does not invoke the hook."""
+        env = restore_config.get_fraise_environment.return_value
+        env["database"]["database_url"] = _APP_URL
+        # No post_migrate key configured.
+        result_mock = MagicMock(
+            success=True,
+            migrations_applied=1,
+            total_duration_seconds=0.0,
+            restore_duration_seconds=0.0,
+            migration_duration_seconds=0.0,
+        )
+        with (
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch(
+                "fraisier.strategies.RestoreMigrateStrategy.execute",
+                return_value=result_mock,
+            ),
+            patch(
+                "fraisier.service_managers.get_service_manager",
+                return_value=MagicMock(),
+            ),
+            patch("fraisier.runners.LocalRunner"),
+            patch("fraisier.post_migrate.run_post_migrate_steps") as mock_run,
+        ):
+            result = runner.invoke(main, ["db", "restore", "my_api", "staging"])
+
+        assert result.exit_code == 0
+        mock_run.assert_not_called()
+
+    def test_db_restore_post_migrate_halt_failure_exits_1(self, runner, restore_config):
+        """A halt-mode post_migrate failure fails the restore command (#273)."""
+        from fraisier.errors import DeploymentError
+
+        env = restore_config.get_fraise_environment.return_value
+        env["database"]["database_url"] = _APP_URL
+        env["database"]["post_migrate"] = [
+            {"sql_file": "db/7_grant/grant.sql", "on_error": "halt"}
+        ]
+        result_mock = MagicMock(
+            success=True,
+            migrations_applied=1,
+            total_duration_seconds=0.0,
+            restore_duration_seconds=0.0,
+            migration_duration_seconds=0.0,
+        )
+        with (
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch(
+                "fraisier.strategies.RestoreMigrateStrategy.execute",
+                return_value=result_mock,
+            ),
+            patch(
+                "fraisier.service_managers.get_service_manager",
+                return_value=MagicMock(),
+            ),
+            patch("fraisier.runners.LocalRunner"),
+            patch(
+                "fraisier.post_migrate.run_post_migrate_steps",
+                side_effect=DeploymentError("grant.sql failed"),
+            ),
+        ):
+            result = runner.invoke(main, ["db", "restore", "my_api", "staging"])
+
+        assert result.exit_code == 1
+        assert "post_migrate failed" in result.output.lower()

--- a/tests/test_post_migrate.py
+++ b/tests/test_post_migrate.py
@@ -26,6 +26,7 @@ from fraisier.errors import DeploymentError
 from fraisier.post_migrate import (
     PostMigrateStep,
     load_post_migrate_steps,
+    run_configured_post_migrate,
     run_post_migrate_steps,
 )
 
@@ -222,3 +223,97 @@ class TestRunPostMigrateStepsOnError:
         assert runner.run.call_count == 2
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("10_bad.sql" in r.getMessage() for r in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Shared orchestration seam (deploy path + `db restore` CLI, #273)
+# ---------------------------------------------------------------------------
+
+
+class TestRunConfiguredPostMigrate:
+    def test_skips_when_database_url_missing(self, tmp_path):
+        # No database_url and none passed — nothing to connect to.
+        sql = tmp_path / "grant.sql"
+        sql.write_text("GRANT USAGE ON SCHEMA tenant TO app;")
+        runner = _runner_ok()
+
+        run_configured_post_migrate(
+            {"post_migrate": [{"sql_file": str(sql)}]},
+            app_path=tmp_path,
+            runner=runner,
+        )
+
+        runner.run.assert_not_called()
+
+    def test_skips_when_no_steps_configured(self):
+        # database_url present but the post_migrate list is empty.
+        runner = _runner_ok()
+
+        run_configured_post_migrate(
+            {"database_url": "postgresql://u@h/db", "post_migrate": []},
+            app_path=Path("/srv/api"),
+            runner=runner,
+        )
+
+        runner.run.assert_not_called()
+
+    def test_runs_configured_steps_with_database_url_from_config(self, tmp_path):
+        sql = tmp_path / "grant.sql"
+        sql.write_text("GRANT USAGE ON SCHEMA tenant TO app;")
+        runner = _runner_ok()
+
+        run_configured_post_migrate(
+            {
+                "database_url": "postgresql://u@h/db",
+                "post_migrate": [{"sql_file": str(sql)}],
+            },
+            app_path=tmp_path,
+            runner=runner,
+        )
+
+        runner.run.assert_called_once()
+        cmd = runner.run.call_args.args[0]
+        assert cmd == [
+            "psql",
+            "postgresql://u@h/db",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-f",
+            str(sql),
+        ]
+
+    def test_explicit_database_url_overrides_config(self, tmp_path):
+        sql = tmp_path / "grant.sql"
+        sql.write_text("GRANT USAGE ON SCHEMA tenant TO app;")
+        runner = _runner_ok()
+
+        run_configured_post_migrate(
+            {
+                "database_url": "postgresql://ignored@h/db",
+                "post_migrate": [{"sql_file": str(sql)}],
+            },
+            app_path=tmp_path,
+            runner=runner,
+            database_url="postgresql://override@h/db",
+        )
+
+        cmd = runner.run.call_args.args[0]
+        assert cmd[1] == "postgresql://override@h/db"
+
+    def test_halt_failure_propagates_deployment_error(self, tmp_path):
+        sql = tmp_path / "grant.sql"
+        sql.write_text("boom")
+        runner = MagicMock()
+        runner.run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["psql"], stderr="permission denied"
+        )
+
+        with pytest.raises(DeploymentError):
+            run_configured_post_migrate(
+                {
+                    "database_url": "postgresql://u@h/db",
+                    "post_migrate": [{"sql_file": str(sql), "on_error": "halt"}],
+                },
+                app_path=tmp_path,
+                runner=runner,
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.43.0"
+version = "0.44.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

`fraisier db restore <fraise> <env>` restored a database with `pg_restore --no-owner --no-acl` but **never ran the configured `database.post_migrate` hooks** — only the webhook/deploy path re-applied them. Any environment refreshed via the standalone CLI (e.g. a nightly *restore-staging-from-production-backup* timer) came back with every non-`public` schema stripped of `USAGE`, so any application/ETL/reporting role that isn't the schema owner could no longer connect. This is the standalone-restore tail of the ACL-stripping bug fixed for the deploy path in printoptim_backend#1681.

Fixes #273.

## Root cause

`run_post_migrate_steps` had exactly one caller — `deployers/api.py::_run_post_migrate` (webhook deploy). The strategy (`strategies/_restore.py`) intentionally restores with `--no-owner --no-acl` and has no grant step, expecting the deployer to do it. `cli/db.py::db_restore()` called `strategy.execute(...)` and returned on success **without** running post_migrate, leaving the DB de-ACL'd.

## Fix

Chosen approach: mirror the deployer in the CLI (issue's Fix A), not "move into the strategy and drop the deployer's `_run_post_migrate`" (Fix B). Fix B would have regressed post_migrate for **every non-restore deploy strategy**, since `_run_post_migrate` runs for all strategies with a `database_config`, not just `restore_migrate` — and it would have leaked orchestration config (`app_path`, the `post_migrate` list) through the strategy boundary, which is deliberately decoupled.

- **New shared seam** `post_migrate.run_configured_post_migrate(database_config, *, app_path, runner)` — resolves `database_url`, loads the configured steps, runs them. No-op when there's no `database_url` or no steps; a `halt` step still raises `DeploymentError`.
- `deployers/api._run_post_migrate` now delegates to the seam (behaviour unchanged).
- `cli/db.db_restore` runs post_migrate after a successful restore; a `halt` failure prints an error and exits 1.

Uses `database_url` (the app-role connection), exactly as the proven deploy path does — not `admin_url`.

## Tests

- `tests/test_post_migrate.py::TestRunConfiguredPostMigrate` — skip-when-no-url, skip-when-no-steps, runs-with-config-url, explicit-url-override, halt-propagates.
- `tests/test_cli_db.py::TestDbRestore` — runs-post-migrate-after-success (asserts `database_url` passed), no-op-without-post_migrate, halt-failure-exits-1.
- Existing deploy-path post_migrate tests unchanged and green (they patch `run_post_migrate_steps`, which the seam still calls).

## Verification

- ✅ 4224 passed (known `test_install_helper` full-suite ordering flake deselected)
- ✅ `ruff check .` + `ruff format --check .` clean
- ✅ `ty check` clean

## Release

- Version bump 0.43.0 → 0.44.0
- CHANGELOG entry (Fixed + Changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)