### PR TITLE
release: v0.51.0 — fraisier setup populates the scaffold state tree (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-07-28
+
+Closes #284. Completes the #283 unification: `fraisier setup` was the last
+server-side consumer that had never been moved onto `scaffold.state_dir`.
+
+### Fixed
+
+- **`fraisier setup` now populates `scaffold.state_dir`** (`setup.py`, #284). After a bare `setup`, `{state_dir}/install.sh` did not exist. That exact path is baked into the scaffold-install-helper unit as its `ExecStart` argument (`renderer.py:936-941`), and the helper daemon exits 1 at startup when it is missing (`scaffold_install_helper.py:228-230`) — so the socket never came up and every deploy silently fell back to the slower subprocess install path, until the first config-changing deploy regenerated the tree. Same silent-degradation class #283 closed for `bootstrap`, narrowed to the manual-`setup`-without-a-deploy window. `setup` now creates and chowns `state_dir` (as `bootstrap` does) and copies its rendered tree in.
+
+### Changed
+
+- `fraisier setup --dry-run` lists two new actions under a `scaffold` category: the copy into `state_dir` and the recursive chown of the result. No existing action changed.
+- `/var/lib/fraisier/<project>/scaffold` is now created and owned by `deploy_user` by `setup`, matching what `bootstrap` already did.
+
+### Docs
+
+- **The two provisioning flows differ on purpose, and that is now written down** (`docs/deployment-guide.md`, `docs/cli-reference.md`). A table contrasting `output_dir` (what you render and review) with `state_dir` (what the machine reads at deploy time), why `setup` writes both while `bootstrap` writes only the second, and a pointer from `setup` to `bootstrap` for fresh servers.
+
+### Notes for operators
+
+- **The install source is unchanged.** `setup` still installs from `scaffold.output_dir`, so the render → `git diff` → install loop that makes it the manual flow works exactly as before. `state_dir` is added as what the machine consumes, not substituted as what you install from. A test pins this.
+- **The webhook env file is deliberately excluded from the copy.** It carries `FRAISIER_WEBHOOK_SECRET`, its only install target is `/etc/fraisier/<project>.webhook.env` at mode `0640`, and `state_dir` is a world-readable system directory. The deploy path's renderer never writes it there either, so excluding it also keeps the two trees comparable.
+- Re-run `sudo fraisier setup` on any host provisioned by `setup` rather than `bootstrap` to close the window without waiting for a config-changing deploy. Hosts already past their first such deploy are unaffected — the tree is already there.
+
+### Known limitations
+
+- **`setup` still installs from `output_dir`, so the trees can diverge.** If you edit files under `state_dir` on the server, the next `setup` overwrites them from `output_dir` without warning. Making `state_dir` the install source too (Option 1 on #284) was rejected: it would break the review-then-install loop for a flow that is not otherwise broken.
+- **The copy is unconditional, not a sync.** Files present in `state_dir` but not in `output_dir` — a unit for an environment you have since removed, say — survive it. Nothing prunes `state_dir`, here or on the deploy path, which regenerates into it the same way. Stale files there are inert (`install.sh` only ever copies files it names), but they are not cleaned up.
+
 ## [0.50.1] - 2026-07-28
 
 Closes #292. Found while re-auditing the unit templates for #286 — not a cause

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -532,6 +532,19 @@ Provision the server: create system users, directories, permissions, sudoers rul
 install systemd units. Run once per server, or again after significant config changes.
 Requires sudo / root.
 
+This is the **manual, on-the-box** provisioning flow: it installs from
+`scaffold.output_dir`, the CWD-relative tree you rendered with `fraisier scaffold` and
+reviewed. For a fresh server, prefer [`fraisier bootstrap`](#fraisier-bootstrap), which
+does the same provisioning end-to-end over SSH.
+
+`setup` installs from `output_dir` but *also* copies that tree into
+`scaffold.state_dir` (default `/var/lib/fraisier/<project>/scaffold`), which is where
+the deploy path and the scaffold-install-helper socket read from. The webhook env file
+is excluded from that copy — it carries `FRAISIER_WEBHOOK_SECRET` and is installed only
+to `/etc/fraisier/<project>.webhook.env` at mode `0640`. See
+[Two trees](deployment-guide.md#two-trees-output_dir-and-state_dir) for why the two
+flows differ.
+
 ```bash
 fraisier setup [OPTIONS]
 ```

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -302,13 +302,17 @@ sudo fraisier setup
 2. Creates system directories:
    - `/var/lib/fraisier/repos/` — bare git repositories
    - `/var/lib/fraisier/status/` — deployment status files
+   - `/var/lib/fraisier/<project>/scaffold/` — the server-side scaffold state tree
+     (`scaffold.state_dir`)
    - `/run/fraisier/` — lock files
-3. Sets ownership and permissions on `app_path` so the deploy user can write to the
+3. Copies the rendered scaffold tree into `scaffold.state_dir` and gives it to the
+   deploy user — see [Two trees: `output_dir` and `state_dir`](#two-trees-output_dir-and-state_dir)
+4. Sets ownership and permissions on `app_path` so the deploy user can write to the
    worktree while the application user owns the running code
-4. Configures `git config --global safe.directory` for the app paths
-5. Installs the sudoers fragment (`/etc/sudoers.d/<project>`)
-6. Installs the webhook systemd unit and application service units
-7. Reloads systemd: `systemctl daemon-reload`
+5. Configures `git config --global safe.directory` for the app paths
+6. Installs the sudoers fragment (`/etc/sudoers.d/<project>`)
+7. Installs the webhook systemd unit and application service units
+8. Reloads systemd: `systemctl daemon-reload`
 
 Filter to a specific environment or server:
 
@@ -316,6 +320,34 @@ Filter to a specific environment or server:
 sudo fraisier setup --environment production
 sudo fraisier setup --server prod.myserver.com
 ```
+
+### Two trees: `output_dir` and `state_dir`
+
+The two provisioning flows render the same files but keep them in different places,
+and the distinction matters if you ever have to debug one.
+
+| | `scaffold.output_dir` | `scaffold.state_dir` |
+|---|---|---|
+| Default | `scripts/generated` (relative to CWD) | `/var/lib/fraisier/<project>/scaffold` |
+| Purpose | what **you** render and review before installing | what the **machine** reads at deploy time |
+| Written by | `fraisier scaffold`, `fraisier setup` | `fraisier bootstrap`, every config-changing deploy, `fraisier setup` |
+| Read by | `fraisier setup` (its install sources) | scaffold regeneration, the scaffold-install-helper socket, the staleness check |
+
+`fraisier setup` installs from `output_dir` — that is deliberate, and it is what makes
+the manual flow reviewable: you render into a directory, read the diff, and install
+exactly what you read. It *also* copies that tree into `state_dir`, because the
+scaffold-install-helper's systemd unit has `<state_dir>/install.sh` baked into its
+`ExecStart` and the helper refuses to start if that file is missing. Without the copy,
+deploys fall back to a slower subprocess install path until the first config-changing
+deploy regenerates the tree.
+
+The webhook env file is the one rendered file **not** copied into `state_dir`: it holds
+`FRAISIER_WEBHOOK_SECRET` and belongs only at `/etc/fraisier/<project>.webhook.env`,
+installed mode `0640`.
+
+`fraisier bootstrap` skips `output_dir` entirely — it renders to a temporary directory
+locally and uploads straight into `state_dir` on the server. There is nothing to review
+because you are not on the machine being provisioned.
 
 ---
 

--- a/fraisier/setup.py
+++ b/fraisier/setup.py
@@ -58,6 +58,7 @@ class ServerSetup:
         actions: list[SetupAction] = []
         actions.extend(self._plan_users())
         actions.extend(self._plan_directories())
+        actions.extend(self._plan_scaffold_state())
         actions.extend(self._plan_app_permissions())
         actions.extend(self._plan_git_safe_directory())
         actions.extend(self._plan_symlinks())
@@ -147,6 +148,11 @@ class ServerSetup:
             ("/var/lib/fraisier", deploy_user),
             ("/var/lib/fraisier/repos", deploy_user),
             ("/var/lib/fraisier/status", deploy_user),
+            # The persistent scaffold state tree (#283) that the socket helper
+            # reads its baked install.sh from. Owned by deploy_user so
+            # deploy-time regeneration (which runs as that user) can refresh
+            # it — the same reason bootstrap chowns it (#284).
+            (self.config.scaffold_state_dir, deploy_user),
             ("/run/fraisier", deploy_user),
         ]
         root_dirs = [
@@ -172,6 +178,56 @@ class ServerSetup:
                     )
                 )
         return actions
+
+    def _plan_scaffold_state(self) -> list[SetupAction]:
+        """Persist the rendered tree into the server-side scaffold state tree.
+
+        ``fraisier setup`` renders into, and installs from, the CWD-relative
+        ``scaffold.output_dir`` — the tree the operator reviews before
+        installing.  The deploy path never looks there: it regenerates into,
+        installs from and staleness-checks ``scaffold_state_dir`` (#283), and
+        the scaffold-install-helper's baked ``allowed_script`` is
+        ``{state_dir}/install.sh``.  Left unpopulated, that helper exits at
+        startup and every deploy silently falls back to the subprocess install
+        path until the first config-changing deploy regenerates the tree (#284).
+
+        Copying rather than moving keeps ``output_dir`` as the review surface.
+        The webhook env file is excluded: it carries
+        ``FRAISIER_WEBHOOK_SECRET`` and belongs only at
+        ``/etc/fraisier/{project}.webhook.env`` (installed 0640 by
+        :meth:`_plan_env_files`), never in a world-readable state directory —
+        and the deploy path's renderer never writes it there either.
+        """
+        output_dir = shlex.quote(self.config.scaffold.output_dir)
+        state_dir = self.config.scaffold_state_dir
+        deploy_user = self.config.scaffold.deploy_user
+        env_file = f"fraisier-{self.config.project_name}.webhook.env"
+
+        quoted_state_dir = shlex.quote(state_dir)
+        secret_copy = shlex.quote(f"{state_dir}/{env_file}")
+        return [
+            SetupAction(
+                description=f"Persist rendered scaffold tree to {state_dir}",
+                command=[
+                    "sudo",
+                    "bash",
+                    "-c",
+                    f"cp -a {output_dir}/. {quoted_state_dir}/ && rm -f {secret_copy}",
+                ],
+                category="scaffold",
+            ),
+            SetupAction(
+                description=f"Set ownership of {state_dir} to {deploy_user}",
+                command=[
+                    "sudo",
+                    "chown",
+                    "-R",
+                    f"{deploy_user}:{deploy_user}",
+                    state_dir,
+                ],
+                category="scaffold",
+            ),
+        ]
 
     def _plan_app_permissions(self) -> list[SetupAction]:
         """Configure ownership when app_user differs from deploy_user."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.50.1"
+version = "0.51.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -189,9 +189,166 @@ class TestPlanDirectories:
         setup = ServerSetup(config, FakeRunner())
         actions = setup._plan_directories()
         chown_actions = [a for a in actions if "ownership" in a.description]
-        assert len(chown_actions) == 4
+        assert len(chown_actions) == 5
         for a in chown_actions:
             assert "fraisier:fraisier" in " ".join(a.command)
+
+    def test_creates_scaffold_state_dir(self, tmp_path):
+        """setup provisions the tree the socket helper reads from (#284).
+
+        Until this directory holds an install.sh the helper daemon exits at
+        startup (``scaffold_install_helper.py:228-230``), so the deploy silently
+        drops onto the subprocess fallback.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup._plan_directories()
+
+        state_dir = config.scaffold_state_dir
+        assert state_dir == "/var/lib/fraisier/tp/scaffold"
+        mkdirs = [a for a in actions if a.command[:3] == ["sudo", "mkdir", "-p"]]
+        assert any(a.command[3] == state_dir for a in mkdirs)
+
+    def test_scaffold_state_dir_owned_by_deploy_user(self, tmp_path):
+        """Deploy-time regeneration runs as deploy_user and must refresh it.
+
+        Same reason ``bootstrap.py:257-273`` chowns it.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup._plan_directories()
+
+        state_dir = config.scaffold_state_dir
+        chowns = [a for a in actions if a.command[:2] == ["sudo", "chown"]]
+        assert any(
+            a.command[2] == "fraisier:fraisier" and a.command[3] == state_dir
+            for a in chowns
+        )
+
+
+class TestPlanScaffoldState:
+    """`setup` also persists its rendered tree into scaffold_state_dir (#284)."""
+
+    def test_copies_rendered_tree_into_state_dir(self, tmp_path):
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        copies = [
+            a for a in actions if a.category == "scaffold" and "cp" in a.command[-1]
+        ]
+        assert len(copies) == 1
+        assert (
+            "cp -a scripts/generated/. /var/lib/fraisier/tp/scaffold/"
+            in copies[0].command[-1]
+        )
+
+    def test_webhook_env_file_is_not_persisted(self, tmp_path):
+        """It holds FRAISIER_WEBHOOK_SECRET and state_dir is world-readable.
+
+        Its only install target is /etc/fraisier/{project}.webhook.env at 0640
+        (``_plan_env_files``), and the deploy path's renderer never writes it
+        into state_dir either.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        copies = [
+            a for a in actions if a.category == "scaffold" and "cp" in a.command[-1]
+        ]
+        assert (
+            "rm -f /var/lib/fraisier/tp/scaffold/fraisier-tp.webhook.env"
+            in copies[0].command[-1]
+        )
+
+    def test_persisted_tree_is_chowned_to_deploy_user(self, tmp_path):
+        """`cp -a` preserves the operator's ownership; deploy_user must own it."""
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        chowns = [
+            a
+            for a in actions
+            if a.category == "scaffold" and a.command[:3] == ["sudo", "chown", "-R"]
+        ]
+        assert len(chowns) == 1
+        assert chowns[0].command[3:] == [
+            "fraisier:fraisier",
+            "/var/lib/fraisier/tp/scaffold",
+        ]
+
+    def test_copy_ordered_after_the_directory_that_receives_it(self, tmp_path):
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        mkdir_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.command[:3] == ["sudo", "mkdir", "-p"]
+            and a.command[3] == "/var/lib/fraisier/tp/scaffold"
+        )
+        copy_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.category == "scaffold" and "cp" in a.command[-1]
+        )
+        chown_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.category == "scaffold" and a.command[:3] == ["sudo", "chown", "-R"]
+        )
+        assert mkdir_idx < copy_idx < chown_idx
+
+    def test_install_sources_still_resolve_against_output_dir(self, tmp_path):
+        """Option 2, not Option 1 — the review-then-install loop is unchanged.
+
+        `setup` renders into a CWD-relative tree the operator inspects and
+        installs what they just read; `state_dir` is added as what the machine
+        consumes, not substituted as the install source.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+
+        sources = [
+            *setup._plan_sudoers(),
+            *setup._plan_app_services(),
+            *setup._plan_webhook_service(),
+            *setup._plan_env_files(),
+            *setup._plan_nginx(),
+        ]
+        installs = [a for a in sources if a.command[1] in {"cp", "install"}]
+        assert len(installs) == 6
+        for action in installs:
+            src = action.command[-2]
+            assert src.startswith("scripts/generated/"), action.description
+
+    def test_persisted_tree_supplies_the_helpers_allowed_script(self, tmp_path):
+        """The copied tree carries exactly the path baked into the helper unit.
+
+        The unit's ExecStart argument is ``{state_dir}/install.sh``
+        (``renderer.py:936-941``) and the daemon exits 1 at startup when that
+        path is absent (``scaffold_install_helper.py:228-230``).  `install.sh`
+        renders at the *root* of the tree `setup` copies, so copying
+        ``output_dir/.`` into ``state_dir/`` is what closes the gap — this is
+        the assertion that makes the two command strings above mean something.
+        """
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        renderer = ScaffoldRenderer(config)
+        renderer.output_dir = tmp_path / "generated"
+        renderer.render()
+
+        assert (renderer.output_dir / "install.sh").is_file()
+        unit = (
+            renderer.output_dir
+            / "systemd"
+            / "fraisier-tp-scaffold-install-helper.service"
+        ).read_text()
+        assert "/var/lib/fraisier/tp/scaffold/install.sh" in unit
 
 
 class TestPlanSymlinks:

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.50.1"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #284.

## The claim, verified before fixing

Both halves of the issue trace into the code exactly as filed:

1. **`setup.py` is the last server-side consumer on `output_dir`.** `grep` over `scaffold.output_dir` in `fraisier/` returns `setup.py` (6 sites), `bootstrap.py:324` (a *temp* dir it renders into before uploading), and `cli/scaffold.py` (the local render command). Nothing else server-side.
2. **An unpopulated `state_dir` really does mean a helper that cannot start.** `renderer.py:936-941` bakes `{state_dir}/install.sh` into the scaffold-install-helper unit as its `ExecStart` argument, and `scaffold_install_helper.py:228-230` exits 1 at startup when that path is absent. So after a bare `fraisier setup` the socket never comes up and `deployers/base.py:568-585` drops onto the subprocess install path — silently, until the first config-changing deploy regenerates the tree.

Same silent-degradation class #283 closed for `bootstrap`, narrowed to the manual-`setup`-without-a-deploy window.

## What changed

**Option 2 of the issue, not Option 1.** `output_dir` stays the install source; `state_dir` is *added* as what the machine consumes.

- `_plan_directories` creates and chowns `scaffold_state_dir`, mirroring `bootstrap.py:257-273` — deploy-time regeneration runs as `deploy_user` and must be able to refresh it.
- New `_plan_scaffold_state` copies the rendered tree into `state_dir` and chowns the result, ordered after the directory that receives it. Both actions fit the existing `SetupAction` plan/execute structure, so `--dry-run` describes them for free.
- The webhook env file is excluded from the copy: it carries `FRAISIER_WEBHOOK_SECRET`, its only install target is `/etc/fraisier/{project}.webhook.env` at `0640`, and `state_dir` is world-readable. The deploy path's renderer never writes it there either, so excluding it also keeps the two trees comparable.
- Issue Option 3 done **as well**: `docs/deployment-guide.md` gains a "Two trees" section, `docs/cli-reference.md` labels `setup` the manual on-the-box flow and points at `bootstrap`.

## Why not Option 1

Moving the install source to `state_dir` is the purest read of #283, but it breaks the render → `git diff` → install loop that is the whole point of the manual flow, for a path the issue itself confirms is not broken. `config/loader.py:414-431` already documents `output_dir` as "a local render/review concern only" — Option 2 is that division, honoured.

## What this does not fix

- **The trees can still diverge.** Hand-edit something under `state_dir` and the next `setup` overwrites it from `output_dir` without warning.
- **The copy is not a sync.** Files in `state_dir` with no counterpart in `output_dir` survive it. Nothing prunes `state_dir`, here or on the deploy path. Stale files are inert — `install.sh` only ever copies files it names — but they are not cleaned up.
- **Hosts already past their first config-changing deploy gain nothing.** Their tree is already there. This closes the window, it does not repair anything.

## Verification

- 4410 passed, 7 skipped, 1 deselected (+8 collected, all new; `--collect-only` 4410 → 4418 against `main`)
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27
- 6 of the 8 new tests confirmed failing before the fix. The other 2 are scope pins that cannot go red on this change and are labelled as such: install sources stay on `output_dir`, and the renderer roots `install.sh` at the tree the copy carries.
- `cp -a <src>/. <dst>/ && rm -f <dst>/<env file>` exercised in a scratch tree: subdirectories preserved, `install.sh` at the root, env file absent.

## Commits

Two, kept separate so each is `git revert`-able — **rebase-merge**, per the repo's convention for multi-commit bundles.

| Commit | Subject |
|---|---|
| `619d21d` | `fix(setup)`: persist the rendered scaffold tree into state_dir |
| `55abc9b` | `release`: v0.51.0 + docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
