### PR TITLE
release: v0.50.1 — app unit stops writing bytecode into its venv (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.1] - 2026-07-28
+
+Closes #292. Found while re-auditing the unit templates for #286 — not a cause
+of #286, whose residue is elsewhere.
+
+### Fixed
+
+- **The app unit no longer byte-compiles into its own venv** (`core/service.j2`, #292). It was the only Python-invoking unit template without `Environment=PYTHONDONTWRITEBYTECODE=1`; the other eight all set it. It is also the one unit whose `User=` can be a **third** identity — `service.user`, independent of both `scaffold.deploy_user` and `install.user` — so the running app wrote `__pycache__` under `app_path/.venv/` owned by an identity the install user cannot unlink on the next `uv sync --frozen`. That is the #196 failure class from a direction #196 did not cover.
+
+### Notes for operators
+
+- **This costs startup time, deliberately.** `--compile-bytecode` is used nowhere, so the venv has never been precompiled at install time; with bytecode writing off, every start recompiles site-packages *and* your app modules. On a `Restart=on-failure` unit that starts rarely this is the right trade against an un-cleanable venv, but it is a real cost on a large codebase.
+- **It is overridable.** The directive is emitted *before* the `service.environment` loop, and systemd resolves a repeated `Environment=` assignment last-wins, so `service.environment: {PYTHONDONTWRITEBYTECODE: "0"}` restores the old behaviour if you measure the cost and decide against it.
+- Re-run `fraisier scaffold` and reinstall the unit to pick this up; an already-running service keeps its current environment until restarted. Existing `__pycache__` residue is cleared by the stale-cache sweep at `scaffold-install` time, as it was in v0.48.0.
+
+### Known limitations
+
+- **Redirecting the cache rather than disabling it is not implemented.** `PYTHONPYCACHEPREFIX` pointed at a `service.user`-writable directory would keep both the compile cache and the ownership guarantee, but needs a state directory, its creation and ownership in scaffold, a `ReadWritePaths` entry and an uninstall sweep. Tracked separately (#298) rather than bundled here.
+- The guard added over the unit templates classifies fail-closed from `ExecStart`: a unit whose executable is a Jinja variable is assumed to be Python. Only a concretely shell `ExecStart` is exempt, and the exempt set is pinned by name, so a wrong exemption fails the suite rather than passing silently.
+
 ## [0.50.0] - 2026-07-28
 
 Closes #290. v0.48.0 fixed the half where source *deletes* a file and named the

--- a/fraisier/scaffold/templates/core/service.j2
+++ b/fraisier/scaffold/templates/core/service.j2
@@ -75,6 +75,10 @@ ReadWritePaths=/var/lib/postgresql
 {% endif %}
 
 # Environment
+# Keep bytecode out of the venv: service.user may differ from the install user,
+# whose next `uv sync --frozen` could not then unlink these __pycache__ dirs.
+# Declared before service.environment so an explicit override there wins.
+Environment=PYTHONDONTWRITEBYTECODE=1
 Environment=ENVIRONMENT={{ env_name }}
 {% if fraise.get('type') == 'api' %}
 Environment=WORKERS={{ worker_count }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.50.0"
+version = "0.50.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_pycache_prevention.py
+++ b/tests/test_pycache_prevention.py
@@ -3,7 +3,42 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_TEMPLATES = Path(__file__).parent.parent / "fraisier/scaffold/templates/core"
+
+_EXEC_START = re.compile(r"^ExecStart=(\S+)", re.MULTILINE)
+
+# Jinja expressions contain spaces, so they must collapse to a single token
+# before the executable can be split off the front of an ExecStart= line.
+_JINJA = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+
+# Concrete shell interpreters. Anything else — including a Jinja variable, whose
+# value is not knowable here — is treated as Python: this guard fails closed, so
+# a unit whose ExecStart cannot be classified must still disable bytecode.
+_SHELL_EXEC = re.compile(r"(^|/)(sh|bash|dash|env)$|\.sh$")
+
+
+def _invokes_python(content: str) -> bool:
+    executables = _EXEC_START.findall(_JINJA.sub("VAR", content))
+    return any(not _SHELL_EXEC.search(exe) for exe in executables)
+
+
+def _unit_templates() -> list[Path]:
+    units = [
+        *sorted(_CORE_TEMPLATES.glob("*.service.j2")),
+        _CORE_TEMPLATES / "service.j2",
+        _CORE_TEMPLATES / "deploy-service.j2",
+    ]
+    return [p for p in units if p.is_file()]
+
+
+def _python_unit_templates() -> list[Path]:
+    return [p for p in _unit_templates() if _invokes_python(p.read_text())]
 
 
 class TestBytecodeDisabled:
@@ -18,3 +53,26 @@ class TestBytecodeDisabled:
         import fraisier
 
         assert os.environ.get("PYTHONDONTWRITEBYTECODE") == "1"
+
+
+class TestUnitTemplatesDisableBytecode:
+    """Every Python-invoking unit template disables bytecode writing (#292).
+
+    #292 was one unit template that missed the directive every other one had.
+    Deriving the list from the templates directory rather than hardcoding it
+    means a unit added later is covered on the day it is added.
+    """
+
+    def test_the_audit_finds_units(self):
+        """Guard the guard: an empty parametrize list would pass vacuously."""
+        assert len(_python_unit_templates()) >= 8
+
+    @pytest.mark.parametrize("template", _python_unit_templates(), ids=lambda p: p.name)
+    def test_python_units_set_dont_write_bytecode(self, template):
+        assert "Environment=PYTHONDONTWRITEBYTECODE=1" in template.read_text()
+
+    def test_only_the_shell_units_are_exempt(self):
+        """Pin what the classifier excludes, so a wrong exclusion is visible."""
+        covered = {p.name for p in _python_unit_templates()}
+        exempt = {p.name for p in _unit_templates()} - covered
+        assert exempt == {"backup.service.j2", "backup-alert@.service.j2"}

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1868,6 +1868,61 @@ scaffold:
         assert "RuntimeDirectory" not in content
         assert "LogsDirectory" not in content
 
+    def test_bytecode_writing_disabled(self, tmp_path):
+        """The app unit sets PYTHONDONTWRITEBYTECODE=1 (#292).
+
+        service.user may be a third identity, distinct from both
+        scaffold.deploy_user and install.user. Without this the running app
+        byte-compiles into app_path/.venv/**/__pycache__ owned by that identity,
+        which the install user cannot unlink on the next `uv sync --frozen`.
+        """
+        content = self._render_service(
+            tmp_path,
+            """
+name: tp
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/app
+        service:
+          user: myapp_user
+scaffold:
+  output_dir: {output}
+  deploy_user: fraisier
+""".format(output=str(tmp_path / "output")),
+        )
+        assert "Environment=PYTHONDONTWRITEBYTECODE=1" in content
+
+    def test_bytecode_default_precedes_user_environment(self, tmp_path):
+        """A user-supplied override renders after ours, so it wins (#292).
+
+        systemd resolves a repeated Environment= assignment last-wins. Emitting
+        the default before service.environment keeps it overridable by anyone
+        who measures the per-start compile cost and decides against it.
+        """
+        content = self._render_service(
+            tmp_path,
+            """
+name: tp
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/app
+        service:
+          environment:
+            PYTHONDONTWRITEBYTECODE: "0"
+scaffold:
+  output_dir: {output}
+""".format(output=str(tmp_path / "output")),
+        )
+        assert content.index("Environment=PYTHONDONTWRITEBYTECODE=1") < content.index(
+            "Environment=PYTHONDONTWRITEBYTECODE=0"
+        )
+
 
 class TestNginxPerEnvConfig:
     """Issue #4: per-environment nginx config files."""

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.50.0"
+version = "0.50.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #292.

`core/service.j2` was the only Python-invoking unit template without `Environment=PYTHONDONTWRITEBYTECODE=1`. I audited all eleven `core/*.service.j2` templates to confirm the issue's claim before fixing it — it holds exactly, with no second gap hiding behind it:

| Template | invokes Python | set the var |
|---|---|---|
| deploy-service, fraisier-webhook, install-helper, poll-deploy, restore-staging, scaffold-install-helper, systemctl-helper, unit-installer | yes | yes |
| `backup.service` | no — `ExecStart={{ output_dir }}/backup.sh` | n/a |
| `backup-alert@.service` | no — `/bin/sh -c "echo … \| systemd-cat"` | n/a |
| **`core/service.j2`** | **yes** — `.venv/bin/uvicorn` | **no** |

It is also the one unit whose `User=` can be a **third** identity — `service.user`, independent of both `scaffold.deploy_user` and `install.user`. When set, the running app byte-compiled into `app_path/.venv/**/__pycache__` owned by that identity, which the install user cannot unlink on the next `uv sync --frozen`. The #196 failure class, from a direction #196 did not cover.

## The ordering is the decision, not the line

The directive is emitted **before** the `service.environment` loop. systemd resolves a repeated `Environment=` assignment last-wins, so this leaves `service.environment: {PYTHONDONTWRITEBYTECODE: "0"}` as a working escape hatch. Emitting it after the loop would have silently ignored a user's own setting for the same key. A test pins the ordering, not just the presence.

That escape hatch matters because **this fix has a real cost**: `--compile-bytecode` appears nowhere in the repo, so the venv has never been precompiled at install time. Every start now recompiles site-packages *and* app modules. Right trade for a `Restart=on-failure` unit that starts rarely; a genuine regression for a large app that restarts often. The CHANGELOG says so rather than presenting this as free.

## A guard, because this will recur

The bug is "a new unit forgot the var". The guard derives its unit list from the templates directory rather than hardcoding it, so a unit added later is covered on the day it is added. It classifies fail-closed from `ExecStart`: a unit whose executable is a Jinja variable (opaque here) is **assumed** to be Python and must set the var; only a concretely shell `ExecStart` is exempt, and the exempt set is pinned by name so a wrong exemption fails loudly instead of silently skipping.

All three new tests were confirmed to fail with the fix reverted — the guard was written after the GREEN, so it was verified to actually bite rather than assumed to.

## What this does not do

- **It does not keep the compile cache.** `PYTHONPYCACHEPREFIX` pointed at a `service.user`-writable directory would keep both the cache and the ownership guarantee, but needs a state dir, its creation and ownership in scaffold, a `ReadWritePaths` entry and an uninstall sweep. Filed as #298, with `uv sync --compile-bytecode` weighed there as the cheaper alternative.
- **It does not fix #286.** That residue is in the deploy user's uv *tool* dir, not the app venv. This was found while re-auditing templates for #286, not as its cause.
- An already-running service keeps its current environment until restarted; re-run `fraisier scaffold` and reinstall the unit.

## Verification

- 4402 passed, 7 skipped, 1 deselected (the known `test_install_helper` ordering flake)
- +15 tests collected vs `main` (4397 → 4412), all accounted for: 2 scaffold, 2 guard, 11 parametrised
- `ruff check` + `ruff format --check` clean across 412 files
- `ty check` 27 — unchanged floor (an added `pytest.skip` diagnostic was designed out rather than suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
