### PR TITLE
release: v0.46.0 — install-path hardening (#276–#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-07-22
+
+Install-path hardening. Five defects on one deploy path, all surfaced by a
+single incident: a `printoptim` `install.command` change (a `bash -c` wrapper)
+that failed to deploy, gave no useful error, then "succeeded but did nothing"
+once patched — and, when the socket path was investigated, turned out to be
+blocked by a stale allowlist under a strict sandbox.
+
+### Fixed
+
+- **`sudo -u` install fallback now sets `HOME` via `-H`** (`deployers/mixins.py`). Without it, `sudo` kept the invoker's `HOME` (`/root` when the deploy runs as root) and HOME-writing tools (`uv`/`pip`/`cargo`/`npm`) failed with `Permission denied` writing their caches under `/root/.cache`. The install-helper socket path was already correct — it runs as the install user via systemd `User=`, so its `HOME` is right by construction — which is why the failure only showed on the sudo fallback (#276).
+- **Install-failure errors now surface the captured `stderr`** in the `DeploymentError` message (bounded to the last 2000 chars), so the real cause lands in the deploy journal instead of only in the un-rendered context dict. A generic `.cache` + `Permission denied` heuristic points at the HOME fix above; the socket path gets the same surfacing with a reworded hint (it never uses sudo). Note: `stderr` now reaches `status.error_message` and the authenticated `/api/status/<fraise>/details` endpoint — a wider (token-gated, bounded) surface than before (#277).
+- **A changed `install.command` is now re-baked into the running install-helper allowlist during the deploy** (#279). The install-helper enforces an exact-match allowlist baked into its systemd unit; when the command changed, the running helper still accepted only the *previous* command and rejected the deploy with `command not allowed`. `install.sh` used `enable --now` on the socket (a no-op on a running unit), so the stale-argv service kept running — now it stops the service and restarts the socket so the next install re-execs with the new allowlist. Those re-bake steps run via a new fatal `_run_strict` (not the failure-swallowing `_run`), and a failed post-pull scaffold re-bake now **aborts the deploy loudly**, naming the stale allowlist, instead of continuing into a masked `command not allowed`. The install-helper rejection message now names the expected vs received command. The allowlist boundary is kept (request-time config validation was explicitly rejected — it would validate against attacker-writable config).
+- **Install caches relocated under `app_path` so the install step works under `ProtectSystem=strict` for any toolchain** (#280). The install-helper unit was hand-fitted for `uv` only (whitelisting `~/.cache/uv`); a wrapper running anything else hit the read-only sandbox. `XDG_CACHE_HOME`/`XDG_DATA_HOME`/`XDG_STATE_HOME`/`UV_CACHE_DIR`/`CARGO_HOME`/`npm_config_cache` are now redirected under `app_path` (already writable), covering uv's managed-Python store as well as pip/cargo/npm. Recommended convention: make `install.command` a stable entrypoint (`[bash, scripts/deploy-install.sh]`) so install content lives in a reviewed repo script and the allowlist effectively never changes.
+
+### Changed
+
+- **The running webhook now picks up a synced `fraises.yaml` without a restart** (#278). `get_config()` cheaply `stat()`s the resolved config path on each call and rebuilds the singleton only when the mtime moves, bounding config staleness to a single deploy instead of "forever, until `systemctl restart`". A failed reload (torn, removed, or invalid file) keeps the last-good config, stamps the offending mtime so it doesn't thrash, and logs a warning — a bad config sync can no longer take down the webhook. `SIGHUP` (wired in the webhook `lifespan`, guarded so it can never crash startup) forces an immediate reload, making `systemctl reload` a supported operation (`ExecReload=/bin/kill -HUP $MAINPID` added to the webhook unit template). Config sync (`deployers/base.py`) now writes atomically (copy to a pid-unique temp file in the destination directory, then rename) so a reader never observes a torn config.
+
 ## [0.45.0] - 2026-07-21
 
 Unifies confiture's exit-code / error-code classification onto a single, confiture-owned source of truth shared by contract with the Rust adapter (`fraisier-core`), and corrects the pre-#146 misreadings that had drifted into the Python side.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,57 @@ service_manager: rc
 
 When set to `rc`, scaffold generates rc.d service scripts instead of systemd units.
 
+### Config reload
+
+The running webhook auto-detects changes to `fraises.yaml`: each deploy syncs
+the committed config to the server and the next `get_config()` re-reads it when
+the file's mtime moves — no `systemctl restart` needed. Staleness is bounded to
+a single deploy (a brand-new `install.command` shipped in commit *N* takes
+effect on deploy *N+1*, since the config that drives deploy *N* is read before
+*N* is pulled).
+
+To force an immediate refresh without waiting for the next deploy:
+
+```bash
+systemctl reload fraisier-<project>-webhook   # sends SIGHUP → reloads config
+```
+
+The generated webhook unit wires this via `ExecReload=/bin/kill -HUP $MAINPID`.
+A config that fails to parse is ignored: the webhook keeps serving the last-good
+config and logs a warning, rather than failing every request.
+
+### Install command
+
+When `install.user` differs from the deploy user, the install step runs through
+a per-fraise **install-helper** unit whose allowlist is the *exact*
+`install.command`, baked into the unit at scaffold time (this is the
+deploy-user → install-user security boundary). A deploy re-bakes that allowlist
+automatically when the command changes, but you avoid re-bakes entirely — and
+keep install *content* in code review — by making the allowlisted command a
+**stable entrypoint** and putting the real steps in a repo-owned script:
+
+```yaml
+install:
+  command: [bash, scripts/deploy-install.sh]   # stable — the allowlisted command
+  user: appuser
+```
+
+```bash
+#!/usr/bin/env bash
+# scripts/deploy-install.sh — edit freely; the allowlisted command never changes
+set -euo pipefail
+uv sync --frozen
+# add build steps here (uv run …, npm ci, cargo build, …)
+```
+
+The install-helper runs under `ProtectSystem=strict`; the caches/state of the
+common toolchains (uv, pip, cargo, npm) are relocated under `app_path` via
+`XDG_CACHE_HOME`/`XDG_DATA_HOME`/`XDG_STATE_HOME`/`UV_CACHE_DIR`/`CARGO_HOME`/
+`npm_config_cache`. `HOME` stays the install user's, read-only under the
+sandbox — so a tool that writes elsewhere in `$HOME` (e.g. `rustup` →
+`~/.rustup`) needs its location exported to a path under `app_path` inside the
+script (e.g. `export RUSTUP_HOME="$PWD/.rustup"`).
+
 ---
 
 ## Commands

--- a/fraisier/config/loader.py
+++ b/fraisier/config/loader.py
@@ -63,6 +63,8 @@ from fraisier.config.schema import (
 )
 from fraisier.errors import ConfigurationError, ValidationError
 
+logger = logging.getLogger(__name__)
+
 _DEFAULT_TIMEOUT = 600  # 10 minutes
 _MEMORY_SIZE_RE = re.compile(r"^\d+[KMGT]$")
 _VALID_SERVICE_TYPES = {
@@ -683,17 +685,84 @@ class FraisierConfig:
 
 # Global config instance (lazy loaded, thread-safe)
 _config: FraisierConfig | None = None
+_config_mtime: float | None = None
 _config_lock = threading.Lock()
 
 
+def _safe_mtime(path: Path | str) -> float | None:
+    """Return ``path``'s mtime, or ``None`` when it can't be stat-ed.
+
+    Powers the cheap staleness check in :func:`get_config`; a file that is
+    briefly absent mid-atomic-replace must never crash config access.
+    """
+    try:
+        return Path(path).stat().st_mtime
+    except OSError:
+        return None
+
+
+def _load_and_stamp(config_path: Path | str | None) -> FraisierConfig:
+    """Build a config and record the mtime of the file it read, together.
+
+    Must be called with ``_config_lock`` held. Assigns ``_config`` and
+    ``_config_mtime`` as a pair so a concurrent staleness check never pairs
+    a fresh config with a stale mtime (or vice versa).
+    """
+    global _config, _config_mtime
+    cfg = FraisierConfig(config_path)
+    _config = cfg
+    _config_mtime = _safe_mtime(cfg.config_path)
+    return cfg
+
+
 def get_config(config_path: Path | str | None = None) -> FraisierConfig:
-    """Get or create global configuration instance."""
-    global _config
-    if _config is None or config_path:
+    """Get or create the global configuration instance.
+
+    A long-running process (e.g. the webhook) picks up an on-disk
+    ``fraises.yaml`` change without a restart: each call cheaply ``stat()``s
+    the resolved config path and rebuilds the singleton only when the mtime
+    moves (#278). An explicit ``config_path`` always (re)builds.
+
+    Resilience: a rebuild that fails — torn, removed, or invalid file —
+    keeps the last-good singleton, stamps the offending mtime so it does not
+    re-raise on every subsequent call, and logs a warning. A bad config sync
+    must not take down a running webhook.
+    """
+    global _config_mtime
+    if config_path:
         with _config_lock:
-            if _config is None or config_path:
-                _config = FraisierConfig(config_path)
-    return _config
+            return _load_and_stamp(config_path)
+
+    # Capture once: a concurrent reset_config() may null the global.
+    cfg = _config
+    if cfg is None:
+        with _config_lock:
+            if _config is None:
+                return _load_and_stamp(None)
+            return _config
+
+    current = _safe_mtime(cfg.config_path)
+    if current is None or current == _config_mtime:
+        return cfg
+
+    with _config_lock:
+        if _config is None:
+            return _load_and_stamp(None)
+        # Double-check under the lock: another thread may have reloaded
+        # already, or the file may have changed again.
+        if _safe_mtime(_config.config_path) == _config_mtime:
+            return _config
+        prev = _config
+        try:
+            return _load_and_stamp(_config.config_path)
+        except Exception:
+            _config_mtime = current
+            logger.warning(
+                "Reload of %s failed; keeping previous configuration",
+                prev.config_path,
+                exc_info=True,
+            )
+            return prev
 
 
 def reset_config() -> None:
@@ -701,6 +770,7 @@ def reset_config() -> None:
 
     Next call to ``get_config()`` will re-read from disk.
     """
-    global _config
+    global _config, _config_mtime
     with _config_lock:
         _config = None
+        _config_mtime = None

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -429,14 +429,34 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
 
                 # Step 1.5: Re-sync after checkout so a new fraises.yaml in this
                 # commit is always picked up before install/migrate (issue #158).
+                #
+                # Fatal by design (#279): this runs after checkout, so it is the
+                # step that re-bakes the install-helper allowlist when
+                # install.command changed. If it fails, the units on disk no
+                # longer match the deployed config and the install step would
+                # hit a stale allowlist ("command not allowed"). Abort here,
+                # naming the cause, instead of sailing into that masked failure.
                 try:
                     self._sync_config_if_needed()
                 except Exception as e:
-                    logger.error(
-                        f"Post-pull scaffold config sync/regeneration failed: {e}\n"
-                        "nginx config may be stale — run: "
-                        "fraisier scaffold && fraisier scaffold-install --yes"
-                    )
+                    raise DeploymentError(
+                        "Post-pull scaffold config sync/regeneration failed "
+                        "after checkout, so system units may not match the "
+                        "deployed fraises.yaml. The most common cause is a "
+                        "changed install.command whose install-helper allowlist "
+                        "could not be re-baked (#279). Deploy aborted before the "
+                        "install step to avoid a misleading 'command not "
+                        "allowed'.\n"
+                        "  Remediation: fix the underlying error below, then "
+                        "redeploy (or run `fraisier scaffold && fraisier "
+                        "scaffold-install --yes`).",
+                        context={"phase": "post_pull_config_sync"},
+                        cause=e,
+                        # Remediation is already inline above; suppress the
+                        # class-level trailing hint so it isn't duplicated with
+                        # the cause's own hint when e is a DeploymentError.
+                        recovery_hint="",
+                    ) from e
 
                 # Step 2: Install dependencies
                 self._install_dependencies()

--- a/fraisier/deployers/base.py
+++ b/fraisier/deployers/base.py
@@ -326,8 +326,15 @@ class BaseDeployer(ABC):
         # Ensure destination directory exists before copying
         self.runner.run(["mkdir", "-p", str(dest_path.parent)])
 
-        # Copy file
-        self.runner.run(["cp", str(source_path), str(dest_path)])
+        # Write atomically: copy to a temp file in the destination directory,
+        # then rename onto the live path. A reader (the mtime-based config
+        # auto-reload, #278) never sees a torn file. The temp name is
+        # pid-unique because several fraises can sync to the same shared
+        # /opt/fraisier/fraises.yaml concurrently (the deploy lock is
+        # per-fraise), and a fixed temp name would let their copies collide.
+        tmp_path = dest_path.with_name(f"{dest_path.name}.tmp.{os.getpid()}")
+        self.runner.run(["cp", str(source_path), str(tmp_path)])
+        self.runner.run(["mv", "-f", str(tmp_path), str(dest_path)])
 
         logger.info(
             "Config synced successfully",

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -33,6 +33,48 @@ logger = logging.getLogger("fraisier")
 DEFAULT_REPOS_BASE = Path("/var/lib/fraisier/repos")
 
 
+def _install_failure_advice(
+    stderr: str, *, app_path: str, via_socket: bool = False
+) -> str | None:
+    """Derive operator advice from an install command's captured ``stderr``.
+
+    Returns ``None`` when no known signature matches. The ``__pycache__``
+    signature is checked first (most specific); the generic
+    ``.cache``/``Permission denied`` signature is the HOME-cache hint that
+    points at the ``sudo -H`` fix for the sudo fallback (#276).
+
+    ``via_socket=True`` reshapes the ``.cache`` hint: the install-helper
+    socket already runs as the install user with a correct HOME by
+    construction, so a cache-write denial there is a genuinely unwritable
+    cache dir — never an unset HOME — and must not suggest ``sudo -H``.
+    """
+    if "__pycache__" in stderr and "Permission denied" in stderr:
+        return (
+            "Root-owned __pycache__ directories are blocking uv sync."
+            f" Fix: sudo find {app_path}/.venv -name __pycache__"
+            " -user root -type d -exec rm -rf {} +"
+            " then retry the deployment."
+            " The venv may be corrupted — run uv sync --frozen"
+            " manually after cleanup."
+            " See: https://github.com/fraiseql/fraisier/issues/196"
+        )
+    if ".cache" in stderr and "Permission denied" in stderr:
+        if via_socket:
+            return (
+                "A tool (uv/pip/cargo) could not write its cache directory."
+                " The install user's cache path (e.g. ~/.cache) is not"
+                " writable — check ownership and that the filesystem is not"
+                " full or mounted read-only."
+            )
+        return (
+            "The install user's HOME may be unset or unwritable, so a tool"
+            " (uv/pip/cargo) could not create its cache. Ensure the fallback"
+            " uses `sudo -H` or run via the install-helper socket."
+            " See: https://github.com/fraiseql/fraisier/issues/276"
+        )
+    return None
+
+
 class GitDeployMixin:
     """Mixin providing bare-repo git operations and status file writing.
 
@@ -162,30 +204,34 @@ class GitDeployMixin:
             resolved = shutil.which(cmd[0])
             if resolved:
                 cmd[0] = resolved
-            cmd = ["sudo", "-u", self.install_user, *cmd]
+            # -H sets HOME to the target user's home so HOME-writing tools
+            # (uv/pip/cargo/npm) can create their caches instead of failing on
+            # the invoker's /root/.cache. -H (not -i): no login shell, cwd stays
+            # app_path. See: https://github.com/fraiseql/fraisier/issues/276
+            cmd = ["sudo", "-H", "-u", self.install_user, *cmd]
         logger.info("Installing dependencies: %s", cmd)
         try:
             self.runner.run(cmd, cwd=self.app_path)
         except subprocess.CalledProcessError as exc:
             suggested = f"cd {self.app_path} && {shlex.join(cmd)}"
             stderr = exc.stderr or ""
-            advice = None
-            if "__pycache__" in stderr and "Permission denied" in stderr:
-                advice = (
-                    "Root-owned __pycache__ directories are blocking uv sync."
-                    f" Fix: sudo find {self.app_path}/.venv -name __pycache__"
-                    " -user root -type d -exec rm -rf {} +"
-                    " then retry the deployment."
-                    " The venv may be corrupted — run uv sync --frozen"
-                    " manually after cleanup."
-                    " See: https://github.com/fraiseql/fraisier/issues/196"
-                )
+            advice = _install_failure_advice(stderr, app_path=self.app_path)
             msg = (
                 f"Install command failed (exit code {exc.returncode}): "
                 f"{shlex.join(exc.cmd) if isinstance(exc.cmd, list) else exc.cmd}\n"
                 f"  Directory: {self.app_path}\n"
                 f"  To debug: {suggested}"
             )
+            # Surface the child's stderr tail so the real cause is visible in
+            # the deploy journal without re-running the command by hand (#277).
+            # Bounded to the last 2000 chars so a noisy build log can't flood
+            # the journal. Note: this folds stderr into the DeploymentError
+            # message, which is persisted as status.error_message and returned
+            # by the authenticated /api/status/<fraise>/details endpoint — a
+            # wider (token-gated, bounded) surface than the un-persisted
+            # context dict alone.
+            if stderr.strip():
+                msg += f"\n  stderr: {stderr.strip()[-2000:]}"
             if advice:
                 msg += f"\n  Advice: {advice}"
             raise DeploymentError(
@@ -246,7 +292,11 @@ class GitDeployMixin:
         if not response.get("ok"):
             error = response.get("error") or response.get("stderr") or "unknown error"
             suggested = f"cd {cwd} && {shlex.join(command)}"
-            advice = response.get("advice")
+            # Prefer advice the helper supplied; otherwise derive it from the
+            # returned stderr. Socket variant: no `sudo -H` hint (#277).
+            advice = response.get("advice") or _install_failure_advice(
+                response.get("stderr") or "", app_path=cwd, via_socket=True
+            )
             msg = (
                 "Install command failed"
                 f" (exit code {response.get('returncode', '?')}):"

--- a/fraisier/install_helper.py
+++ b/fraisier/install_helper.py
@@ -100,8 +100,28 @@ def _handle_connection(conn: socket.socket, allowed_command: list[str]) -> None:
             return
 
         if command != allowed_command:
-            logger.warning("Command not allowed: %s", command)
-            _send_error(conn, "command not allowed")
+            logger.warning(
+                "Command not allowed: got %s, allowed %s", command, allowed_command
+            )
+            # Name both commands + the likely cause so a stale allowlist is
+            # self-diagnosing in the deploy journal (#279) instead of a bare
+            # "command not allowed". Surfaced by the deployer via _install_via_socket.
+            _send_response(
+                conn,
+                {
+                    "ok": False,
+                    "error": (
+                        f"command not allowed: this install-helper permits "
+                        f"{allowed_command}, but received {command}"
+                    ),
+                    "advice": (
+                        "The configured install.command no longer matches this "
+                        "install-helper unit's baked allowlist. Redeploy (which "
+                        "re-bakes and restarts the unit) or run scaffold-install. "
+                        "See: https://github.com/fraiseql/fraisier/issues/279"
+                    ),
+                },
+            )
             return
 
         logger.info("Running install command: %s in %s", command, cwd)

--- a/fraisier/scaffold/templates/core/fraisier-webhook.service.j2
+++ b/fraisier/scaffold/templates/core/fraisier-webhook.service.j2
@@ -8,6 +8,10 @@ Type=exec
 User={{ scaffold.deploy_user }}
 Group={{ scaffold.deploy_user }}
 ExecStart=/home/{{ scaffold.deploy_user }}/.local/bin/fraisier-webhook
+# systemctl reload drops the cached fraises.yaml so a config change takes
+# effect without a full restart. The running server also auto-detects
+# fraises.yaml mtime changes on the next deploy; SIGHUP forces it immediately.
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartSec=5
 # WatchdogSec intentionally omitted: uvicorn does not implement sd_notify

--- a/fraisier/scaffold/templates/core/install-helper.service.j2
+++ b/fraisier/scaffold/templates/core/install-helper.service.j2
@@ -13,8 +13,19 @@ Group={{ install_user }}
 ExecStart=/home/{{ scaffold.deploy_user }}/.local/bin/fraisier-install-helper --deploy-user {{ scaffold.deploy_user }} {{ install_command | join(' ') }}
 
 Environment=PYTHONDONTWRITEBYTECODE=1
-# Pin the uv cache to a known path so ReadWritePaths can cover it exactly.
-Environment=UV_CACHE_DIR=/home/{{ install_user }}/.cache/uv
+# Relocate every write-heavy tool dir under app_path (already writable via
+# ReadWritePaths) so ANY install.command — not just `uv sync` — works under
+# ProtectSystem=strict (#280). Covers uv's wheel cache AND its managed-Python
+# store (XDG_DATA_HOME), plus pip/cargo/npm. HOME and XDG_CONFIG_HOME are left
+# at the install user's real home so credentials/config there (e.g. a private
+# index ~/.config/uv or ~/.netrc) remain readable; only writes are redirected.
+Environment=HOME=/home/{{ install_user }}
+Environment=XDG_CACHE_HOME={{ app_path }}/.cache
+Environment=XDG_DATA_HOME={{ app_path }}/.local/share
+Environment=XDG_STATE_HOME={{ app_path }}/.local/state
+Environment=UV_CACHE_DIR={{ app_path }}/.cache/uv
+Environment=CARGO_HOME={{ app_path }}/.cargo
+Environment=npm_config_cache={{ app_path }}/.npm
 
 NoNewPrivileges=true
 ProtectSystem=strict
@@ -25,8 +36,9 @@ ProtectKernelModules=true
 ProtectControlGroups=true
 # AF_INET/AF_INET6 are required for uv to reach PyPI when the cache is cold.
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-# Project directory + uv wheel cache (uv sync writes to both)
-ReadWritePaths={{ app_path }} /home/{{ install_user }}/.cache/uv
+# App directory holds the venv + all relocated tool caches/state (Environment=
+# above), so a single writable root covers the whole install step.
+ReadWritePaths={{ app_path }}
 
 [Install]
 WantedBy=multi-user.target

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -108,6 +108,26 @@ _run() {
   fi
 }
 
+# Like _run, but failures are FATAL — no `|| true`, no stderr suppression — so
+# a broken step surfaces a non-zero exit (with `set -e`) instead of being
+# silently swallowed. Use for steps whose failure a caller must be able to
+# detect, e.g. the install-helper allowlist re-bake (#279): if the helper
+# can't be restarted, the deploy must fail loudly here rather than later at the
+# install step with a misleading "command not allowed".
+_run_strict() {
+  if [[ "$VALIDATE_ONLY" == "true" ]]; then
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "  [validate] $*"
+    fi
+    return 0
+  elif [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [would run] $*"
+    return 0
+  else
+    "$@"
+  fi
+}
+
 # Helper function to check if file/directory exists
 _check_exists() {
   local path="$1"
@@ -447,12 +467,26 @@ if _env_active "{{ ish.env_name }}"; then
     if [ -f "${SCAFFOLD_DIR}/systemd/{{ ish.socket_unit }}" ] && \
        [ -f "${SCAFFOLD_DIR}/systemd/{{ ish.service_unit }}" ]; then
         echo "  Installing install helper for {{ ish.fraise_name }}-{{ ish.env_name }}"
-        _run sudo cp "${SCAFFOLD_DIR}/systemd/{{ ish.socket_unit }}" \
+        # Copying the NEW unit files is the load-bearing step of the re-bake, so
+        # it is _run_strict too (#279): if the new .service can't be written,
+        # the stop/restart below would re-exec the STALE unit and the deploy
+        # would hit a masked "command not allowed" behind a green re-bake.
+        _run_strict sudo cp "${SCAFFOLD_DIR}/systemd/{{ ish.socket_unit }}" \
            /etc/systemd/system/{{ ish.socket_unit }}
-        _run sudo cp "${SCAFFOLD_DIR}/systemd/{{ ish.service_unit }}" \
+        _run_strict sudo cp "${SCAFFOLD_DIR}/systemd/{{ ish.service_unit }}" \
            /etc/systemd/system/{{ ish.service_unit }}
-        _run sudo systemctl daemon-reload
-        _run sudo systemctl enable --now {{ ish.socket_unit }}
+        # Re-bake the allowlist (#279). The running .service still carries the
+        # OLD allowed_command in its argv, and `enable --now` is a no-op on an
+        # already-running unit — so the stale allowlist would persist. Instead:
+        # daemon-reload the new unit, STOP the stale-argv .service, then enable
+        # + restart the .socket so the next install connection re-execs the
+        # .service with the new argv. _run_strict (not _run): a failed re-bake
+        # must surface as a non-zero exit so the deploy aborts loudly (#279)
+        # rather than proceeding to a masked "command not allowed".
+        _run_strict sudo systemctl daemon-reload
+        _run_strict sudo systemctl stop {{ ish.service_unit }}
+        _run_strict sudo systemctl enable {{ ish.socket_unit }}
+        _run_strict sudo systemctl restart {{ ish.socket_unit }}
     fi
 fi
 {% endfor %}

--- a/fraisier/webhook.py
+++ b/fraisier/webhook.py
@@ -3,6 +3,7 @@
 Supports any Git provider: GitHub, GitLab, Gitea, Bitbucket, or custom.
 """
 
+import asyncio
 import hmac
 import json
 import logging
@@ -16,7 +17,7 @@ from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from ._env import get_int_env
-from .config import get_config
+from .config import get_config, reset_config
 from .config._lazy_env import LazyEnv, to_str
 
 if TYPE_CHECKING:
@@ -67,12 +68,60 @@ def _clear_stale_drain_flag() -> None:
         logger.debug("Could not clear stale draining flag", exc_info=True)
 
 
+def _install_sighup_reload() -> asyncio.AbstractEventLoop | None:
+    """Register a SIGHUP handler that forces a config reload, if possible.
+
+    Makes ``systemctl reload`` (``ExecReload=/bin/kill -HUP $MAINPID``) drop
+    the cached config so the next ``get_config()`` re-reads ``fraises.yaml``
+    immediately (#278). Returns the loop the handler was bound to, so the
+    caller can unregister it on shutdown, or ``None`` when registration is
+    unavailable: no SIGHUP on this platform, or the loop is not on the main
+    thread (Starlette's TestClient, some multi-worker setups). Registration
+    must never crash startup — every failure degrades to "no handler", and
+    SIGHUP then falls back to its default (terminate) disposition.
+    """
+    import signal
+
+    if not hasattr(signal, "SIGHUP"):
+        return None
+    try:
+        loop = asyncio.get_running_loop()
+
+        def _reload() -> None:
+            logger.info("SIGHUP received — reloading configuration")
+            reset_config()
+
+        loop.add_signal_handler(signal.SIGHUP, _reload)
+    except (NotImplementedError, RuntimeError, ValueError):
+        logger.debug(
+            "SIGHUP config reload unavailable in this runtime; skipping",
+            exc_info=True,
+        )
+        return None
+    logger.info("SIGHUP config reload enabled (systemctl reload re-reads config)")
+    return loop
+
+
+def _remove_sighup_reload(loop: asyncio.AbstractEventLoop | None) -> None:
+    """Best-effort removal of the SIGHUP handler installed at startup."""
+    import signal
+
+    if loop is None or not hasattr(signal, "SIGHUP"):
+        return
+    try:
+        loop.remove_signal_handler(signal.SIGHUP)
+    except (NotImplementedError, RuntimeError, ValueError):
+        logger.debug("Could not remove SIGHUP handler", exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Manage webhook server lifecycle."""
     logger.info("Fraisier webhook server starting")
     _clear_stale_drain_flag()
+    sighup_loop = _install_sighup_reload()
     yield
+    _remove_sighup_reload(sighup_loop)
     logger.info("Fraisier webhook server shutting down")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.45.0"
+version = "0.46.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1,0 +1,93 @@
+"""Tests for mtime-based config auto-reload in ``get_config`` (#278)."""
+
+from __future__ import annotations
+
+import os
+
+from fraisier.config import loader
+
+
+def _write(path, name: str, mtime: float) -> None:
+    """Write a minimal valid fraises.yaml carrying *name*, with a fixed mtime.
+
+    mtime is set explicitly (not via wall clock) so the staleness check is
+    deterministic regardless of filesystem timestamp resolution.
+    """
+    path.write_text(f"name: {name}\n")
+    os.utime(path, (mtime, mtime))
+
+
+def test_get_config_reloads_when_mtime_advances(tmp_path):
+    """A newer on-disk mtime makes the next no-arg get_config() re-read."""
+    loader.reset_config()
+    p = tmp_path / "fraises.yaml"
+    _write(p, "alpha", 1000)
+
+    assert loader.get_config(p).project_name == "alpha"
+
+    _write(p, "beta", 2000)
+    # No explicit path, no reset_config(): the mtime bump alone forces reload.
+    assert loader.get_config().project_name == "beta"
+
+
+def test_get_config_stable_when_unchanged(tmp_path):
+    """Two calls with no file change return the same object (no needless reload)."""
+    loader.reset_config()
+    p = tmp_path / "fraises.yaml"
+    _write(p, "alpha", 1000)
+
+    first = loader.get_config(p)
+    second = loader.get_config()
+    assert first is second
+
+
+def test_get_config_survives_stat_error(tmp_path):
+    """A missing tracked file (mid-atomic-replace) never crashes get_config()."""
+    loader.reset_config()
+    p = tmp_path / "fraises.yaml"
+    _write(p, "alpha", 1000)
+    cfg = loader.get_config(p)
+
+    p.unlink()
+    again = loader.get_config()
+    assert again is cfg
+    assert again.project_name == "alpha"
+
+
+def test_get_config_keeps_previous_on_invalid_reload(tmp_path):
+    """An invalid new config keeps the last-good singleton — no raise, no thrash.
+
+    A bad ``fraises.yaml`` sync must not take down a running webhook: every
+    get_config() consumer would otherwise start raising where the cached
+    config used to serve.
+    """
+    loader.reset_config()
+    p = tmp_path / "fraises.yaml"
+    _write(p, "alpha", 1000)
+    cfg = loader.get_config(p)
+    assert cfg.project_name == "alpha"
+
+    # Syntactically broken YAML, newer mtime → reload attempt raises internally.
+    p.write_text("name: [unterminated\n")
+    os.utime(p, (2000, 2000))
+
+    again = loader.get_config()
+    assert again is cfg
+    assert again.project_name == "alpha"
+
+    # The offending mtime is stamped, so a second call returns immediately
+    # instead of rebuilding+raising on every access.
+    assert loader.get_config() is cfg
+
+
+def test_reset_config_clears_mtime(tmp_path):
+    """reset_config() drops both the singleton and its stamped mtime."""
+    loader.reset_config()
+    p = tmp_path / "fraises.yaml"
+    _write(p, "alpha", 1000)
+    loader.get_config(p)
+    assert loader._config_mtime is not None
+
+    loader.reset_config()
+    assert loader._config is None
+    assert loader._config_mtime is None

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -123,8 +123,15 @@ class TestAPIDeployer:
         assert result.status == DeploymentStatus.FAILED
         assert result.error_message is not None
 
-    def test_execute_logs_error_on_scaffold_install_failure(self, tmp_path):
-        """Test execute logs ERROR (not WARNING) when scaffold install fails."""
+    def test_post_pull_config_sync_failure_aborts_before_install(self, tmp_path):
+        """A failed post-pull scaffold re-bake is FATAL and aborts before the
+        install step (#279).
+
+        Previously non-fatal: the deploy logged an error and continued into a
+        masked ``command not allowed`` at the install step. Now the post-pull
+        sync (which re-bakes the install-helper allowlist) hard-gates the
+        deploy — it fails there, naming the likely stale allowlist.
+        """
         config = {
             "app_path": str(tmp_path),
             "systemd_service": "api.service",
@@ -133,14 +140,13 @@ class TestAPIDeployer:
 
         deployer = APIDeployer(config)
 
-        # Set up a counter to track calls to _sync_config_if_needed
+        # Track calls to _sync_config_if_needed; fail only the 2nd (post-pull).
         call_count = {"count": 0}
 
         def sync_config_side_effect():
             call_count["count"] += 1
-            # Fail on the second call (post-pull)
             if call_count["count"] == 2:
-                raise DeploymentError("Post-pull scaffold install failed")
+                raise DeploymentError("boom: command not allowed")
 
         with (
             patch.object(deployer, "_validate_wrapper_scripts"),
@@ -151,27 +157,72 @@ class TestAPIDeployer:
                 "_sync_config_if_needed",
                 side_effect=sync_config_side_effect,
             ),
+            patch.object(deployer, "_install_dependencies") as mock_install,
             patch.object(deployer, "_write_status"),
             patch.object(deployer, "_start_db_record", return_value=None),
             patch.object(deployer, "_complete_db_record"),
             patch.object(deployer, "_notify"),
             patch.object(deployer, "_wrap_error"),
             patch.object(deployer, "_restore_previous_state"),
+            patch.object(deployer, "_restore_version_json"),
         ):
-            # Capture log records
-            import logging
+            result = deployer.execute()
 
-            with patch.object(logging.getLogger("fraisier"), "error") as mock_error:
-                result = deployer.execute()
+        # Fatal: deploy failed, and aborted BEFORE the install step, so the
+        # stale-allowlist "command not allowed" is never reached.
+        assert result.success is False
+        mock_install.assert_not_called()
+        # The surfaced error names the likely cause + the issue.
+        assert result.error_message is not None
+        assert "279" in result.error_message
+        lowered = result.error_message.lower()
+        assert "install.command" in lowered or "allowlist" in lowered
 
-            # Should still complete deployment (error is non-fatal)
-            assert result.success is False
+    def test_pre_pull_config_sync_failure_is_nonfatal(self, tmp_path):
+        """A pre-pull sync failure stays non-fatal (#279).
 
-            # Should log error, not warning
-            mock_error.assert_called()
-            # Check that the error message includes the expected text
-            calls = [str(call) for call in mock_error.call_args_list]
-            assert any("scaffold" in str(call).lower() for call in calls)
+        The pre-pull sync runs from the old, pre-checkout worktree, whose
+        install.command still matches the baked allowlist — not the trap. Only
+        the post-pull re-sync hard-gates. Reaching git pull proves the pre-pull
+        failure did not abort the deploy.
+        """
+        config = {
+            "app_path": str(tmp_path),
+            "systemd_service": "api.service",
+            "health_check": {"url": "http://localhost:8000/health"},
+        }
+        deployer = APIDeployer(config)
+
+        call_count = {"count": 0}
+
+        def sync_config_side_effect():
+            call_count["count"] += 1
+            if call_count["count"] == 1:
+                raise DeploymentError("pre-pull boom")
+
+        with (
+            patch.object(deployer, "_validate_wrapper_scripts"),
+            patch.object(deployer, "_check_service_file_staleness"),
+            # Stop the deploy right after git pull so the full pipeline isn't
+            # exercised; reaching git pull is what proves pre-pull was non-fatal.
+            patch.object(
+                deployer, "_git_pull", side_effect=RuntimeError("stop")
+            ) as mock_pull,
+            patch.object(
+                deployer, "_sync_config_if_needed", side_effect=sync_config_side_effect
+            ),
+            patch.object(deployer, "_write_status"),
+            patch.object(deployer, "_start_db_record", return_value=None),
+            patch.object(deployer, "_complete_db_record"),
+            patch.object(deployer, "_notify"),
+            patch.object(deployer, "_wrap_error"),
+            patch.object(deployer, "_restore_previous_state"),
+            patch.object(deployer, "_restore_version_json"),
+        ):
+            result = deployer.execute()
+
+        assert result.success is False
+        mock_pull.assert_called_once()
 
     def test_fetch_and_checkout_called_during_execute(
         self,
@@ -593,7 +644,7 @@ class TestAPIDeployer:
 
         # Verify sudo was used
         args, kwargs = mock_subprocess.call_args
-        assert args[0][:3] == ["sudo", "-u", "appuser"]
+        assert args[0][:4] == ["sudo", "-H", "-u", "appuser"]
         assert kwargs["cwd"] == "/var/www/api"
 
     def test_sync_config_uses_fraisier_config_env_var(self, tmp_path, monkeypatch):
@@ -696,7 +747,7 @@ class TestAPIDeployer:
         # Should call install command with sudo -u appuser
         assert mock_subprocess.call_count == 1
         install_call = mock_subprocess.call_args_list[0][0][0]
-        assert install_call[:3] == ["sudo", "-u", "appuser"]
+        assert install_call[:4] == ["sudo", "-H", "-u", "appuser"]
 
     def test_install_dependencies_skips_chown_when_no_venv(
         self, tmp_path, mock_subprocess
@@ -717,7 +768,7 @@ class TestAPIDeployer:
 
         assert mock_subprocess.call_count == 1
         install_call = mock_subprocess.call_args_list[0][0][0]
-        assert install_call[:3] == ["sudo", "-u", "appuser"]
+        assert install_call[:4] == ["sudo", "-H", "-u", "appuser"]
 
     def test_sync_config_saves_hash_after_successful_install(
         self, tmp_path, monkeypatch

--- a/tests/test_deployers_base_unit.py
+++ b/tests/test_deployers_base_unit.py
@@ -80,10 +80,48 @@ class TestSyncFraisesYaml:
         deployer.runner = mock_runner
 
         deployer._sync_fraises_yaml(source_path=source, dest_path=dest)
-        assert mock_runner.run.call_count == 2
+        # Atomic write: mkdir, copy to a temp file, then rename onto dest (#278).
+        assert mock_runner.run.call_count == 3
         calls = mock_runner.run.call_args_list
         assert calls[0][0][0] == ["mkdir", "-p", str(tmp_path)]
-        assert calls[1][0][0] == ["cp", str(source), str(dest)]
+
+        cp_cmd = calls[1][0][0]
+        mv_cmd = calls[2][0][0]
+        assert cp_cmd[0] == "cp"
+        assert cp_cmd[1] == str(source)
+        tmp_target = cp_cmd[2]
+        # Temp file lives in dest's directory (same filesystem → atomic rename)
+        # and is not the live path itself.
+        assert tmp_target.startswith(str(dest) + ".tmp.")
+        assert mv_cmd == ["mv", "-f", tmp_target, str(dest)]
+
+    def test_sync_fraises_yaml_is_atomic(self, tmp_path):
+        """The live dest is written via rename, never a bare cp onto it (#278).
+
+        A concurrent reader (the mtime config auto-reload) must never observe a
+        half-written config, so the runner must see a ``mv`` onto ``dest`` and
+        the preceding ``cp`` must target a temp path, not ``dest`` directly.
+        """
+        source = tmp_path / "fraises.yaml"
+        source.write_text("fraises: []")
+        dest = tmp_path / "opt" / "fraises.yaml"
+
+        deployer = APIDeployer({})
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = MagicMock(ok=True)
+        deployer.runner = mock_runner
+
+        deployer._sync_fraises_yaml(source_path=source, dest_path=dest)
+
+        commands = [c[0][0] for c in mock_runner.run.call_args_list]
+        # No command copies directly onto the live destination path.
+        assert ["cp", str(source), str(dest)] not in commands
+        # Exactly one rename lands on dest, from a temp file in dest.parent.
+        mv_cmds = [c for c in commands if c[:2] == ["mv", "-f"]]
+        assert len(mv_cmds) == 1
+        mv = mv_cmds[0]
+        assert mv[3] == str(dest)
+        assert mv[2].startswith(str(dest) + ".tmp.")
 
     def test_creates_dest_directory_if_missing(self, tmp_path):
         source = tmp_path / "fraises.yaml"

--- a/tests/test_install_dependencies.py
+++ b/tests/test_install_dependencies.py
@@ -96,9 +96,35 @@ class TestInstallDependenciesExecution:
             deployer._install_dependencies()
 
         mock_runner.run.assert_called_once_with(
-            ["sudo", "-u", "myapp", "/usr/local/bin/uv", "sync", "--frozen"],
+            ["sudo", "-H", "-u", "myapp", "/usr/local/bin/uv", "sync", "--frozen"],
             cwd="/var/www/api",
         )
+
+    def test_sudo_fallback_sets_home_with_dash_h(self):
+        """The sudo fallback passes -H so HOME points at the install user (#276).
+
+        Without -H, sudo keeps the invoker's HOME (/root when the deploy runs
+        as root) and HOME-writing tools (uv/pip/cargo) fail writing their
+        caches under /root/.cache.
+        """
+        config = {
+            "app_path": "/var/www/api",
+            "install": {
+                "command": ["uv", "sync", "--frozen"],
+                "user": "myapp",
+            },
+        }
+        deployer = APIDeployer(config)
+        mock_runner = MagicMock()
+        deployer.runner = mock_runner
+
+        with patch(
+            "fraisier.deployers.mixins.shutil.which", return_value="/usr/local/bin/uv"
+        ):
+            deployer._install_dependencies()
+
+        called_cmd = mock_runner.run.call_args[0][0]
+        assert called_cmd[:4] == ["sudo", "-H", "-u", "myapp"]
 
     def test_no_sudo_when_install_user_equals_deploy_user(self):
         """When install.user equals deploy_user, command runs without sudo."""
@@ -143,7 +169,7 @@ class TestInstallDependenciesExecution:
 
         # Should use sudo since install_user != deploy_user
         mock_runner.run.assert_called_once_with(
-            ["sudo", "-u", "myapp", "/usr/local/bin/uv", "sync", "--frozen"],
+            ["sudo", "-H", "-u", "myapp", "/usr/local/bin/uv", "sync", "--frozen"],
             cwd="/var/www/api",
         )
 
@@ -165,7 +191,7 @@ class TestInstallDependenciesExecution:
             deployer._install_dependencies()
 
         mock_runner.run.assert_called_once_with(
-            ["sudo", "-u", "myapp", "uv", "sync", "--frozen"],
+            ["sudo", "-H", "-u", "myapp", "uv", "sync", "--frozen"],
             cwd="/var/www/api",
         )
 
@@ -256,6 +282,7 @@ class TestInstallViaSocket:
         mock_runner.run.assert_called_once_with(
             [
                 "sudo",
+                "-H",
                 "-u",
                 "appuser",
                 "/home/fraisier/.local/bin/uv",
@@ -293,6 +320,7 @@ class TestInstallViaSocket:
         mock_runner.run.assert_called_once_with(
             [
                 "sudo",
+                "-H",
                 "-u",
                 "appuser",
                 "/home/fraisier/.local/bin/uv",

--- a/tests/test_install_helper.py
+++ b/tests/test_install_helper.py
@@ -139,6 +139,22 @@ class TestInputValidation:
         assert result["ok"] is False
         assert "command not allowed" in result["error"]
 
+    def test_rejection_names_expected_and_received(self):
+        """The rejection names both commands and points at the stale allowlist (#279)."""
+        result = _call(
+            {"command": ["bash", "-c", "echo hi"], "cwd": "/var/www/app"},
+            allowed_command=_DEFAULT_ALLOWED,
+        )
+        assert result["ok"] is False
+        # Both the received and the allowed command appear in the error.
+        assert "bash" in result["error"]
+        for token in _DEFAULT_ALLOWED:
+            assert token in result["error"]
+        # Advice points at the re-bake path + issue.
+        assert "advice" in result
+        assert "install.command" in result["advice"]
+        assert "279" in result["advice"]
+
     def test_accepts_exact_allowed_command(self):
         """Exact match of allowed command passes the allowlist check."""
         mock_result = MagicMock()

--- a/tests/test_pycache_diagnostics.py
+++ b/tests/test_pycache_diagnostics.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fraisier.deployers.api import APIDeployer
+from fraisier.deployers.mixins import _install_failure_advice
 from fraisier.errors import DeploymentError
 from fraisier.install_helper import _handle_connection
 
@@ -152,6 +153,80 @@ class TestSudoFallbackAdvice:
         ):
             deployer._install_dependencies()
 
+    def test_install_failure_message_includes_stderr(self):
+        """Captured stderr is surfaced in the error message itself (#277).
+
+        Before the fix the stderr lived only in ``context["stderr"]`` and was
+        never rendered, so the deploy journal hid the real cause.
+        """
+        config = {
+            "app_path": "/var/www/api",
+            "deploy_user": "fraisier",
+            "fraise_name": "api",
+            "environment": "production",
+            "install": {"command": ["uv", "sync", "--frozen"], "user": "appuser"},
+        }
+        deployer = APIDeployer(config)
+        mock_runner = MagicMock()
+        exc = subprocess.CalledProcessError(1, ["sudo", "-H", "-u", "appuser", "uv"])
+        exc.stdout = ""
+        exc.stderr = "boom: something is denied"
+        mock_runner.run.side_effect = exc
+        deployer.runner = mock_runner
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "fraisier.deployers.mixins.shutil.which",
+                return_value="/usr/local/bin/uv",
+            ),
+            pytest.raises(DeploymentError) as exc_info,
+        ):
+            deployer._install_dependencies()
+
+        # In the message (args[0]), not only in context["stderr"].
+        assert "boom: something is denied" in exc_info.value.args[0]
+        assert exc_info.value.context["stderr"] == "boom: something is denied"
+
+    def test_cache_permission_denied_advice(self):
+        """.cache + Permission denied points at the HOME/#276 fix (#277)."""
+        config = {
+            "app_path": "/var/www/api",
+            "deploy_user": "fraisier",
+            "fraise_name": "api",
+            "environment": "production",
+            "install": {"command": ["uv", "sync", "--frozen"], "user": "appuser"},
+        }
+        deployer = APIDeployer(config)
+        mock_runner = MagicMock()
+        exc = subprocess.CalledProcessError(1, ["sudo", "-H", "-u", "appuser", "uv"])
+        exc.stdout = ""
+        exc.stderr = "Failed to initialize cache at /root/.cache/uv: Permission denied"
+        mock_runner.run.side_effect = exc
+        deployer.runner = mock_runner
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "fraisier.deployers.mixins.shutil.which",
+                return_value="/usr/local/bin/uv",
+            ),
+            pytest.raises(DeploymentError) as exc_info,
+        ):
+            deployer._install_dependencies()
+
+        msg = str(exc_info.value)
+        assert "Advice:" in msg
+        assert "HOME" in msg
+        assert "276" in msg
+
+    def test_cache_advice_not_triggered_by_pycache(self):
+        """__pycache__ stays the more specific match; .cache does not shadow it."""
+        advice = _install_failure_advice(_PYCACHE_STDERR, app_path="/var/www/api")
+        assert advice is not None
+        assert "__pycache__" in advice
+        assert "276" not in advice
+
 
 # ---------------------------------------------------------------------------
 # Phase 4: Integration test — socket returns advice, deployer surfaces it
@@ -226,3 +301,68 @@ class TestIntegrationPycacheAdvice:
         assert _PYCACHE_STDERR in str(error)
         assert "Advice:" in str(error)
         assert "venv may be corrupted" in str(error)
+
+    def test_socket_failure_cache_advice(self, tmp_path):
+        """Socket path derives a cache-write advice — without the sudo -H hint.
+
+        The socket helper already runs as the install user with a correct
+        HOME, so a .cache denial there must not send the operator to
+        ``sudo -H`` (the fallback-path fix, #276), which does not apply.
+        """
+        sock_path = str(tmp_path / "install.sock")
+        server_sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        server_sock.bind(sock_path)
+        server_sock.listen(1)
+
+        cache_stderr = (
+            "error: Failed to initialize cache at /home/appuser/.cache/uv: "
+            "Permission denied (os error 13)"
+        )
+        response_payload = (
+            json.dumps(
+                {
+                    "ok": False,
+                    "stdout": "",
+                    "stderr": cache_stderr,
+                    "returncode": 1,
+                }
+            ).encode()
+            + b"\n"
+        )
+
+        def _serve():
+            conn, _ = server_sock.accept()
+            with conn:
+                conn.recv(4096)
+                conn.sendall(response_payload)
+            server_sock.close()
+
+        t = threading.Thread(target=_serve, daemon=True)
+        t.start()
+
+        config = {
+            "app_path": "/var/www/api",
+            "deploy_user": "fraisier",
+            "fraise_name": "api",
+            "environment": "production",
+            "install": {"command": ["uv", "sync", "--frozen"], "user": "appuser"},
+        }
+        deployer = APIDeployer(config)
+        deployer.runner = MagicMock()
+
+        with (
+            patch.dict(
+                "os.environ", {"FRAISIER_INSTALL_SOCKET_API_PRODUCTION": sock_path}
+            ),
+            pytest.raises(DeploymentError) as exc_info,
+        ):
+            deployer._install_dependencies()
+
+        t.join(timeout=2)
+
+        msg = str(exc_info.value)
+        assert "Advice:" in msg
+        assert "cache" in msg
+        # Socket path never shells out to sudo, so it must not suggest sudo -H.
+        assert "sudo -H" not in msg
+        assert "276" not in msg

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -2566,6 +2566,56 @@ fraises:
         )
         assert "--deploy-user deployer" in execstart
 
+    def test_install_helper_relocates_caches_under_app_path(self, tmp_path):
+        """The install-helper relocates write-heavy tool dirs under app_path so
+        any toolchain works under ProtectSystem=strict (#280).
+
+        No dependency on a writable /home/<user>/.cache: a single writable root
+        (app_path) covers the venv plus every relocated cache/state dir.
+        """
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        p = tmp_path / "fraises.yaml"
+        p.write_text(
+            f"""
+name: myproj
+scaffold:
+  deploy_user: deployer
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/prod
+        install:
+          user: install_bot
+          command: ["bash", "scripts/deploy-install.sh"]
+"""
+        )
+        config = FraisierConfig(p)
+        ScaffoldRenderer(config).render()
+
+        svc = next(
+            p
+            for p in (tmp_path / "output" / "systemd").iterdir()
+            if p.name.endswith("-install-helper.service")
+            and "scaffold-install-helper" not in p.name
+        )
+        content = svc.read_text()
+
+        # Caches/state/data all under app_path.
+        assert "Environment=XDG_CACHE_HOME=/var/www/prod/.cache" in content
+        assert "Environment=XDG_DATA_HOME=/var/www/prod/.local/share" in content
+        assert "Environment=XDG_STATE_HOME=/var/www/prod/.local/state" in content
+        assert "Environment=UV_CACHE_DIR=/var/www/prod/.cache/uv" in content
+        assert "Environment=CARGO_HOME=/var/www/prod/.cargo" in content
+        # No dependency on a writable home cache in the sandbox allowlist.
+        assert "/home/install_bot/.cache" not in content
+        assert "ReadWritePaths=/var/www/prod" in content
+        # Still strictly sandboxed.
+        assert "ProtectSystem=strict" in content
+
     def test_collect_allowed_services_skips_jobs_on_non_scheduled_types(self):
         """Only type:scheduled fraises contribute jobs.* unit names to the
         allowlist. type:backup fraises (which also use jobs.*) must NOT —
@@ -3072,6 +3122,56 @@ fraises:
         content = (tmp_path / "output" / "install.sh").read_text()
         assert "myapp" in content
         assert "Creating app user myapp" in content
+
+    def test_install_sh_rebakes_install_helper_allowlist(self, tmp_path):
+        """install.sh re-bakes a changed install.command's allowlist (#279).
+
+        The running install-helper .service carries the old allowed_command in
+        its argv, and `enable --now` is a no-op on a running unit — so install.sh
+        must STOP the service and RESTART the socket, via _run_strict so a failed
+        re-bake surfaces (and the deploy's post-pull gate aborts) instead of
+        being swallowed by `_run … || true`.
+        """
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        p = tmp_path / "fraises.yaml"
+        p.write_text(
+            f"""
+name: tp
+scaffold:
+  deploy_user: deployer
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+        install:
+          command: [uv, sync, --frozen]
+          user: myapp
+"""
+        )
+        config = FraisierConfig(p)
+        ScaffoldRenderer(config).render()
+
+        content = (tmp_path / "output" / "install.sh").read_text()
+        sock = "fraisier-tp-my_api-production-install-helper.socket"
+        svc = "fraisier-tp-my_api-production-install-helper.service"
+
+        # A fatal (non-swallowing) runner exists and gates the re-bake.
+        assert "_run_strict()" in content
+        # Copying the NEW unit files is fatal too — the load-bearing step: a
+        # swallowed cp would re-exec the stale unit behind a green re-bake.
+        assert "_run_strict sudo cp" in content
+        assert f"/etc/systemd/system/{svc}" in content
+        # ...and specifically the service copy is not swallowed by _run.
+        assert f'_run sudo cp "${{SCAFFOLD_DIR}}/systemd/{svc}"' not in content
+        # The stale-argv service is stopped and the socket restarted (fatal).
+        assert f"_run_strict sudo systemctl stop {svc}" in content
+        assert f"_run_strict sudo systemctl restart {sock}" in content
+        # The old no-op form for the install-helper socket is gone.
+        assert f"enable --now {sock}" not in content
 
     def test_install_sh_service_names_include_project_prefix(self, tmp_path):
         """install.sh copies service files with project-prefixed names."""

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1087,6 +1087,85 @@ class TestDrainingFlagDispatch:
                 assert not flag.exists()
 
 
+class TestSighupConfigReload:
+    """``lifespan`` wires SIGHUP to a config reload, safely (#278)."""
+
+    def test_registered_handler_resets_config(self):
+        """The SIGHUP handler installed on the loop calls reset_config()."""
+        import asyncio
+        import signal
+
+        from fraisier import webhook
+
+        if not hasattr(signal, "SIGHUP"):
+            pytest.skip("SIGHUP not available on this platform")
+
+        captured: dict[str, object] = {}
+
+        async def _run() -> None:
+            loop = asyncio.get_running_loop()
+            real_add = loop.add_signal_handler
+
+            def _spy(sig, cb, *a):
+                captured["sig"] = sig
+                captured["cb"] = cb
+                return real_add(sig, cb, *a)
+
+            with patch.object(loop, "add_signal_handler", side_effect=_spy):
+                result_loop = webhook._install_sighup_reload()
+
+            assert result_loop is loop
+            assert captured["sig"] == signal.SIGHUP
+
+            # Invoke the registered callback directly (deterministic — no
+            # dependence on real signal-delivery timing) and prove it reloads.
+            with patch("fraisier.webhook.reset_config") as mock_reset:
+                captured["cb"]()  # type: ignore[operator]
+                assert mock_reset.called
+
+            webhook._remove_sighup_reload(loop)
+
+        asyncio.run(_run())
+
+    def test_registration_failure_is_swallowed(self):
+        """A loop that can't take signal handlers degrades to no handler (B1).
+
+        Starlette's TestClient runs the loop off the main thread, where
+        add_signal_handler raises — startup must not crash.
+        """
+        import asyncio
+        import signal
+
+        from fraisier import webhook
+
+        if not hasattr(signal, "SIGHUP"):
+            pytest.skip("SIGHUP not available on this platform")
+
+        async def _run() -> None:
+            loop = asyncio.get_running_loop()
+            with patch.object(
+                loop,
+                "add_signal_handler",
+                side_effect=RuntimeError("loop not on main thread"),
+            ):
+                assert webhook._install_sighup_reload() is None
+
+        asyncio.run(_run())
+
+    def test_lifespan_enters_under_testclient(self, tmp_path):
+        """Entering the real lifespan under TestClient must not raise (B1)."""
+        from fraisier.webhook import app as webhook_app
+
+        with patch("fraisier.webhook.get_config") as mock_config:
+            mock_config_obj = MagicMock()
+            mock_config_obj.deployment.lock_dir = str(tmp_path)
+            mock_config.return_value = mock_config_obj
+
+            # No exception on enter/exit of the lifespan context.
+            with TestClient(webhook_app):
+                pass
+
+
 class TestUnavailableHelper:
     """``_unavailable`` builds a 503 JSONResponse with the right header."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Install-path hardening — five defects on one dependency-install path, all
surfaced by a single incident: a `printoptim` `install.command` change (a
`bash -c` wrapper running `uv sync … && uv run …`) that failed to deploy, gave
no useful error, then "succeeded but did nothing" once patched — and, when the
socket path was investigated, turned out to be blocked by a stale allowlist
under a strict sandbox.

Version bump to **0.46.0** rolled in (per release convention).

## What's fixed

- **#276 — `sudo -u` fallback sets `HOME` via `-H`.** HOME-writing tools
  (uv/pip/cargo/npm) no longer fail on `/root/.cache` when the deploy runs as
  root. The socket path was already correct (runs as the install user).
- **#277 — install failures surface the captured `stderr`** (bounded 2000
  chars) in the `DeploymentError` message, plus a `.cache`/`Permission denied`
  HOME hint. The socket path gets the same surfacing with a reworded hint.
  Note: `stderr` now reaches `status.error_message` / the authenticated
  `/details` endpoint — a wider (token-gated, bounded) surface than before.
- **#278 — the running webhook picks up a synced `fraises.yaml` without a
  restart.** `get_config()` mtime-invalidates the singleton; a bad reload keeps
  the last-good config (no outage). `SIGHUP` forces an immediate reload
  (`systemctl reload`, guarded so it can't crash startup). Config sync is now
  atomic (temp + rename).
- **#279 — a changed `install.command` is re-baked into the running
  install-helper allowlist during the deploy.** The old `enable --now` was a
  no-op on a running unit, so the stale-argv service kept rejecting the new
  command; now the deploy stops the service and restarts the socket, via a
  fatal `_run_strict` so a failed re-bake **aborts the deploy loudly** (naming
  the stale allowlist) instead of masking a later `command not allowed`. The
  rejection message names expected vs received command. The
  deploy_user→install_user boundary is kept — request-time config validation
  was explicitly rejected (it would validate against attacker-writable config).
- **#280 — install caches/state relocated under `app_path`** so the install
  step works under `ProtectSystem=strict` for any of uv/pip/cargo/npm.
  Recommended stable-entrypoint convention (`install.command: [bash,
  scripts/deploy-install.sh]`) so install content lives in a reviewed repo
  script and the allowlist effectively never changes.

## Notable design decisions

- The exact-match install-helper allowlist is kept as **defense-in-depth**, not
  a hard wall; the fail-loud gate is the actual fix.
- **All deploy-running units are `NoNewPrivileges`**, so the sudo fallback only
  runs unsandboxed — which is why #276's `-H` suffices there and #280 targets
  the socket (sandboxed) path only.

## Verification

- `ruff check` + `ruff format --check` clean (406 files)
- `pytest`: **4274 passed, 7 skipped**
- Two independent adversarial review passes (plan, then diff); all findings
  addressed.

Closes #276
Closes #277
Closes #278
Closes #279
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
