### PR TITLE
release: v0.52.0 — the sudoers install rule actually authorises the install (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-07-28
+
+Closes #294. The issue was filed explicitly unverified because it needed
+`sudo -l` on a real box; it has now been settled against sudo's own policy
+engine, and it was right.
+
+### Fixed
+
+- **The generated sudoers rule now authorises the command the deploy actually runs** (`core/sudoers.j2`, #294). Every rule was rendered as `NOPASSWD: <cmd> *`, but `deployers/mixins.py:211` invokes `sudo -H -u <install_user> <install.command>` and appends nothing. sudo requires a trailing ` *` to match **at least one** further argument, so the rule never matched: the `sudo -u` install fallback has never been authorised for any project, and would have prompted for a password and failed non-interactively. The wildcard is gone.
+
+### How it was settled
+
+A fragment of exactly the rendered shape, installed and queried with `sudo -l` (which checks the policy and never executes), sudo 1.9.17p2:
+
+| rule `/usr/bin/true sync --frozen *` | query | result |
+|---|---|---|
+| the real invocation | `sync --frozen` | **NO MATCH** |
+| control — the wildcard has an argument to eat | `sync --frozen --offline` | MATCH |
+| negative controls | `build`, no args | NO MATCH |
+
+With the wildcard dropped, `sync --frozen` matches. Both controls behaving is what makes that readable as cause rather than coincidence. The fixed fragment was then re-probed the same way.
+
+### Notes for operators
+
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`** to pick this up. Until you do, the installed fragment keeps the old rule — which is not a regression, since that rule never authorised anything, but the fallback stays broken.
+- **This is a tightening, not a loosening.** The rule now authorises exactly the configured `install.command` and nothing else. If you were relying on the fragment to run the install command with *extra* arguments by hand (`sudo -u <user> uv sync --frozen --offline`), that stops working — deliberately. Nothing automated did so.
+- **The socket path was never affected.** For `install.user != deploy_user` the steady state is the install-helper socket, which does not use sudo at all (`deployers/mixins.py:177-184`). That is why this went unnoticed: the broken fallback only runs on a first bootstrap, before the socket unit exists.
+
+### Known limitations
+
+- **Only the dependency-install rules go through this template.** `_collect_deduplicated_sudoers_rules` (`renderer.py:350-397`) reads `install.command` and nothing else, so this fix says nothing about any other privilege fraisier grants.
+- **A second, permissive rule was deliberately not rendered.** Emitting both the exact and the wildcard form would preserve the ability to append arbitrary arguments under NOPASSWD; no caller in fraisier appends any, so that would be authorisation granted to nobody.
+- **Verified on sudo 1.9.17p2 only.** Argument matching has been stable across sudo releases for a long time, but the probe answered for one version. The behaviour it relies on — that ` *` needs something to match — is the documented shell-style wildcard semantics, not a version quirk.
+
 ## [0.50.1] - 2026-07-28
 
 Closes #292. Found while re-auditing the unit templates for #286 — not a cause

--- a/fraisier/scaffold/templates/core/sudoers.j2
+++ b/fraisier/scaffold/templates/core/sudoers.j2
@@ -7,7 +7,10 @@
 {% for rule in sudoers_rules %}
 # {{ rule.description }}
 # Environments: {{ rule.environments | join(', ') }}
-{{ rule.from_user }} ALL=({{ rule.as_user }}) NOPASSWD: {{ rule.cmd }} *
+{# No trailing wildcard: sudo requires a ` *` tail to match at least one further
+   argument, and the deploy path invokes install.command with no extra arguments
+   (deployers/mixins.py), so a wildcard rule never matched at all (#294). #}
+{{ rule.from_user }} ALL=({{ rule.as_user }}) NOPASSWD: {{ rule.cmd }}
 {% if not loop.last %}
 
 {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.50.1"
+version = "0.52.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -2974,7 +2974,9 @@ fraises:
 
         content = (tmp_path / "output" / "sudoers").read_text()
         assert "ALL=(myapp)" in content
-        assert "/home/myapp/.local/bin/uv sync --frozen *" in content
+        # No trailing wildcard — sudo requires ` *` to match at least one further
+        # argument, and the deploy path appends none (#294).
+        assert "/home/myapp/.local/bin/uv sync --frozen" in content
 
     def test_sudoers_omits_install_when_no_user(self, tmp_path):
         """Sudoers omits install rule when install.user is not set (#44)."""
@@ -3337,7 +3339,7 @@ fraises:
         body = content.split("# Dependency install rules (deduplicated)\n", 1)[1]
         rule_blocks = [b for b in body.split("/usr/bin/") if b]
         assert len(rule_blocks) >= 2, "expected both rules to render"
-        between = body.split("/usr/bin/apt-get install *", 1)[1]
+        between = body.split("/usr/bin/apt-get install", 1)[1]
         between = between.split("# Dependency install", 1)[0]
         assert "\n\n" in between, (
             "blank line between rules should be preserved for human-readability"

--- a/tests/test_sudoers_command_path.py
+++ b/tests/test_sudoers_command_path.py
@@ -212,3 +212,68 @@ class TestSudoersValidatedBeforeInstall:
         content = _render_install_sh(tmp_path)
 
         assert "File was not installed." in content
+
+
+class TestCmndArgumentsMatchTheInvocation:
+    """The rendered `Cmnd` must authorise the argv the deploy path builds (#294).
+
+    `sudoers.j2` used to append ` *` to every rule. Verified against sudo
+    1.9.17p2's own policy engine (`sudo -l`, which checks without executing): a
+    trailing ` *` requires *at least one* further argument, so a rule
+    `/usr/bin/uv sync --frozen *` does **not** match an invocation of
+    `/usr/bin/uv sync --frozen`. `mixins.py:211` appends nothing after
+    `install.command`, so the rule never authorised the `sudo -u` fallback.
+    """
+
+    def test_no_trailing_wildcard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+
+        assert not _cmnd_line(content).rstrip().endswith(" *")
+
+    def test_argument_tail_is_exactly_the_configured_command(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+
+        authorised = _cmnd_line(content).split("NOPASSWD:", 1)[1].strip()
+        assert authorised == "/usr/local/bin/uv sync --frozen"
+
+    def test_authorised_cmnd_equals_what_the_deployer_hands_to_sudo(
+        self, tmp_path, monkeypatch
+    ):
+        """The drift guard: render and invoke from the same `install:` block.
+
+        Nothing previously tied the two sides together — `grep NOPASSWD tests/`
+        hit only synthetic strings — which is how #294 survived.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from fraisier.deployers.api import APIDeployer
+
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+        authorised = _cmnd_line(content).split("NOPASSWD:", 1)[1].strip()
+
+        deployer = APIDeployer(
+            {
+                "app_path": "/var/www/prod",
+                "install": {"command": ["uv", "sync", "--frozen"], "user": "appuser"},
+            }
+        )
+        deployer.runner = MagicMock()
+        with patch(
+            "fraisier.deployers.mixins.shutil.which", return_value="/usr/local/bin/uv"
+        ):
+            deployer._install_dependencies()
+
+        argv = deployer.runner.run.call_args[0][0]
+        assert argv[:4] == ["sudo", "-H", "-u", "appuser"]
+        assert " ".join(argv[4:]) == authorised

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.50.1"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #294.

The issue was filed explicitly unverified — it needed `sudo -l` on a real box. It has now been settled against sudo's own policy engine, and it was right.

## How it was settled

`cvtsudoers -m cmnd=` was tried first and **cannot** answer this: its filter matches command *names*, not argument lists (a rule `NOPASSWD: /usr/bin/uv` matches `cmnd=/usr/bin/uv`; nothing with arguments matches anything). `testsudoers` is not installed by Arch's sudo package.

So the fragment was installed for real and queried with `sudo -l`, which checks the policy and **never executes** — syntax-checked with `visudo -cf` before installing, granting `nobody` the right to run `/usr/bin/true` as `nobody`, removed and re-validated afterwards. sudo 1.9.17p2:

| rule `/usr/bin/true sync --frozen *` — exactly the rendered shape | query | result |
|---|---|---|
| **the real invocation** | `sync --frozen` | **NO MATCH** |
| control — the wildcard has an argument to eat | `sync --frozen --offline` | MATCH |
| negative control | `build` | NO MATCH |
| negative control | *(no args)* | NO MATCH |
| same rule, wildcard dropped | `sync --frozen` | **MATCH** |

Both controls behaving is what makes this readable as cause rather than coincidence. A trailing ` *` requires **at least one** further argument; `deployers/mixins.py:211` appends none.

**Consequence:** the `sudo -u` install fallback has never been authorised for any project. It would have prompted for a password and failed non-interactively.

## Why nobody noticed

For `install.user != deploy_user` the steady state is the install-helper socket, which does not use sudo at all (`deployers/mixins.py:177-184`). The broken fallback only runs on a first bootstrap, before the socket unit exists — exactly as the issue predicted.

## The fix

Drop the wildcard. Verified again after the change, against **the fragment fraisier actually renders** rather than a hand-written approximation:

```
nobody ALL=(nobody) NOPASSWD: /usr/bin/true sync --frozen

  MATCH     /usr/bin/true sync --frozen        <- the deploy path's exact invocation
  NO MATCH  /usr/bin/true sync --frozen --oops <- not authorised any more
  NO MATCH  /usr/bin/true build                <- negative control
```

Plus a **drift guard**: a test that renders the fragment and drives `_install_dependencies` from the same `install:` block, asserting the authorised `Cmnd` equals the argv handed to sudo. Nothing previously tied the two sides together — `grep NOPASSWD tests/` hit only synthetic strings, which is how this survived.

## Scope and the road not taken

- **Blast radius is the install rule only.** `_collect_deduplicated_sudoers_rules` (`renderer.py:350-397`) reads `install.command` and nothing else — no systemctl, nginx or database rule goes through this template. Nothing can break by narrowing a rule that never matched.
- **A second permissive rule was deliberately not rendered.** The issue offered that as an alternative. It would authorise arbitrary extra arguments to the install command under NOPASSWD, for a caller that does not exist. The narrow rule is both the fix and a tightening.

## What this does not fix

- **Operators must re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`.** Until then the installed fragment keeps the old rule. Not a regression — that rule authorised nothing — but the fallback stays broken.
- **Manual convenience is removed, deliberately.** If you ran `sudo -u <user> uv sync --frozen --offline` by hand and relied on the fragment, that stops working. Nothing automated did.
- **Verified on sudo 1.9.17p2 only.** The behaviour relied on is documented shell-style wildcard semantics, not a version quirk, but the probe answered for one version.

## Verification

- 4405 passed, 7 skipped, 1 deselected (+3 collected, all new)
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27
- All 3 new tests confirmed failing before the fix

## Merge note

Numbered **0.52.0** assuming PR #300 (v0.51.0, #284) lands first. The branches touch disjoint files; if #300 is not merged first this needs only a version-line rebase.

Two commits, kept separate so each is `git revert`-able — **rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)