### PR TITLE
release: v0.54.0 — sweep __pycache__ by owner, and correct v0.50.1's claim (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-07-29
+
+Closes #303. Found by auditing v0.48.0's sweep widening, not from a report —
+and it corrects a claim made in v0.50.1's own release notes.
+
+### Fixed
+
+- **Stale `__pycache__` sweeps now match any foreign owner, not just root** (`core/install.sh.j2`, #303). v0.48.0 widened the owner filter for the *new* uv-tool sweep only; the app-venv and `~/.local/lib` sweeps kept `-user root`. Residue written by `service.user` — an identity independent of both `deploy_user` and `install.user`, i.e. exactly the #292 failure class — therefore survived every sweep. Nothing else cleared it: the manifest ownership preflight stats the venv *directory*, whose owner does not change when a third user writes nested `__pycache__`. The app-venv sweep now targets the identity that actually owns that venv (`install.user`, falling back to `deploy_user`).
+- **The remediation advice no longer hands you a command that cannot work** (`deployers/mixins.py`, `install_helper.py`, #303). Both `Permission denied` advice strings hardcoded `find … -user root`. The writer can be `service.user` (#292) or `install.user` (#286) — neither is root — so an operator hitting this exact error was told to run something that would match nothing. Both now resolve the venv's owner at paste time with `stat -c %U`.
+
+### Corrected
+
+- **v0.50.1's release notes claimed existing residue was already cleared by the sweep.** It was not, for the residue that entry is about. The v0.50.1 entry above now carries a correction pointing here. On v0.50.1–v0.53.0 that residue must be cleared by hand:
+  ```sh
+  sudo find <app_path>/.venv -name __pycache__ ! -user "$(stat -c %U <app_path>/.venv)" -type d -exec rm -rf {} +
+  ```
+
+### Notes for operators
+
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`** to install the corrected sweeps. They then self-heal at every subsequent `scaffold-install`.
+- **The sweep deletes more than before, by design.** Anything under a swept tree not owned by that tree's owner goes. `__pycache__` is regenerated on the next import, so the cost is one recompile.
+- The boundedness and privilege guards from v0.48.0 are unchanged: still `-name "__pycache__" -type d` only — never a bare `rm -rf` on a computed path — still under `sudo` via `_run`, so `--dry-run` and `--validate-only` still delete nothing.
+
+### Known limitations
+
+- **This clears residue; it does not stop every writer.** v0.50.1 stopped the app unit writing into its venv, and the helper units have set `PYTHONDONTWRITEBYTECODE=1` since v0.6.0. A process invoked outside systemd (a manual `sudo -u <user> …` while debugging) is still unconstrained — which remains the leading candidate for #286's residue, and is why #286 was closed without a code cause being found.
+- **The sweep runs at `scaffold-install` time only.** Residue created between installs sits until the next one.
+- **`~/.local/lib` and the uv tool dir are swept against `deploy_user`, not against their own `stat`.** Both are that user's trees by construction; if you have relocated either, the filter is still right but for a weaker reason.
+
 ## [0.50.1] - 2026-07-28
 
 Closes #292. Found while re-auditing the unit templates for #286 — not a cause
@@ -21,6 +50,7 @@ of #286, whose residue is elsewhere.
 - **This costs startup time, deliberately.** `--compile-bytecode` is used nowhere, so the venv has never been precompiled at install time; with bytecode writing off, every start recompiles site-packages *and* your app modules. On a `Restart=on-failure` unit that starts rarely this is the right trade against an un-cleanable venv, but it is a real cost on a large codebase.
 - **It is overridable.** The directive is emitted *before* the `service.environment` loop, and systemd resolves a repeated `Environment=` assignment last-wins, so `service.environment: {PYTHONDONTWRITEBYTECODE: "0"}` restores the old behaviour if you measure the cost and decide against it.
 - Re-run `fraisier scaffold` and reinstall the unit to pick this up; an already-running service keeps its current environment until restarted. Existing `__pycache__` residue is cleared by the stale-cache sweep at `scaffold-install` time, as it was in v0.48.0.
+  - **Correction (v0.54.0, #303):** that last sentence was wrong. The app-venv sweep filtered `-user root` only, so `service.user`-owned residue — exactly what this entry is about — survived it. Fixed in v0.54.0; on v0.50.1–v0.53.0 the residue must be cleared by hand.
 
 ### Known limitations
 

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -50,9 +50,13 @@ def _install_failure_advice(
     """
     if "__pycache__" in stderr and "Permission denied" in stderr:
         return (
-            "Root-owned __pycache__ directories are blocking uv sync."
+            "Foreign-owned __pycache__ directories are blocking uv sync."
+            # Not `-user root`: the writer can be service.user (#292) or
+            # install.user (#286). Resolve the venv's owner at paste time so
+            # the command is right whichever identity actually owns it (#303).
             f" Fix: sudo find {app_path}/.venv -name __pycache__"
-            " -user root -type d -exec rm -rf {} +"
+            f' ! -user "$(stat -c %U {app_path}/.venv)"'
+            " -type d -exec rm -rf {} +"
             " then retry the deployment."
             " The venv may be corrupted — run uv sync --frozen"
             " manually after cleanup."

--- a/fraisier/install_helper.py
+++ b/fraisier/install_helper.py
@@ -158,9 +158,13 @@ def _handle_connection(conn: socket.socket, allowed_command: list[str]) -> None:
                 result.stderr.strip(),
             )
             if "__pycache__" in result.stderr and "Permission denied" in result.stderr:
+                # Not `-user root`: the writer can be service.user (#292) or
+                # install.user (#286). Resolve the venv's owner at paste time
+                # so the command is right whichever identity owns it (#303).
                 response["advice"] = (
-                    "Root-owned __pycache__ directories are blocking uv sync. "
-                    f"Fix: sudo find {cwd}/.venv -name __pycache__ -user root "
+                    "Foreign-owned __pycache__ directories are blocking uv sync. "
+                    f"Fix: sudo find {cwd}/.venv -name __pycache__ "
+                    f'! -user "$(stat -c %U {cwd}/.venv)" '
                     "-type d -exec rm -rf {{}} + then retry the deployment. "
                     "The venv may be corrupted — run uv sync --frozen manually "
                     "after cleanup. See: https://github.com/fraiseql/fraisier/issues/196"

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -236,10 +236,14 @@ fi
 {% endfor %}
 
 # Clean up stray __pycache__ dirs that block uv sync / uv tool install (#196, #286)
-# A process running as another user (root, or an install_user helper) can leave
-# byte-compiled files inside a directory the deploy user owns, and the deploy
-# user cannot unlink them — breaking the next `uv sync --frozen` or
-# `uv tool install --force`.
+# A process running as another user can leave byte-compiled files inside a
+# directory a different user owns, and that owner cannot unlink them — breaking
+# the next `uv sync --frozen` or `uv tool install --force`.
+#
+# Every sweep matches "not owned by the identity that owns this tree" rather
+# than `-user root` (#303). Root is not the only writer: `service.user` — an
+# identity independent of both deploy_user and install.user — writes into the
+# app venv, which is the #292 failure class and what `-user root` missed.
 #
 # These run under sudo deliberately: the whole point is removing files owned by
 # *another* user, which an unprivileged find cannot do (the failure would be
@@ -249,14 +253,16 @@ echo "  Cleaning stray __pycache__ directories"
 {% for fraise in local_fraises %}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% set app_path = env_config.get('app_path') %}
+{% set install_cfg = env_config.get('install') or fraise.get('install') or {} %}
+{% set venv_owner = install_cfg.get('user') %}
 {% if app_path %}
 if _env_active "{{ env_name }}"; then
-    _run sudo find "{{ app_path }}/.venv" -name "__pycache__" -user root -type d -exec rm -rf {} + || true
+    _run sudo find "{{ app_path }}/.venv" -name "__pycache__" ! -user "{{ venv_owner if venv_owner else '${DEPLOY_USER}' }}" -type d -exec rm -rf {} + || true
 fi
 {% endif %}
 {% endfor %}
 {% endfor %}
-_run sudo find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" -user root -type d -exec rm -rf {} + || true
+_run sudo find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" ! -user "${DEPLOY_USER}" -type d -exec rm -rf {} + || true
 # uv installs tools under XDG_DATA_HOME, not ~/.local/lib — the sweep above never
 # reached the tool venv. Match any foreign owner here, not just root: the residue
 # reported in #286 is install_user-owned (the helper runs as install_user but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.50.1"
+version = "0.54.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_pycache_diagnostics.py
+++ b/tests/test_pycache_diagnostics.py
@@ -366,3 +366,48 @@ class TestIntegrationPycacheAdvice:
         # Socket path never shells out to sudo, so it must not suggest sudo -H.
         assert "sudo -H" not in msg
         assert "276" not in msg
+
+
+class TestAdviceMatchesTheSweep:
+    """The remediation must fix the failure it is shown for (#303).
+
+    Both advice strings hardcoded ``-user root``. The residue that produces
+    this exact ``Permission denied`` can be owned by ``service.user`` (#292) or
+    ``install.user`` (#286) — neither is root, so the suggested command was a
+    no-op for the cases most likely to hit it.
+    """
+
+    def test_deployer_advice_does_not_assume_root(self):
+        from fraisier.deployers.mixins import _install_failure_advice
+
+        advice = _install_failure_advice(
+            "error: Permission denied ... __pycache__ ...", app_path="/var/www/api"
+        )
+
+        assert advice is not None
+        assert "-user root" not in advice
+        assert "! -user" in advice
+        assert "stat -c %U" in advice
+
+    def test_deployer_advice_still_names_the_venv(self):
+        from fraisier.deployers.mixins import _install_failure_advice
+
+        advice = _install_failure_advice(
+            "error: Permission denied ... __pycache__ ...", app_path="/var/www/api"
+        )
+
+        assert advice is not None
+        assert "/var/www/api/.venv" in advice
+
+    def test_helper_advice_does_not_assume_root(self):
+        """The socket helper's advice reaches the operator through the deployer."""
+        import inspect
+
+        from fraisier import install_helper
+
+        source = inspect.getsource(install_helper._handle_connection)
+        pycache_advice = source.split("__pycache__ directories are blocking", 1)[1]
+        pycache_advice = pycache_advice.split("issues/196", 1)[0]
+
+        assert "-user root" not in pycache_advice
+        assert "! -user" in pycache_advice

--- a/tests/test_pycache_install_sh.py
+++ b/tests/test_pycache_install_sh.py
@@ -41,8 +41,8 @@ scaffold:
 """,
         )
         assert (
-            'find "/var/www/api/.venv" -name "__pycache__" -user root -type d'
-            in content
+            'find "/var/www/api/.venv" -name "__pycache__" ! -user "${DEPLOY_USER}"'
+            " -type d" in content
         )
 
     def test_cleanup_targets_deploy_user_local_lib(self, tmp_path):
@@ -68,8 +68,8 @@ scaffold:
 """,
         )
         assert (
-            'find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" -user root -type d'
-            in content
+            'find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__"'
+            ' ! -user "${DEPLOY_USER}" -type d' in content
         )
 
     def test_no_cleanup_when_no_app_path(self, tmp_path):
@@ -96,7 +96,7 @@ scaffold:
         )
         # Should not have any app venv cleanup (no app_path)
         assert (
-            '__pycache__" -user root' in content
+            '__pycache__" ! -user "${DEPLOY_USER}"' in content
         )  # deploy user lib cleanup still present
         # But no /var/www or app-specific venv path
         assert ".venv" not in content or "/home/${DEPLOY_USER}" in content
@@ -261,3 +261,105 @@ class TestSweepsArePrivilegedAndDryRunSafe:
 
         assert "/var/www/api/.venv" in joined
         assert "/home/${DEPLOY_USER}/.local/lib" in joined
+
+
+_SPLIT_USER_YAML = """\
+name: testapp
+servers:
+  prod.example.com:
+    machine_hostnames: [prod-01]
+
+fraises:
+  api:
+    type: api
+    install:
+      user: installer
+      command: [/usr/bin/uv, sync, --frozen]
+    environments:
+      production:
+        server: prod.example.com
+        app_path: /var/www/api
+        service:
+          user: appsvc
+          exec: /var/www/api/.venv/bin/uvicorn app:app
+          port: 8000
+
+scaffold:
+  deploy_user: testapp_deploy
+"""
+
+
+def _render(tmp_path, yaml_content: str) -> str:
+    config_file = tmp_path / "fraises.yaml"
+    config_file.write_text(yaml_content)
+    renderer = ScaffoldRenderer(FraisierConfig(str(config_file)))
+    return renderer.env.get_template("core/install.sh.j2").render(**renderer.context)
+
+
+def _sweep_line(content: str, needle: str) -> str:
+    return next(
+        ln
+        for ln in content.splitlines()
+        if needle in ln and "find" in ln and not ln.strip().startswith("#")
+    )
+
+
+class TestSweepsMatchAnyForeignOwner:
+    """`-user root` misses the identity #292 is about (#303).
+
+    `c34a6b6` widened the owner filter for the new uv-tool sweep only. The app
+    venv and `.local/lib` sweeps kept `-user root`, so residue written by
+    `service.user` — an identity independent of both `deploy_user` and
+    `install.user` — survives every sweep. Nothing else clears it:
+    `_verify_manifest_ownership` stats the venv *directory*, whose owner does
+    not change when a third user writes nested `__pycache__`.
+    """
+
+    def test_app_venv_sweep_targets_the_venv_owner(self, tmp_path):
+        """The venv belongs to install.user, so anything else in it is foreign."""
+        line = _sweep_line(_render(tmp_path, _SPLIT_USER_YAML), "/var/www/api/.venv")
+
+        assert '! -user "installer"' in line
+        assert "-user root" not in line
+
+    def test_app_venv_sweep_falls_back_to_deploy_user(self, tmp_path):
+        """No install.user configured → the deploy user owns the venv."""
+        line = _sweep_line(_render(tmp_path, _UV_TOOL_YAML), "/var/www/api/.venv")
+
+        assert '! -user "${DEPLOY_USER}"' in line
+        assert "-user root" not in line
+
+    def test_local_lib_sweep_matches_any_foreign_owner(self, tmp_path):
+        """The deploy user owns ~/.local/lib; any other owner is residue."""
+        line = _sweep_line(_render(tmp_path, _SPLIT_USER_YAML), ".local/lib")
+
+        assert '! -user "${DEPLOY_USER}"' in line
+        assert "-user root" not in line
+
+    def test_no_sweep_still_filters_on_root_alone(self, tmp_path):
+        """The whole point: root is no longer the only writer we clean up after."""
+        content = _render(tmp_path, _SPLIT_USER_YAML)
+
+        sweeps = [
+            ln
+            for ln in content.splitlines()
+            if "__pycache__" in ln and "find" in ln and not ln.strip().startswith("#")
+        ]
+        assert len(sweeps) == 3
+        for line in sweeps:
+            assert "-user root" not in line, line.strip()
+
+    def test_sweeps_stay_bounded_and_privileged(self, tmp_path):
+        """Widening the owner filter must not relax the other guards."""
+        content = _render(tmp_path, _SPLIT_USER_YAML)
+
+        sweeps = [
+            ln
+            for ln in content.splitlines()
+            if "__pycache__" in ln and "find" in ln and not ln.strip().startswith("#")
+        ]
+        for line in sweeps:
+            assert '-name "__pycache__"' in line
+            assert "-type d" in line
+            assert "sudo find" in line
+            assert line.strip().startswith("_run ")

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.50.1"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #303.

Found by auditing `c34a6b6` (v0.48.0's sweep widening) while checking whether #286 was safe to leave closed — not from a report. It also **corrects a claim I made in v0.50.1's own release notes**.

## The gap

`c34a6b6` widened the owner filter for the **new** uv-tool sweep only. The two pre-existing sweeps kept `-user root`. Verified in the rendered artifact, not the template:

```
224: … find "/var/www/demo/.venv"             -name "__pycache__" -user root                …
226: … find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" -user root                …
231: … find "…/.local/share/uv/tools"         -name "__pycache__" ! -user "${DEPLOY_USER}"  …
```

So residue written by `service.user` — an identity independent of both `deploy_user` and `install.user`, i.e. **exactly the #292 failure class** — survived every sweep. Nothing else clears it: `_verify_manifest_ownership` stats the venv *directory* (`manifest.py:231-248`), whose owner does not change when a third user writes nested `__pycache__`.

## Demonstrated, not asserted

A venv holding one owner-written and one third-identity `__pycache__`:

```
before:            lionel  …/pkg_a/__pycache__
                   nobody  …/pkg_b/__pycache__
old (-user root):  lionel  …/pkg_a/__pycache__     <- removed NEITHER
                   nobody  …/pkg_b/__pycache__
new (! -user …):   lionel  …/pkg_a/__pycache__     <- foreign gone, owner's spared
```

## Changes

- **App-venv sweep targets the venv's actual owner** — `! -user "<install.user>"`, falling back to `${DEPLOY_USER}`. Using `! -user "${DEPLOY_USER}"` everywhere (mirroring the uv-tool sweep) would also delete the *install* user's legitimate caches whenever the two differ: harmless, since they regenerate, but it makes the sweep's intent unreadable. The template already resolves the identity in the same loop, so precision is free. Verified per-env in the generated artifact: `installer` for the fraise that sets `install.user`, `${DEPLOY_USER}` for the one that doesn't.
- **`~/.local/lib` sweep** matches any owner other than the deploy user, who owns that tree.
- **Both advice strings** resolve the venv's owner with `stat -c %U` instead of hardcoding `-user root`, and no longer claim the writer must be root. An operator hitting this exact `Permission denied` was being handed a command that could not fix it.

The boundedness, privilege and dry-run guards from `c34a6b6` are unchanged and re-pinned by tests: still `-name "__pycache__" -type d`, still `_run sudo`.

## The correction

v0.50.1's notes said:

> Existing `__pycache__` residue is cleared by the stale-cache sweep at `scaffold-install` time, as it was in v0.48.0.

For the residue that entry is about, it was not. That line is mine. The v0.50.1 entry now carries an inline correction naming the affected versions (v0.50.1–v0.53.0) and the manual command, so a reader of *that* entry sees it — rather than silently rewriting it.

## What this does not fix

- **It clears residue; it does not stop every writer.** v0.50.1 stopped the app unit, and the helper units have set `PYTHONDONTWRITEBYTECODE=1` since v0.6.0. A process invoked *outside* systemd (a manual `sudo -u <user> …` while debugging) is still unconstrained — which remains the leading candidate for #286's residue, and is why #286 closed without a code cause being found.
- **The sweep runs at `scaffold-install` time only.** Residue created between installs sits until the next one.
- **`~/.local/lib` and the uv tool dir are swept against `deploy_user`, not their own `stat`.** Both are that user's trees by construction; the filter is right, but for a weaker reason than the app-venv one.
- **The sweep now deletes more than before, by design.** Anything under a swept tree not owned by that tree's owner goes; the cost is one recompile.

## Verification

- 4410 passed, 7 skipped, 1 deselected (+8 collected, all new; 6 confirmed failing before the fix, the other 2 pin guards that must survive the widening)
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27
- Rendered `install.sh` passes `bash -n`
- Sweep predicate verified functionally against real foreign-owned files (above)

## Merge note

Numbered **0.54.0** assuming PRs #300 (v0.51.0), #301 (v0.52.0) and #302 (v0.53.0) land first. All four touch disjoint files; out-of-order merges need only a version-line rebase.

Two commits, kept separate so each is `git revert`-able — **rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)