### PR TITLE
release: v0.50.0 — sync honours source-side content reverts (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-07-28
+
+Closes #290. v0.48.0 fixed the half where source *deletes* a file and named the
+half it did not fix; this is that half — source *reverting* a previously
+promoted change.
+
+### Fixed
+
+- **A source-side content revert is no longer silently undone by the pre-merge** (`cli/sync.py`, #290). When source reverts a file to exactly its merge-base content, git's 3-way merge sees `ours == base` and resolves it as *take theirs* — with a zero exit code and no conflict, so the tier loop never saw it and target's stale promoted copy won. Given a correct merge-base that resolution is right; under squash promotion the base is the ancient fork point that never advances, so `ours == base` no longer means "source never touched this" but "source added it and then reverted it". A new pre-pass restores source's version when target's copy is source-derived. This is the same stale-anchor root cause as the deletion half, reached through a different code path.
+- The `--dry-run` plan describes the second pre-pass alongside the first.
+
+### Notes for operators
+
+- **Only the exact revert to base content was affected.** A revert to any *other* content produces a real conflict, which tier 3 has resolved since v0.48.0; and a revert in one hunk while target edits a different hunk auto-merges correctly with both changes surviving. If you worked around this by hand-deleting or hand-reverting files directly on the target branch, that is no longer needed.
+- **Target-authored content is never overwritten.** When target's copy of a differing file is not source-derived, sync keeps target's version and prints a warning naming the path. Promotion silently clobbering a target-side hotfix is a worse failure than a missed revert, so the gate fails closed in that direction.
+
+### Changed
+
+- `_propagate_source_deletions` and the new `_propagate_source_reverts` share a `_diff_paths` helper. Both compute candidates target-side (`origin/<tgt>` vs `origin/<source>`) rather than from a merge-base, and both keep `--no-renames`, without which git's default rename detection reports a rename as `R` and hides every rename-shaped deletion.
+
+### Known limitations
+
+- Detection is anchored on what the merge did to the **index**, so it only applies to the pre-merge inside `fraisier sync`. A revert lost by a merge performed outside the tool is not recovered retroactively.
+- `_target_blob_is_source_derived` stops after 200 commits of source history for one path and treats exhaustion as "target-authored", leaving the file alone and warning. A revert to a file with a very long history on source can therefore still need a manual decision.
+
 ## [0.49.0] - 2026-07-28
 
 Completes the other half of #272. v0.48.0 made the automatic database rollback

--- a/fraisier/cli/sync.py
+++ b/fraisier/cli/sync.py
@@ -50,6 +50,37 @@ def _z_lines(result: subprocess.CompletedProcess) -> list[str]:
     return [item for item in (result.stdout or "").split("\0") if item]
 
 
+def _diff_paths(tgt: str, source: str, diff_filter: str) -> list[str]:
+    """Paths differing between ``origin/<tgt>`` and ``origin/<source>``.
+
+    Shared by both #290 pre-passes — ``D`` for deletions, ``M`` for content
+    reverts. Computed target-side rather than from ``merge-base..source``:
+    sync PRs are squash-merged, so the merge-base never advances past the
+    original fork point and anchoring on it is what hid the deletions.
+
+    ``--no-renames`` is required, not cosmetic: ``git diff`` applies rename
+    detection by default, which reports a rename as ``R`` rather than ``D``+``A``
+    and would hide every rename-shaped deletion from the scan.
+    """
+    return _z_lines(
+        subprocess.run(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "-z",
+                "--no-renames",
+                f"--diff-filter={diff_filter}",
+                f"origin/{tgt}",
+                f"origin/{source}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    )
+
+
 def _target_blob_is_source_derived(source: str, tgt: str, path: str) -> bool:
     """Return True when target's copy of *path* is content it received from source.
 
@@ -560,21 +591,13 @@ def _propagate_source_deletions(source: str, tgt: str) -> list[str]:
     UU-style conflict — it silently keeps target's copy. This pre-pass finds
     those files and mirrors the deletion with ``git rm``.
 
-    Candidates are computed from the **target** side — files present in
-    ``origin/<tgt>`` and absent from ``origin/<source>``:
-
-        git diff --diff-filter=D --no-renames origin/<tgt> origin/<source>
-
-    not from ``merge-base..origin/<source>`` as before. Sync PRs are
-    squash-merged, so the merge-base never advances past the original fork
-    point; a file created on source *after* that ancient base and later deleted
-    there is absent at both ends of that range and was never listed, while
-    target still carried a copy from an earlier squash-sync. The result was a
-    file resurrecting on every single sync (#290).
-
-    ``--no-renames`` is required, not cosmetic: ``git diff`` applies rename
-    detection by default, which reports a rename as R rather than D+A and would
-    hide every rename-shaped deletion from this scan.
+    Candidates are the ``D`` set from :func:`_diff_paths` — present on target,
+    absent from source — not ``merge-base..origin/<source>`` as before. Sync
+    PRs are squash-merged, so the merge-base never advances past the original
+    fork point; a file created on source *after* that ancient base and later
+    deleted there is absent at both ends of that range and was never listed,
+    while target still carried a copy from an earlier squash-sync. The result
+    was a file resurrecting on every single sync (#290).
 
     Two gates narrow the candidate set, both failing closed:
 
@@ -588,23 +611,7 @@ def _propagate_source_deletions(source: str, tgt: str) -> list[str]:
     — we don't lie to the operator log that resolution succeeded when the index
     is unchanged.
     """
-    candidates = _z_lines(
-        subprocess.run(
-            [
-                "git",
-                "diff",
-                "--name-only",
-                "-z",
-                "--no-renames",
-                "--diff-filter=D",
-                f"origin/{tgt}",
-                f"origin/{source}",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    )
+    candidates = _diff_paths(tgt, source, "D")
 
     propagated: list[str] = []
     for path in candidates:
@@ -649,6 +656,91 @@ def _propagate_source_deletions(source: str, tgt: str) -> list[str]:
     return propagated
 
 
+def _propagate_source_reverts(source: str, tgt: str) -> list[str]:
+    """Restore source's content where the merge silently took target's stale copy.
+
+    The other half of #290. ``_propagate_source_deletions`` handles source
+    removing a file; this handles source *reverting* one.
+
+    When source reverts a path to exactly its merge-base content, git's 3-way
+    merge sees ``ours == base`` and resolves it as *take theirs* — with a zero
+    exit code and no conflict, so the tier loop never sees it. Given a correct
+    base that is right. Under squash promotion the base is the ancient fork
+    point that never advances, so ``ours == base`` stops meaning "source never
+    touched this" and starts meaning "source added it and then reverted it",
+    while target still carries the promoted copy. The revert is lost on every
+    sync.
+
+    A revert to any *other* content leaves ``ours != base != theirs`` and does
+    conflict, where tier 3 already resolves it. Only the exact return to base
+    content is silent, which is why this half survived the deletion fix.
+
+    Detection deliberately computes no merge-base — anchoring on one is what
+    broke the deletion half. It asks what the merge actually did:
+
+    1. ``origin/<tgt>`` and ``origin/<source>`` differ on the path;
+    2. the merged **index** blob equals *target's* blob — git took theirs whole;
+    3. target's blob is source-derived, the same gate the deletion pass uses.
+
+    Gate 2 replaces a merge-base computation and excludes two classes for free:
+    a conflicted path has no stage-0 entry, so ``git rev-parse :<path>`` fails
+    and it falls through to the tier loop untouched; and a clean auto-merge of
+    non-overlapping hunks produces a blob equal to neither side, so both changes
+    survive.
+
+    Only paths whose checkout actually succeeds are returned — the operator log
+    must not claim a resolution the index does not reflect.
+    """
+    candidates = _diff_paths(tgt, source, "M")
+
+    restored: list[str] = []
+    for path in candidates:
+        target_blob = subprocess.run(
+            ["git", "rev-parse", f"origin/{tgt}:{path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        merged_blob = subprocess.run(
+            ["git", "rev-parse", f":{path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if target_blob.returncode != 0 or merged_blob.returncode != 0:
+            # No stage-0 entry means the path is still unmerged: a real
+            # conflict, which the tier loop owns.
+            continue
+        if merged_blob.stdout.strip() != target_blob.stdout.strip():
+            # The merge did not take target's side wholesale — either source
+            # won or the hunks merged cleanly. Nothing was silently lost.
+            continue
+        if not _target_blob_is_source_derived(source, tgt, path):
+            err_console.print(
+                f"[yellow]Warning:[/yellow] [bold]{path}[/bold] differs on "
+                f"{source} but {tgt}'s copy is not source-derived — keeping "
+                f"{tgt}'s version for you to decide."
+            )
+            continue
+        # `git checkout <tree-ish> -- <path>` updates the index as well as the
+        # worktree, so no separate `git add` is needed to stage the restore.
+        checkout = subprocess.run(
+            ["git", "checkout", f"origin/{source}", "--", path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if checkout.returncode == 0:
+            restored.append(path)
+        else:
+            detail = checkout.stderr.strip() or "git checkout failed"
+            err_console.print(
+                f"[yellow]Warning:[/yellow] could not restore "
+                f"[bold]{path}[/bold] from {source}: {detail}"
+            )
+    return restored
+
+
 def _print_dry_run_plan(source: str, tgt: str, sync_branch: str) -> None:
     """Print the shell commands that sync would execute, without running them."""
     auto_owned = ", ".join(_AUTO_RESOLVED)
@@ -665,6 +757,9 @@ def _print_dry_run_plan(source: str, tgt: str, sync_branch: str) -> None:
     console.print(
         f"    # files present on {tgt} but deleted on {source} are 'git rm'-ed to"
         f" propagate the deletion, when {source}'s history shows the deletion and"
+        f" {tgt}'s copy is source-derived;"
+        f" files {source} reverted to their merge-base content — which the merge"
+        f" silently resolves in {tgt}'s favour — are restored from {source} when"
         f" {tgt}'s copy is source-derived;"
         f" conflicts in [{auto_owned}] auto-resolved from {source};"
         f" conflicts where {tgt} holds source-derived content also resolved from"
@@ -817,6 +912,12 @@ def sync_cmd(
         # source-deleted-target-modified files still flow through tier 1.
         for deleted in _propagate_source_deletions(source, tgt):
             console.print(f"  Auto-resolved (source deletion): {deleted}")
+
+        # The other half of #290, and unconditional for the same reason: a
+        # source-side revert to base content merges *cleanly* and takes
+        # target's stale copy, so it never reaches the conflict loop below.
+        for restored in _propagate_source_reverts(source, tgt):
+            console.print(f"  Auto-resolved (source revert): {restored}")
 
         if merge_result.returncode != 0:
             conflicted = _capture(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.49.0"
+version = "0.50.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -47,6 +47,17 @@ def _no_source_deletions() -> MagicMock:
     return _mk(stdout="")
 
 
+def _no_source_reverts() -> MagicMock:
+    """Mock the post-merge `git diff --filter=M` pre-pass returning nothing.
+
+    The second half of #290. Sits immediately after `_no_source_deletions()`
+    for the same reason: `_propagate_source_reverts` fires once per sync run
+    whether or not the merge conflicted, because a source-side revert to base
+    content merges cleanly and never reaches the conflict loop.
+    """
+    return _mk(stdout="")
+
+
 def _merge_finalize_tail() -> list[MagicMock]:
     """Mock the post-commit pre-push invariant check (#233 Layer 2, #268).
 
@@ -567,6 +578,7 @@ class TestSyncHappyPath:
             _mk(),  # git checkout -b
             _mk(),  # git merge (clean)
             _no_source_deletions(),  # diff --filter=D pre-pass
+            _no_source_reverts(),  # diff --filter=M pre-pass
             _in_merge(),  # rev-parse MERGE_HEAD (in merge)
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),  # pre-push merge-commit invariant check
@@ -630,6 +642,7 @@ class TestSyncHappyPath:
                 _mk(),  # git checkout -b
                 _mk(),  # git merge (clean)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _in_merge(),  # MERGE_HEAD set → commit unconditionally
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
@@ -830,6 +843,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="version.json\npyproject.toml\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:version.json (exists)
                 _mk(),  # checkout origin/dev -- version.json
@@ -867,6 +881,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="version.json\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:version.json (exists)
                 _mk(),  # checkout origin/dev -- version.json
@@ -914,6 +929,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="pyproject.toml\n"),  # diff --filter=U
                 _mk(returncode=0),  # cat-file origin/dev:pyproject.toml (exists)
                 _mk(),  # checkout origin/dev -- pyproject.toml
@@ -962,6 +978,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="old_script.py\n"),  # diff --filter=U (first)
                 _mk(
                     returncode=1
@@ -996,6 +1013,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),  # diff --filter=U (first)
                 _mk(
                     returncode=0
@@ -1026,6 +1044,7 @@ class TestSyncConflicts:
                 _mk(),
                 _mk(returncode=1),
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),
                 _mk(
                     returncode=0
@@ -1057,6 +1076,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:src/routes.py (exists)
                 # Tier 3 now asks "is staging's blob source-derived?" instead
@@ -1100,6 +1120,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:src/routes.py (exists)
                 _mk(
@@ -1141,6 +1162,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:src/routes.py (exists)
                 _mk(
@@ -1180,6 +1202,7 @@ class TestSyncConflicts:
                 _mk(),  # git checkout -b
                 _mk(returncode=1),  # git merge (conflict)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _mk(stdout="src/routes.py\n"),  # diff --filter=U (first)
                 _mk(returncode=0),  # cat-file origin/dev:src/routes.py (exists)
                 _mk(
@@ -1245,6 +1268,7 @@ class TestSyncConfirmation:
                 _mk(),  # git checkout -b
                 _mk(),  # git merge (clean)
                 _no_source_deletions(),  # diff --filter=D pre-pass
+                _no_source_reverts(),  # diff --filter=M pre-pass
                 _in_merge(),  # MERGE_HEAD set
                 _mk(),  # git commit
                 *_merge_finalize_tail(),
@@ -1400,6 +1424,7 @@ class TestSyncBranchForceCreate:
             _mk(),  # git checkout -B
             _mk(),  # git merge (clean)
             _no_source_deletions(),  # diff --filter=D pre-pass
+            _no_source_reverts(),  # diff --filter=M pre-pass
             _in_merge(),  # MERGE_HEAD set
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),
@@ -1476,6 +1501,7 @@ class TestSyncExistingPR:
             _mk(),  # git checkout -B
             _mk(),  # git merge (clean)
             _no_source_deletions(),  # diff --filter=D pre-pass
+            _no_source_reverts(),  # diff --filter=M pre-pass
             _in_merge(),  # MERGE_HEAD set
             _mk(),  # git commit pre-merge
             *_merge_finalize_tail(),
@@ -1621,6 +1647,31 @@ class TestSyncExistingPR:
 # ---------------------------------------------------------------------------
 
 
+_PROP_SHA = "deadbeef" * 5
+_PROP_MERGE_BASE = "cafe1234" * 5
+_PROP_PR_URL = "https://github.com/org/repo/pull/42"
+
+
+def _propagation_scaffold() -> MockGit:
+    """Common scaffolding for the two post-merge pre-passes (#235, #290).
+
+    Covers rev-parse, fetch, version reads, checkout, push and the gh PR ops.
+    Tests layer on the merge + propagation calls they care about.
+    """
+    return (
+        MockGit()
+        .queue("git", "rev-parse", "--abbrev-ref", stdout="main\n")
+        .queue("git", "rev-parse", "origin/dev", stdout=_PROP_SHA + "\n")
+        .queue("git", "merge-base", stdout=_PROP_MERGE_BASE + "\n")
+        .queue("git", "show", "origin/dev:version.json", stdout='{"version": "1.1.0"}')
+        .queue(
+            "git", "show", "origin/staging:version.json", stdout='{"version": "1.0.0"}'
+        )
+        .queue("gh", "pr", "view", returncode=1)
+        .queue("gh", "pr", "create", stdout=_PROP_PR_URL + "\n")
+    )
+
+
 class TestSyncPropagatesSourceDeletions:
     """End-to-end regression for #235: source deletes a file, target unchanged,
     `git merge` succeeds clean. Pre-pass must `git rm` the file and the sync
@@ -1631,34 +1682,8 @@ class TestSyncPropagatesSourceDeletions:
     added or reordered elsewhere in `sync_cmd`.
     """
 
-    SHA = "deadbeef" * 5
-    MERGE_BASE = "cafe1234" * 5
-    PR_URL = "https://github.com/org/repo/pull/42"
-
     def _scaffold_mockgit(self) -> MockGit:
-        """Common scaffolding: rev-parse, fetch, version reads, checkout, push,
-        gh PR ops. Tests layer on the merge + propagation calls they care about.
-        """
-        return (
-            MockGit()
-            .queue("git", "rev-parse", "--abbrev-ref", stdout="main\n")
-            .queue("git", "rev-parse", "origin/dev", stdout=self.SHA + "\n")
-            .queue("git", "merge-base", stdout=self.MERGE_BASE + "\n")
-            .queue(
-                "git",
-                "show",
-                "origin/dev:version.json",
-                stdout='{"version": "1.1.0"}',
-            )
-            .queue(
-                "git",
-                "show",
-                "origin/staging:version.json",
-                stdout='{"version": "1.0.0"}',
-            )
-            .queue("gh", "pr", "view", returncode=1)
-            .queue("gh", "pr", "create", stdout=self.PR_URL + "\n")
-        )
+        return _propagation_scaffold()
 
     def test_clean_merge_with_source_deletion_propagates(self, tmp_path):
         cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
@@ -1817,6 +1842,82 @@ class TestSyncPropagatesSourceDeletions:
             "could not propagate deletion" in result.output
             or "submodules/legacy" in result.output
         )
+
+
+class TestSyncPropagatesSourceReverts:
+    """End-to-end for #290's content-revert half: source reverts a promoted
+    file back to its base content, so `git merge` resolves it silently in
+    target's favour and the conflict loop never sees it.
+
+    Shares `_propagation_scaffold` with the deletion pre-pass above; the
+    behaviour under test is the second pre-pass, which runs right after it.
+    """
+
+    def test_clean_merge_with_source_revert_restores_source_content(self, tmp_path):
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        mg = (
+            _propagation_scaffold()
+            # Clean merge — the revert is silently resolved in target's favour.
+            .queue("git", "merge")
+            # Deletion pre-pass finds nothing...
+            .queue("git", "diff", "--name-only", "-z", stdout="")
+            # ...then the revert pre-pass reports the modified path. Both share
+            # the same argv prefix, so these are consumed FIFO in call order.
+            .queue("git", "diff", "--name-only", "-z", stdout="app/shared.py\0")
+            # target blob, then the merged index blob — equal, so the merge
+            # took target's side wholesale.
+            .queue("git", "rev-parse", stdout="blob1\n")
+            .queue("git", "rev-parse", stdout="blob1\n")
+            # gate 3: target holds source-derived content
+            .queue("git", "rev-parse", stdout="blob1\n")
+            .queue("git", "rev-list", stdout="sha1\n")
+            .queue("git", "rev-parse", stdout="blob1\n")
+            .queue("git", "checkout", "origin/dev")  # the restore
+            .queue("git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD")
+            .queue("git", "commit")
+            .queue("git", "log", "-1", "--pretty=%P", stdout=_MERGE_PARENTS)
+            .queue(
+                "git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD", returncode=1
+            )
+            .queue("git", "ls-remote", returncode=2)  # orphan absent
+        )
+        with patch(_PATCH, side_effect=mg):
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "Auto-resolved (source revert): app/shared.py" in result.output
+        assert mg.was_called(["git", "checkout", "origin/dev", "--", "app/shared.py"])
+
+    def test_target_authored_content_is_not_restored(self, tmp_path):
+        """Same merge shape, but target's blob never appears in source's
+        history — the operator keeps target's version and is told so."""
+        cfg = _setup(tmp_path, [{"source": "dev", "target": "staging"}])
+        mg = (
+            _propagation_scaffold()
+            .queue("git", "merge")
+            .queue("git", "diff", "--name-only", "-z", stdout="")
+            .queue("git", "diff", "--name-only", "-z", stdout="app/hotfix.py\0")
+            .queue("git", "rev-parse", stdout="blobT\n")  # target blob
+            .queue("git", "rev-parse", stdout="blobT\n")  # merged == target
+            # gate 3 fails: source's history of the path never held blobT
+            .queue("git", "rev-parse", stdout="blobT\n")
+            .queue("git", "rev-list", stdout="sha1\n")
+            .queue("git", "rev-parse", stdout="blobOTHER\n")
+            .queue("git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD")
+            .queue("git", "commit")
+            .queue("git", "log", "-1", "--pretty=%P", stdout=_MERGE_PARENTS)
+            .queue(
+                "git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD", returncode=1
+            )
+            .queue("git", "ls-remote", returncode=2)
+        )
+        with patch(_PATCH, side_effect=mg):
+            result = CliRunner().invoke(main, ["-c", cfg, "sync", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "Auto-resolved (source revert): app/hotfix.py" not in result.output
+        assert not mg.was_called(
+            ["git", "checkout", "origin/dev", "--", "app/hotfix.py"]
+        )
+        assert "not source-derived" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_content_revert.py
+++ b/tests/test_sync_content_revert.py
@@ -1,0 +1,249 @@
+"""Source-side content reverts must survive the pre-merge (#290, second half).
+
+`f9388b9` fixed the deletion half and said the content-revert half needed its
+own fix. This is that case.
+
+When source reverts a file to **exactly** its merge-base content, git's 3-way
+merge sees ``ours == base`` and resolves it as *take theirs* — silently, with a
+zero exit code and no conflict. Given a correct base that is right. Under squash
+promotion the base is the ancient fork point that never advances, so "ours ==
+base" no longer means "source never touched this"; it means "source added it and
+then reverted it", and target's stale promoted copy wins.
+
+A revert to any *other* content conflicts instead, and tier 3 already handles it.
+That asymmetry is why this half survived the first fix.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from fraisier.cli.sync import (
+    _propagate_source_reverts,
+    _target_blob_is_source_derived,
+)
+
+BASE_SHARED = "registry = []\n"
+PROMOTED_SHARED = "registry = ['feature']\n"
+TARGET_HOTFIX = "x = 99  # staging-only hotfix\n"
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch) -> Path:
+    """`dev` and `staging` related only by squash promotion, with a reverted file.
+
+    Three subjects, chosen so that the only difference between the file that
+    must be restored and the file that must not is gate 3:
+
+    * ``shared.py``   — dev added wiring, promoted it, then reverted it exactly.
+    * ``untouched.py``— staging authored its own hotfix; dev never touched it
+      again. Same merge shape as ``shared.py`` (``ours == base``, merge takes
+      theirs) so only "is target's blob source-derived?" separates them.
+    * ``partial.py``  — promoted, then diverged on both sides by
+      ``_diverge_partial_on_dev`` to produce a genuine conflict.
+
+    The fixture chdirs into the work tree: the code under test shells out to git
+    against the process cwd, so a test that forgot would silently run against
+    the fraisier repo.
+    """
+    work = tmp_path / "work"
+    work.mkdir()
+    _git("init", "-q", "-b", "dev", cwd=work)
+    _git("config", "user.email", "t@example.com", cwd=work)
+    _git("config", "user.name", "T", cwd=work)
+
+    # --- the ancient common ancestor -------------------------------------
+    (work / "README.md").write_text("base\n")
+    (work / "shared.py").write_text(BASE_SHARED)
+    (work / "untouched.py").write_text("x = 1\n")
+    (work / "partial.py").write_text("v = 0\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "base", cwd=work)
+    _git("branch", "staging", cwd=work)
+
+    # --- dev adds the wiring, well after the fork ------------------------
+    (work / "shared.py").write_text(PROMOTED_SHARED)
+    (work / "partial.py").write_text("v = 1\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "add wiring", cwd=work)
+
+    # --- promotion: staging receives dev's tree as ONE squashed commit ---
+    _git("checkout", "-q", "staging", cwd=work)
+    _git("checkout", "dev", "--", ".", cwd=work)
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "Promote dev -> staging", cwd=work)
+
+    # --- staging authors its own change, and a target-only artifact ------
+    (work / "untouched.py").write_text(TARGET_HOTFIX)
+    (work / "RELEASE_NOTES.md").write_text("v1\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "staging hotfix + release notes", cwd=work)
+
+    # --- dev reverts the wiring back to exactly the base content ---------
+    _git("checkout", "-q", "dev", cwd=work)
+    (work / "shared.py").write_text(BASE_SHARED)
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "revert wiring", cwd=work)
+
+    # --- publish as `origin/*` so the code under test can address them ---
+    bare = tmp_path / "origin.git"
+    _git("init", "-q", "--bare", str(bare), cwd=work)
+    _git("remote", "add", "origin", str(bare), cwd=work)
+    _git("push", "-q", "origin", "dev", "staging", cwd=work)
+    _git("fetch", "-q", "origin", cwd=work)
+    monkeypatch.chdir(work)
+    return work
+
+
+def _diverge_partial_on_dev(work: Path) -> None:
+    """Move dev's partial.py off both base and the promoted copy — a real conflict."""
+    _git("checkout", "-q", "dev", cwd=work)
+    (work / "partial.py").write_text("v = 2\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-qm", "diverge partial", cwd=work)
+    _git("push", "-q", "origin", "dev", cwd=work)
+    _git("fetch", "-q", "origin", cwd=work)
+
+
+def _premerge(work: Path) -> subprocess.CompletedProcess:
+    """Reproduce sync's pre-merge: branch from dev, merge staging in."""
+    _git("checkout", "-q", "-B", "syncbranch", "origin/dev", cwd=work)
+    return subprocess.run(
+        ["git", "merge", "origin/staging", "--no-edit", "--no-commit"],
+        cwd=work,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _index_blob(work: Path, path: str) -> str:
+    return _git("rev-parse", f":{path}", cwd=work).stdout.strip()
+
+
+def _rev(work: Path, ref: str) -> str:
+    return _git("rev-parse", ref, cwd=work).stdout.strip()
+
+
+class TestTheSilentResurrection:
+    """The bug: git takes target's stale copy without saying anything."""
+
+    def test_premerge_reports_no_conflict_at_all(self, repo):
+        """Precondition — this is why the tier loop never sees it."""
+        result = _premerge(repo)
+
+        assert result.returncode == 0
+        assert not _git(
+            "diff", "--name-only", "--diff-filter=U", cwd=repo
+        ).stdout.strip()
+
+    def test_revert_is_lost_before_the_pass_runs(self, repo):
+        """Precondition — the merge alone resurrects the reverted wiring."""
+        _premerge(repo)
+
+        assert (repo / "shared.py").read_text() == PROMOTED_SHARED
+
+    def test_reverted_file_is_reported_as_restored(self, repo):
+        _premerge(repo)
+
+        assert _propagate_source_reverts("dev", "staging") == ["shared.py"]
+
+    def test_worktree_holds_the_reverted_content(self, repo):
+        _premerge(repo)
+        _propagate_source_reverts("dev", "staging")
+
+        assert (repo / "shared.py").read_text() == BASE_SHARED
+
+    def test_index_holds_the_reverted_content(self, repo):
+        """Reporting the path is not enough — the index is what gets committed."""
+        _premerge(repo)
+        _propagate_source_reverts("dev", "staging")
+
+        assert _index_blob(repo, "shared.py") == _rev(repo, "origin/dev:shared.py")
+
+
+class TestTargetAuthoredContentIsLeftAlone:
+    """The highest-consequence regression: never clobber target's own work.
+
+    ``untouched.py`` has the *same merge shape* as the restored file — dev's copy
+    equals the base, so the merge takes theirs. Only gate 3 tells them apart.
+    """
+
+    def test_target_hotfix_is_not_claimed(self, repo):
+        _premerge(repo)
+
+        assert "untouched.py" not in _propagate_source_reverts("dev", "staging")
+
+    def test_target_hotfix_content_survives(self, repo):
+        _premerge(repo)
+        _propagate_source_reverts("dev", "staging")
+
+        assert (repo / "untouched.py").read_text() == TARGET_HOTFIX
+
+    def test_gate_three_is_what_makes_that_safe(self, repo):
+        """The blob staging authored never appears in dev's history of the path."""
+        _premerge(repo)
+
+        assert _target_blob_is_source_derived("dev", "staging", "untouched.py") is False
+        assert _target_blob_is_source_derived("dev", "staging", "shared.py") is True
+
+    def test_target_only_file_is_not_a_candidate(self, repo):
+        """A file source never had is absent, not modified — never in scope."""
+        _premerge(repo)
+
+        assert "RELEASE_NOTES.md" not in _propagate_source_reverts("dev", "staging")
+
+
+class TestConflictsAreLeftToTheTierLoop:
+    """A path with conflict markers has no stage-0 entry, so it excludes itself."""
+
+    def test_conflicted_path_is_not_claimed(self, repo):
+        _diverge_partial_on_dev(repo)
+        assert _premerge(repo).returncode != 0
+
+        assert "partial.py" not in _propagate_source_reverts("dev", "staging")
+
+    def test_conflicted_path_stays_unmerged_for_tier_three(self, repo):
+        _diverge_partial_on_dev(repo)
+        _premerge(repo)
+        _propagate_source_reverts("dev", "staging")
+
+        unmerged = _git(
+            "diff", "--name-only", "--diff-filter=U", cwd=repo
+        ).stdout.split()
+        assert "partial.py" in unmerged
+
+    def test_the_silent_path_is_still_restored_alongside_a_conflict(self, repo):
+        """The pass must run on conflicted merges too, not only clean ones."""
+        _diverge_partial_on_dev(repo)
+        _premerge(repo)
+
+        assert _propagate_source_reverts("dev", "staging") == ["shared.py"]
+
+
+class TestNothingToDo:
+    """No revert, no candidates — the pass must be inert."""
+
+    def test_clean_promotion_restores_nothing(self, repo, monkeypatch):
+        """With dev's revert undone, dev and staging agree on shared.py."""
+        _git("checkout", "-q", "dev", cwd=repo)
+        (repo / "shared.py").write_text(PROMOTED_SHARED)
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-qm", "un-revert", cwd=repo)
+        _git("push", "-q", "origin", "dev", cwd=repo)
+        _git("fetch", "-q", "origin", cwd=repo)
+        _premerge(repo)
+
+        assert _propagate_source_reverts("dev", "staging") == []

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.49.0"
+version = "0.50.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #290 — the content-revert half, deferred by `f9388b9` in v0.48.0 which fixed the deletion half and said so explicitly.

## The mechanism, established empirically

A probe built a real repo with genuine squash-promotion topology and ran sync's actual pre-merge (`git checkout -B sync origin/dev` + `git merge origin/staging --no-edit --no-commit`). Two shapes of source-side revert, two different outcomes:

| Source reverts the file to… | merge exit | Result |
|---|---|---|
| **exactly** its merge-base content | **0 — clean, no conflict** | target's stale copy silently wins; the revert is **lost** |
| any *other* content | 1 — conflict | flows to the tier loop; tier 3 already resolves it |

Git resolves `ours == base` as *take theirs*, silently and correctly — **given a correct base**. Under squash promotion the base is the ancient fork point that never advances, so `ours == base` stops meaning "source never touched this" and starts meaning "source added it and then reverted it". Same stale-anchor root cause as the deletion half, surfacing through a different code path — which is why it needed its own fix rather than a wider net on the existing one.

**The narrowness is the finding.** A revert in one hunk while target edits a different hunk auto-merges correctly and both changes survive. Only the whole-file return to base content is silent. That matches the reporter's case exactly: dev removed the registration wiring it had added after the fork, returning the file to its pre-feature state.

## Detection

Computes **no merge-base** — anchoring on one is what broke the deletion half. It asks what the merge actually did:

1. `origin/<tgt>` and `origin/<source>` differ on the path;
2. the merged **index** blob equals *target's* blob — git took theirs wholesale;
3. target's blob is source-derived — `_target_blob_is_source_derived`, reused verbatim from the deletion fix.

Inspecting the index rather than a computed base buys two exclusions free: a conflicted path has no stage-0 entry, so `git rev-parse :<path>` fails and it falls through to the tier loop untouched; and a clean auto-merge of non-overlapping hunks yields a blob equal to neither side.

## What it must not do

`untouched.py` in the fixture has the **same merge shape** as the restored file — source's copy equals the base, so the merge takes theirs — and differs only in gate 3. It stays untouched, with a warning naming the path. Promotion silently clobbering a target-side hotfix is a worse failure than a missed revert, so the gate fails closed in that direction.

## Tests

13 real-repo cases on genuine squash topology (`tests/test_sync_content_revert.py`), following the precedent set when `f9388b9` deleted the ordered-mock sync suites for passing while the feature could not remove a file at all. Plus 2 call-site cases.

The 15 grandfathered ordered-`side_effect` suites in `test_sync.py` broke on the one extra subprocess call, as they did last time — fixed with a `_no_source_reverts()` filler beside the existing `_no_source_deletions()`.

## Not fixed here

- Detection is anchored on what the merge did to the index, so it applies to the pre-merge inside `fraisier sync` only — a revert lost by a merge performed outside the tool is not recovered retroactively.
- `_target_blob_is_source_derived` stops after 200 commits of source history for one path and treats exhaustion as target-authored, leaving the file alone and warning.

## Verification

✅ 4390 passed, 7 skipped (baseline 4375 + 15 new)
✅ `ruff check` + `ruff format --check` clean, 412 files
✅ `ty check` unchanged at 27 diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)