### PR TITLE
release: v0.52.0 — sudoers, setup state_dir, rollback status, __pycache__ sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-07-29
+
+Four fixes that had been carried as separate branches, released together.
+Closes #284, #294, #296, #303. **Read the compatibility note first** — #296
+changes the status reported by nearly every failed deployment.
+
+### ⚠️ Compatibility — deployment status
+
+A failed deploy that reverted the working tree and restarted the service now reports **`rolled_back`** where it previously reported **`failed`** (#296). Most deploy failures on a box with history fall into this case: the automatic restore git-reverts on *every* failure that has a previous SHA, migrations or not.
+
+- **Alerting that tests `state == "failed"` will stop seeing most failed deploys.** Test membership in `status.FAILURE_STATES` (`{failed, rolled_back, rollback_failed}`) instead — that set exists for exactly this reason and has since v0.49.0.
+- **Deployment-history stats shift too.** A `rolled_back` result is mapped onto `mark_deployment_rolled_back`, so `fraisier ops` shows these under "Rolled back" rather than "Failed". The deploy is still recorded as unsuccessful.
+- Nothing inside fraisier needed changing: `cli/_info.py`, `cli/ops.py`, `notifications/base.py` and the webhook already handle `rolled_back`.
+
+### Fixed
+
+- **The generated sudoers rule now authorises the command the deploy actually runs** (`core/sudoers.j2`, #294). Every rule was rendered as `NOPASSWD: <cmd> *`, but the deploy invokes `sudo -H -u <install_user> <install.command>` and appends nothing. sudo requires a trailing ` *` to match **at least one** further argument, so the rule never matched: the `sudo -u` install fallback has never been authorised for any project, and would have prompted for a password and failed non-interactively. Settled against sudo's own policy engine (1.9.17p2) with `sudo -l`, which checks the policy without executing — the real invocation reported NO MATCH while a control with a trailing argument matched. The wildcard is gone.
+- **`fraisier setup` now populates `scaffold.state_dir`** (`setup.py`, #284). After a bare `setup`, `{state_dir}/install.sh` did not exist. That exact path is baked into the scaffold-install-helper unit as its `ExecStart` argument, and the helper daemon exits 1 at startup when it is missing — so the socket never came up and every deploy silently fell back to the slower subprocess install path, until the first config-changing deploy regenerated the tree. Same silent-degradation class #283 closed for `bootstrap`, narrowed to the manual-`setup`-without-a-deploy window.
+- **Stale `__pycache__` sweeps now match any foreign owner, not just root** (`core/install.sh.j2`, #303). v0.48.0 widened the owner filter for the *new* uv-tool sweep only; the app-venv and `~/.local/lib` sweeps kept `-user root`. Residue written by `service.user` — an identity independent of both `deploy_user` and `install.user`, i.e. exactly the #292 failure class — therefore survived every sweep. The app-venv sweep now targets the identity that actually owns that venv (`install.user`, falling back to `deploy_user`).
+- **The `__pycache__` remediation advice no longer hands you a command that cannot work** (`deployers/mixins.py`, `install_helper.py`, #303). Both `Permission denied` advice strings hardcoded `find … -user root`. The writer can be `service.user` (#292) or `install.user` (#286) — neither is root — so an operator hitting this exact error was told to run something that would match nothing. Both now resolve the venv's owner at paste time with `stat -c %U`.
+
+### Changed
+
+- **A git-only revert reports `ROLLED_BACK`** (`deployers/api.py`, #296). It is what actually happened: the tree is back on the previous commit and the service is running it. Reporting `FAILED` left an operator unable to tell that from an undefined half-deployed state — the same ambiguity #293 closed on the database axis, on the axis #293 deliberately left open. The status message names what was restored and does not mention the database when no migrations ran.
+- `fraisier setup --dry-run` lists two new actions under a `scaffold` category: the copy into `state_dir` and the recursive chown of the result. No existing action changed.
+- `/var/lib/fraisier/<project>/scaffold` is now created and owned by `deploy_user` by `setup`, matching what `bootstrap` already did.
+
+### Docs
+
+- **The two provisioning flows differ on purpose, and that is now written down** (`docs/deployment-guide.md`, `docs/cli-reference.md`, #284). A table contrasting `output_dir` (what you render and review) with `state_dir` (what the machine reads at deploy time), why `setup` writes both while `bootstrap` writes only the second, and a pointer from `setup` to `bootstrap` for fresh servers.
+
+### Corrected
+
+- **v0.50.1's release notes claimed existing `__pycache__` residue was already cleared by the sweep.** It was not, for the residue that entry is about. The v0.50.1 entry below now carries a correction pointing here. On v0.50.1 that residue must be cleared by hand:
+  ```sh
+  sudo find <app_path>/.venv -name __pycache__ ! -user "$(stat -c %U <app_path>/.venv)" -type d -exec rm -rf {} +
+  ```
+
+### Notes for operators
+
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`** on every host. This release changes three generated artifacts — the sudoers fragment, `install.sh`'s sweeps, and (via `setup`) the scaffold state tree. Until you do, the installed copies keep the old behaviour.
+- **The sudoers change is a tightening.** The rule now authorises exactly the configured `install.command` and nothing else. If you ran `sudo -u <user> uv sync --frozen --offline` by hand and relied on the fragment, that stops working — deliberately. Nothing automated did.
+- **`fraisier setup` still installs from `output_dir`.** The render → `git diff` → install loop that makes it the manual flow is unchanged; `state_dir` is added as what the machine consumes, not substituted as what you install from.
+- **The webhook env file is deliberately excluded from the `state_dir` copy.** It carries `FRAISIER_WEBHOOK_SECRET`, its only install target is `/etc/fraisier/<project>.webhook.env` at mode `0640`, and `state_dir` is world-readable.
+- **A revert that itself failed still reports `FAILED`, deliberately.** `ROLLBACK_FAILED` means "the schema may be half-migrated, do not restart the service"; that is false when no migrations ever ran.
+
+### Known limitations
+
+- **#294 was verified on sudo 1.9.17p2 only.** The behaviour relied on is documented shell-style wildcard semantics, not a version quirk, but the probe answered for one version. A second, permissive rule was deliberately **not** rendered: it would authorise arbitrary extra arguments under NOPASSWD, for a caller that does not exist.
+- **`setup` still installs from `output_dir`, so the trees can diverge** (#284). Hand-edit something under `state_dir` and the next `setup` overwrites it. The copy is also unconditional, not a sync — files present in `state_dir` with no counterpart in `output_dir` survive it, and nothing prunes `state_dir`.
+- **Only the automatic post-failure restore changed** (#296). The explicit `rollback()` entry point already reported `ROLLED_BACK` in `ETLDeployer` and `ScheduledDeployer`; the timeout path builds its own result and is untouched. `fraisier status` still cannot distinguish a database rollback from a git-only revert — both write `rolled_back`, and only the message differs.
+- **The sweep clears residue; it does not stop every writer** (#303). A process invoked *outside* systemd (a manual `sudo -u <user> …` while debugging) is still unconstrained — the leading candidate for #286's residue, and why #286 closed without a code cause being found. The sweep also runs at `scaffold-install` time only.
+
 ## [0.50.1] - 2026-07-28
 
 Closes #292. Found while re-auditing the unit templates for #286 — not a cause
@@ -21,6 +74,7 @@ of #286, whose residue is elsewhere.
 - **This costs startup time, deliberately.** `--compile-bytecode` is used nowhere, so the venv has never been precompiled at install time; with bytecode writing off, every start recompiles site-packages *and* your app modules. On a `Restart=on-failure` unit that starts rarely this is the right trade against an un-cleanable venv, but it is a real cost on a large codebase.
 - **It is overridable.** The directive is emitted *before* the `service.environment` loop, and systemd resolves a repeated `Environment=` assignment last-wins, so `service.environment: {PYTHONDONTWRITEBYTECODE: "0"}` restores the old behaviour if you measure the cost and decide against it.
 - Re-run `fraisier scaffold` and reinstall the unit to pick this up; an already-running service keeps its current environment until restarted. Existing `__pycache__` residue is cleared by the stale-cache sweep at `scaffold-install` time, as it was in v0.48.0.
+  - **Correction (v0.52.0, #303):** that last sentence was wrong. The app-venv sweep filtered `-user root` only, so `service.user`-owned residue — exactly what this entry is about — survived it. Fixed in v0.52.0; on v0.50.1 the residue must be cleared by hand.
 
 ### Known limitations
 

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -31,14 +31,20 @@ class RestoreOutcome:
     which status to use, and — when the database rollback failed — the incident
     text, so it does not overwrite it with the original deploy error.
 
-    Only *database* rollbacks are described here. A git-only revert is not
-    reported as a rollback: ``_restore_previous_state`` git-reverts on every
-    failed deploy that has a previous SHA, so claiming one would change the
-    reported status of nearly every deployment failure.
+    Both axes are described: the database rollback and the git revert. #293
+    deliberately reported only the first, because promoting git-only reverts
+    changes the status of nearly every failed deploy — that compatibility call
+    was taken separately and is what #296 decided.
+
+    ``git_reverted`` and ``service_restarted`` are claimed only when the step
+    actually completed: a revert that raised leaves both false, because nothing
+    was restored.
     """
 
     db_rollback_attempted: bool = False
     db_rollback_succeeded: bool = False
+    git_reverted: bool = False
+    service_restarted: bool = False
     error_message: str | None = None
 
 
@@ -569,24 +575,37 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
     ) -> tuple[DeploymentStatus, str, str]:
         """Map a restore outcome onto (result status, status-file state, message).
 
-        Only a database rollback changes the reported status. A failed deploy
-        that was merely git-reverted stays ``FAILED``, as it always has —
-        promoting it would change the status of nearly every deployment
-        failure, which is a separate call from #293.
+        The database axis is checked first because it is the one that can leave
+        the schema dirty. A git-only revert is a real rollback and reports as
+        one (#296) — that changes the status of nearly every failed deploy on a
+        box with history, which is why it was decided separately from #293.
+
+        A revert that *raised* stays ``FAILED``, deliberately: it restored
+        nothing, and ``ROLLBACK_FAILED`` means "the schema may be half-migrated,
+        do not restart", which is false when no migrations ever ran.
         """
-        if not outcome.db_rollback_attempted:
-            return DeploymentStatus.FAILED, "failed", deploy_error
-        if outcome.db_rollback_succeeded:
+        if outcome.db_rollback_attempted:
+            if outcome.db_rollback_succeeded:
+                return (
+                    DeploymentStatus.ROLLED_BACK,
+                    "rolled_back",
+                    f"{deploy_error} — database rolled back to the previous state",
+                )
+            return (
+                DeploymentStatus.ROLLBACK_FAILED,
+                "rollback_failed",
+                outcome.error_message or deploy_error,
+            )
+        if outcome.git_reverted:
+            restored = "reverted to the previous commit"
+            if outcome.service_restarted:
+                restored += " and the service restarted on it"
             return (
                 DeploymentStatus.ROLLED_BACK,
                 "rolled_back",
-                f"{deploy_error} — database rolled back to the previous state",
+                f"{deploy_error} — {restored}",
             )
-        return (
-            DeploymentStatus.ROLLBACK_FAILED,
-            "rollback_failed",
-            outcome.error_message or deploy_error,
-        )
+        return DeploymentStatus.FAILED, "failed", deploy_error
 
     def _handle_timeout(
         self,
@@ -647,7 +666,8 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
                         error_message=db_result.error_message,
                     )
             self._git_rollback(self._previous_sha)
-            if self.systemd_service:
+            restarted = bool(self.systemd_service)
+            if restarted:
                 self._restart_service()
         except Exception as rollback_exc:
             logger.critical("Rollback after failure also failed: %s", rollback_exc)
@@ -658,6 +678,8 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         return RestoreOutcome(
             db_rollback_attempted=attempted,
             db_rollback_succeeded=attempted,
+            git_reverted=True,
+            service_restarted=restarted,
         )
 
     def _resolve_strategy(self) -> tuple[Any, Path, Path, str | None]:

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -50,9 +50,13 @@ def _install_failure_advice(
     """
     if "__pycache__" in stderr and "Permission denied" in stderr:
         return (
-            "Root-owned __pycache__ directories are blocking uv sync."
+            "Foreign-owned __pycache__ directories are blocking uv sync."
+            # Not `-user root`: the writer can be service.user (#292) or
+            # install.user (#286). Resolve the venv's owner at paste time so
+            # the command is right whichever identity actually owns it (#303).
             f" Fix: sudo find {app_path}/.venv -name __pycache__"
-            " -user root -type d -exec rm -rf {} +"
+            f' ! -user "$(stat -c %U {app_path}/.venv)"'
+            " -type d -exec rm -rf {} +"
             " then retry the deployment."
             " The venv may be corrupted — run uv sync --frozen"
             " manually after cleanup."

--- a/fraisier/install_helper.py
+++ b/fraisier/install_helper.py
@@ -158,9 +158,13 @@ def _handle_connection(conn: socket.socket, allowed_command: list[str]) -> None:
                 result.stderr.strip(),
             )
             if "__pycache__" in result.stderr and "Permission denied" in result.stderr:
+                # Not `-user root`: the writer can be service.user (#292) or
+                # install.user (#286). Resolve the venv's owner at paste time
+                # so the command is right whichever identity owns it (#303).
                 response["advice"] = (
-                    "Root-owned __pycache__ directories are blocking uv sync. "
-                    f"Fix: sudo find {cwd}/.venv -name __pycache__ -user root "
+                    "Foreign-owned __pycache__ directories are blocking uv sync. "
+                    f"Fix: sudo find {cwd}/.venv -name __pycache__ "
+                    f'! -user "$(stat -c %U {cwd}/.venv)" '
                     "-type d -exec rm -rf {{}} + then retry the deployment. "
                     "The venv may be corrupted — run uv sync --frozen manually "
                     "after cleanup. See: https://github.com/fraiseql/fraisier/issues/196"

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -236,10 +236,14 @@ fi
 {% endfor %}
 
 # Clean up stray __pycache__ dirs that block uv sync / uv tool install (#196, #286)
-# A process running as another user (root, or an install_user helper) can leave
-# byte-compiled files inside a directory the deploy user owns, and the deploy
-# user cannot unlink them — breaking the next `uv sync --frozen` or
-# `uv tool install --force`.
+# A process running as another user can leave byte-compiled files inside a
+# directory a different user owns, and that owner cannot unlink them — breaking
+# the next `uv sync --frozen` or `uv tool install --force`.
+#
+# Every sweep matches "not owned by the identity that owns this tree" rather
+# than `-user root` (#303). Root is not the only writer: `service.user` — an
+# identity independent of both deploy_user and install.user — writes into the
+# app venv, which is the #292 failure class and what `-user root` missed.
 #
 # These run under sudo deliberately: the whole point is removing files owned by
 # *another* user, which an unprivileged find cannot do (the failure would be
@@ -249,14 +253,16 @@ echo "  Cleaning stray __pycache__ directories"
 {% for fraise in local_fraises %}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% set app_path = env_config.get('app_path') %}
+{% set install_cfg = env_config.get('install') or fraise.get('install') or {} %}
+{% set venv_owner = install_cfg.get('user') %}
 {% if app_path %}
 if _env_active "{{ env_name }}"; then
-    _run sudo find "{{ app_path }}/.venv" -name "__pycache__" -user root -type d -exec rm -rf {} + || true
+    _run sudo find "{{ app_path }}/.venv" -name "__pycache__" ! -user "{{ venv_owner if venv_owner else '${DEPLOY_USER}' }}" -type d -exec rm -rf {} + || true
 fi
 {% endif %}
 {% endfor %}
 {% endfor %}
-_run sudo find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" -user root -type d -exec rm -rf {} + || true
+_run sudo find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" ! -user "${DEPLOY_USER}" -type d -exec rm -rf {} + || true
 # uv installs tools under XDG_DATA_HOME, not ~/.local/lib — the sweep above never
 # reached the tool venv. Match any foreign owner here, not just root: the residue
 # reported in #286 is install_user-owned (the helper runs as install_user but

--- a/fraisier/scaffold/templates/core/sudoers.j2
+++ b/fraisier/scaffold/templates/core/sudoers.j2
@@ -7,7 +7,10 @@
 {% for rule in sudoers_rules %}
 # {{ rule.description }}
 # Environments: {{ rule.environments | join(', ') }}
-{{ rule.from_user }} ALL=({{ rule.as_user }}) NOPASSWD: {{ rule.cmd }} *
+{# No trailing wildcard: sudo requires a ` *` tail to match at least one further
+   argument, and the deploy path invokes install.command with no extra arguments
+   (deployers/mixins.py), so a wildcard rule never matched at all (#294). #}
+{{ rule.from_user }} ALL=({{ rule.as_user }}) NOPASSWD: {{ rule.cmd }}
 {% if not loop.last %}
 
 {% endif %}

--- a/fraisier/setup.py
+++ b/fraisier/setup.py
@@ -58,6 +58,7 @@ class ServerSetup:
         actions: list[SetupAction] = []
         actions.extend(self._plan_users())
         actions.extend(self._plan_directories())
+        actions.extend(self._plan_scaffold_state())
         actions.extend(self._plan_app_permissions())
         actions.extend(self._plan_git_safe_directory())
         actions.extend(self._plan_symlinks())
@@ -147,6 +148,11 @@ class ServerSetup:
             ("/var/lib/fraisier", deploy_user),
             ("/var/lib/fraisier/repos", deploy_user),
             ("/var/lib/fraisier/status", deploy_user),
+            # The persistent scaffold state tree (#283) that the socket helper
+            # reads its baked install.sh from. Owned by deploy_user so
+            # deploy-time regeneration (which runs as that user) can refresh
+            # it — the same reason bootstrap chowns it (#284).
+            (self.config.scaffold_state_dir, deploy_user),
             ("/run/fraisier", deploy_user),
         ]
         root_dirs = [
@@ -172,6 +178,56 @@ class ServerSetup:
                     )
                 )
         return actions
+
+    def _plan_scaffold_state(self) -> list[SetupAction]:
+        """Persist the rendered tree into the server-side scaffold state tree.
+
+        ``fraisier setup`` renders into, and installs from, the CWD-relative
+        ``scaffold.output_dir`` — the tree the operator reviews before
+        installing.  The deploy path never looks there: it regenerates into,
+        installs from and staleness-checks ``scaffold_state_dir`` (#283), and
+        the scaffold-install-helper's baked ``allowed_script`` is
+        ``{state_dir}/install.sh``.  Left unpopulated, that helper exits at
+        startup and every deploy silently falls back to the subprocess install
+        path until the first config-changing deploy regenerates the tree (#284).
+
+        Copying rather than moving keeps ``output_dir`` as the review surface.
+        The webhook env file is excluded: it carries
+        ``FRAISIER_WEBHOOK_SECRET`` and belongs only at
+        ``/etc/fraisier/{project}.webhook.env`` (installed 0640 by
+        :meth:`_plan_env_files`), never in a world-readable state directory —
+        and the deploy path's renderer never writes it there either.
+        """
+        output_dir = shlex.quote(self.config.scaffold.output_dir)
+        state_dir = self.config.scaffold_state_dir
+        deploy_user = self.config.scaffold.deploy_user
+        env_file = f"fraisier-{self.config.project_name}.webhook.env"
+
+        quoted_state_dir = shlex.quote(state_dir)
+        secret_copy = shlex.quote(f"{state_dir}/{env_file}")
+        return [
+            SetupAction(
+                description=f"Persist rendered scaffold tree to {state_dir}",
+                command=[
+                    "sudo",
+                    "bash",
+                    "-c",
+                    f"cp -a {output_dir}/. {quoted_state_dir}/ && rm -f {secret_copy}",
+                ],
+                category="scaffold",
+            ),
+            SetupAction(
+                description=f"Set ownership of {state_dir} to {deploy_user}",
+                command=[
+                    "sudo",
+                    "chown",
+                    "-R",
+                    f"{deploy_user}:{deploy_user}",
+                    state_dir,
+                ],
+                category="scaffold",
+            ),
+        ]
 
     def _plan_app_permissions(self) -> list[SetupAction]:
         """Configure ownership when app_user differs from deploy_user."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.50.1"
+version = "0.52.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_pycache_diagnostics.py
+++ b/tests/test_pycache_diagnostics.py
@@ -366,3 +366,48 @@ class TestIntegrationPycacheAdvice:
         # Socket path never shells out to sudo, so it must not suggest sudo -H.
         assert "sudo -H" not in msg
         assert "276" not in msg
+
+
+class TestAdviceMatchesTheSweep:
+    """The remediation must fix the failure it is shown for (#303).
+
+    Both advice strings hardcoded ``-user root``. The residue that produces
+    this exact ``Permission denied`` can be owned by ``service.user`` (#292) or
+    ``install.user`` (#286) — neither is root, so the suggested command was a
+    no-op for the cases most likely to hit it.
+    """
+
+    def test_deployer_advice_does_not_assume_root(self):
+        from fraisier.deployers.mixins import _install_failure_advice
+
+        advice = _install_failure_advice(
+            "error: Permission denied ... __pycache__ ...", app_path="/var/www/api"
+        )
+
+        assert advice is not None
+        assert "-user root" not in advice
+        assert "! -user" in advice
+        assert "stat -c %U" in advice
+
+    def test_deployer_advice_still_names_the_venv(self):
+        from fraisier.deployers.mixins import _install_failure_advice
+
+        advice = _install_failure_advice(
+            "error: Permission denied ... __pycache__ ...", app_path="/var/www/api"
+        )
+
+        assert advice is not None
+        assert "/var/www/api/.venv" in advice
+
+    def test_helper_advice_does_not_assume_root(self):
+        """The socket helper's advice reaches the operator through the deployer."""
+        import inspect
+
+        from fraisier import install_helper
+
+        source = inspect.getsource(install_helper._handle_connection)
+        pycache_advice = source.split("__pycache__ directories are blocking", 1)[1]
+        pycache_advice = pycache_advice.split("issues/196", 1)[0]
+
+        assert "-user root" not in pycache_advice
+        assert "! -user" in pycache_advice

--- a/tests/test_pycache_install_sh.py
+++ b/tests/test_pycache_install_sh.py
@@ -41,8 +41,8 @@ scaffold:
 """,
         )
         assert (
-            'find "/var/www/api/.venv" -name "__pycache__" -user root -type d'
-            in content
+            'find "/var/www/api/.venv" -name "__pycache__" ! -user "${DEPLOY_USER}"'
+            " -type d" in content
         )
 
     def test_cleanup_targets_deploy_user_local_lib(self, tmp_path):
@@ -68,8 +68,8 @@ scaffold:
 """,
         )
         assert (
-            'find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__" -user root -type d'
-            in content
+            'find "/home/${DEPLOY_USER}/.local/lib" -name "__pycache__"'
+            ' ! -user "${DEPLOY_USER}" -type d' in content
         )
 
     def test_no_cleanup_when_no_app_path(self, tmp_path):
@@ -96,7 +96,7 @@ scaffold:
         )
         # Should not have any app venv cleanup (no app_path)
         assert (
-            '__pycache__" -user root' in content
+            '__pycache__" ! -user "${DEPLOY_USER}"' in content
         )  # deploy user lib cleanup still present
         # But no /var/www or app-specific venv path
         assert ".venv" not in content or "/home/${DEPLOY_USER}" in content
@@ -261,3 +261,105 @@ class TestSweepsArePrivilegedAndDryRunSafe:
 
         assert "/var/www/api/.venv" in joined
         assert "/home/${DEPLOY_USER}/.local/lib" in joined
+
+
+_SPLIT_USER_YAML = """\
+name: testapp
+servers:
+  prod.example.com:
+    machine_hostnames: [prod-01]
+
+fraises:
+  api:
+    type: api
+    install:
+      user: installer
+      command: [/usr/bin/uv, sync, --frozen]
+    environments:
+      production:
+        server: prod.example.com
+        app_path: /var/www/api
+        service:
+          user: appsvc
+          exec: /var/www/api/.venv/bin/uvicorn app:app
+          port: 8000
+
+scaffold:
+  deploy_user: testapp_deploy
+"""
+
+
+def _render(tmp_path, yaml_content: str) -> str:
+    config_file = tmp_path / "fraises.yaml"
+    config_file.write_text(yaml_content)
+    renderer = ScaffoldRenderer(FraisierConfig(str(config_file)))
+    return renderer.env.get_template("core/install.sh.j2").render(**renderer.context)
+
+
+def _sweep_line(content: str, needle: str) -> str:
+    return next(
+        ln
+        for ln in content.splitlines()
+        if needle in ln and "find" in ln and not ln.strip().startswith("#")
+    )
+
+
+class TestSweepsMatchAnyForeignOwner:
+    """`-user root` misses the identity #292 is about (#303).
+
+    `c34a6b6` widened the owner filter for the new uv-tool sweep only. The app
+    venv and `.local/lib` sweeps kept `-user root`, so residue written by
+    `service.user` — an identity independent of both `deploy_user` and
+    `install.user` — survives every sweep. Nothing else clears it:
+    `_verify_manifest_ownership` stats the venv *directory*, whose owner does
+    not change when a third user writes nested `__pycache__`.
+    """
+
+    def test_app_venv_sweep_targets_the_venv_owner(self, tmp_path):
+        """The venv belongs to install.user, so anything else in it is foreign."""
+        line = _sweep_line(_render(tmp_path, _SPLIT_USER_YAML), "/var/www/api/.venv")
+
+        assert '! -user "installer"' in line
+        assert "-user root" not in line
+
+    def test_app_venv_sweep_falls_back_to_deploy_user(self, tmp_path):
+        """No install.user configured → the deploy user owns the venv."""
+        line = _sweep_line(_render(tmp_path, _UV_TOOL_YAML), "/var/www/api/.venv")
+
+        assert '! -user "${DEPLOY_USER}"' in line
+        assert "-user root" not in line
+
+    def test_local_lib_sweep_matches_any_foreign_owner(self, tmp_path):
+        """The deploy user owns ~/.local/lib; any other owner is residue."""
+        line = _sweep_line(_render(tmp_path, _SPLIT_USER_YAML), ".local/lib")
+
+        assert '! -user "${DEPLOY_USER}"' in line
+        assert "-user root" not in line
+
+    def test_no_sweep_still_filters_on_root_alone(self, tmp_path):
+        """The whole point: root is no longer the only writer we clean up after."""
+        content = _render(tmp_path, _SPLIT_USER_YAML)
+
+        sweeps = [
+            ln
+            for ln in content.splitlines()
+            if "__pycache__" in ln and "find" in ln and not ln.strip().startswith("#")
+        ]
+        assert len(sweeps) == 3
+        for line in sweeps:
+            assert "-user root" not in line, line.strip()
+
+    def test_sweeps_stay_bounded_and_privileged(self, tmp_path):
+        """Widening the owner filter must not relax the other guards."""
+        content = _render(tmp_path, _SPLIT_USER_YAML)
+
+        sweeps = [
+            ln
+            for ln in content.splitlines()
+            if "__pycache__" in ln and "find" in ln and not ln.strip().startswith("#")
+        ]
+        for line in sweeps:
+            assert '-name "__pycache__"' in line
+            assert "-type d" in line
+            assert "sudo find" in line
+            assert line.strip().startswith("_run ")

--- a/tests/test_rollback_status_reporting.py
+++ b/tests/test_rollback_status_reporting.py
@@ -109,6 +109,57 @@ class TestRestoreOutcomeIsReported:
         assert outcome.db_rollback_attempted is False
         assert outcome.error_message is None
 
+    def test_git_only_restore_records_what_it_did(self, tmp_path):
+        """A git revert is a real restore and must be reported as one (#296)."""
+        deployer = _deployer(tmp_path)
+        deployer._previous_sha = "prev123"
+        deployer._migrations_applied = 0
+
+        outcome = _restore(deployer, None)
+
+        assert outcome.git_reverted is True
+        assert outcome.service_restarted is True
+
+    def test_no_previous_sha_reverts_nothing(self, tmp_path):
+        """Nothing to revert to, so nothing is claimed on the git axis either."""
+        deployer = _deployer(tmp_path)
+        deployer._previous_sha = None
+
+        outcome = _restore(deployer, None)
+
+        assert outcome.git_reverted is False
+        assert outcome.service_restarted is False
+
+    def test_service_restart_not_claimed_without_a_unit(self, tmp_path):
+        """No systemd_service configured → the tree moved, the service did not."""
+        deployer = _deployer(tmp_path, systemd_service=None)
+        deployer._previous_sha = "prev123"
+        deployer._migrations_applied = 0
+
+        outcome = _restore(deployer, None)
+
+        assert outcome.git_reverted is True
+        assert outcome.service_restarted is False
+
+    def test_raising_git_revert_is_not_reported_as_reverted(self, tmp_path):
+        """The revert blew up, so nothing was restored — do not claim it."""
+        deployer = _deployer(tmp_path)
+        deployer._previous_sha = "prev123"
+        deployer._migrations_applied = 0
+
+        with (
+            patch("subprocess.run"),
+            patch.object(
+                deployer, "_git_rollback", side_effect=RuntimeError("checkout failed")
+            ),
+            patch.object(deployer, "_restart_service"),
+            patch.object(deployer, "_write_incident"),
+        ):
+            outcome = deployer._restore_previous_state()
+
+        assert outcome.git_reverted is False
+        assert outcome.service_restarted is False
+
     def test_rollback_raising_is_reported_as_failure(self, tmp_path):
         """An exception mid-rollback must not read as a clean revert."""
         deployer = _deployer(tmp_path)
@@ -135,13 +186,26 @@ class TestRestoreOutcomeIsReported:
 class TestDeployReportsTheRollback:
     """The failure handler must map the outcome onto the deploy status."""
 
-    def _failing_deploy(self, deployer, rollback_result: StrategyResult | None):
+    def _failing_deploy(
+        self,
+        deployer,
+        rollback_result: StrategyResult | None,
+        *,
+        git_rollback_error: Exception | None = None,
+    ):
         """Drive execute() to failure at the git-pull step."""
         strategy = MagicMock()
         if rollback_result is not None:
             strategy.rollback.return_value = rollback_result
 
+        git_rollback = patch.object(deployer, "_git_rollback")
+        if git_rollback_error is not None:
+            git_rollback = patch.object(
+                deployer, "_git_rollback", side_effect=git_rollback_error
+            )
+
         with (
+            git_rollback,
             patch.object(
                 deployer, "_git_pull", side_effect=RuntimeError("pull exploded")
             ),
@@ -187,13 +251,15 @@ class TestDeployReportsTheRollback:
         assert result.success is False
         assert result.status == DeploymentStatus.ROLLBACK_FAILED
 
-    def test_git_only_failure_still_reports_failed(self, tmp_path):
-        """Blast-radius pin: no DB rollback attempted → status is unchanged.
+    def test_git_only_failure_reports_rolled_back(self, tmp_path):
+        """The blast-radius pin, inverted by an explicit decision (#296).
 
-        _restore_previous_state runs on every deploy failure that has a previous
-        SHA, git-reverting even when no migrations ran. Promoting those to
-        ROLLED_BACK would change the reported status of nearly every failed
-        deploy. Deliberately out of scope for #293 — see the phase README.
+        This test previously asserted FAILED, and existed so that changing it
+        would be a deliberate act rather than an accident. It is that act: a
+        deploy that reverted the tree and restarted the service on the old code
+        did roll back, and now says so. This changes the reported status of
+        nearly every failed deploy on a box with history — see the CHANGELOG's
+        compatibility note.
         """
         deployer = _deployer(tmp_path)
         deployer._previous_sha = "prev123"
@@ -201,10 +267,40 @@ class TestDeployReportsTheRollback:
 
         result = self._failing_deploy(deployer, None)
 
+        assert result.status == DeploymentStatus.ROLLED_BACK
+
+    def test_git_only_rollback_message_does_not_claim_a_database_rollback(
+        self, tmp_path
+    ):
+        """No migrations ran, so the message must not mention the database."""
+        deployer = _deployer(tmp_path)
+        deployer._previous_sha = "prev123"
+        deployer._migrations_applied = 0
+
+        result = self._failing_deploy(deployer, None)
+
+        assert "database" not in (result.error_message or "").lower()
+        assert "previous commit" in (result.error_message or "")
+
+    def test_failed_git_revert_reports_failed_not_rollback_failed(self, tmp_path):
+        """A revert that raised restored nothing — and the schema is clean.
+
+        ROLLBACK_FAILED means "the schema may be half-migrated, do not restart"
+        (``status.py``). That is false when no migrations ever ran, so a failed
+        git-only revert must not borrow it.
+        """
+        deployer = _deployer(tmp_path)
+        deployer._previous_sha = "prev123"
+        deployer._migrations_applied = 0
+
+        result = self._failing_deploy(
+            deployer, None, git_rollback_error=RuntimeError("checkout failed")
+        )
+
         assert result.status == DeploymentStatus.FAILED
 
     def test_no_previous_sha_still_reports_failed(self, tmp_path):
-        """Nothing was restored, so nothing is claimed."""
+        """Nothing was restored, so nothing is claimed. Unchanged by #296."""
         deployer = _deployer(tmp_path)
         deployer._previous_sha = None
         deployer._migrations_applied = 2

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -2974,7 +2974,9 @@ fraises:
 
         content = (tmp_path / "output" / "sudoers").read_text()
         assert "ALL=(myapp)" in content
-        assert "/home/myapp/.local/bin/uv sync --frozen *" in content
+        # No trailing wildcard — sudo requires ` *` to match at least one further
+        # argument, and the deploy path appends none (#294).
+        assert "/home/myapp/.local/bin/uv sync --frozen" in content
 
     def test_sudoers_omits_install_when_no_user(self, tmp_path):
         """Sudoers omits install rule when install.user is not set (#44)."""
@@ -3337,7 +3339,7 @@ fraises:
         body = content.split("# Dependency install rules (deduplicated)\n", 1)[1]
         rule_blocks = [b for b in body.split("/usr/bin/") if b]
         assert len(rule_blocks) >= 2, "expected both rules to render"
-        between = body.split("/usr/bin/apt-get install *", 1)[1]
+        between = body.split("/usr/bin/apt-get install", 1)[1]
         between = between.split("# Dependency install", 1)[0]
         assert "\n\n" in between, (
             "blank line between rules should be preserved for human-readability"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -189,9 +189,166 @@ class TestPlanDirectories:
         setup = ServerSetup(config, FakeRunner())
         actions = setup._plan_directories()
         chown_actions = [a for a in actions if "ownership" in a.description]
-        assert len(chown_actions) == 4
+        assert len(chown_actions) == 5
         for a in chown_actions:
             assert "fraisier:fraisier" in " ".join(a.command)
+
+    def test_creates_scaffold_state_dir(self, tmp_path):
+        """setup provisions the tree the socket helper reads from (#284).
+
+        Until this directory holds an install.sh the helper daemon exits at
+        startup (``scaffold_install_helper.py:228-230``), so the deploy silently
+        drops onto the subprocess fallback.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup._plan_directories()
+
+        state_dir = config.scaffold_state_dir
+        assert state_dir == "/var/lib/fraisier/tp/scaffold"
+        mkdirs = [a for a in actions if a.command[:3] == ["sudo", "mkdir", "-p"]]
+        assert any(a.command[3] == state_dir for a in mkdirs)
+
+    def test_scaffold_state_dir_owned_by_deploy_user(self, tmp_path):
+        """Deploy-time regeneration runs as deploy_user and must refresh it.
+
+        Same reason ``bootstrap.py:257-273`` chowns it.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup._plan_directories()
+
+        state_dir = config.scaffold_state_dir
+        chowns = [a for a in actions if a.command[:2] == ["sudo", "chown"]]
+        assert any(
+            a.command[2] == "fraisier:fraisier" and a.command[3] == state_dir
+            for a in chowns
+        )
+
+
+class TestPlanScaffoldState:
+    """`setup` also persists its rendered tree into scaffold_state_dir (#284)."""
+
+    def test_copies_rendered_tree_into_state_dir(self, tmp_path):
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        copies = [
+            a for a in actions if a.category == "scaffold" and "cp" in a.command[-1]
+        ]
+        assert len(copies) == 1
+        assert (
+            "cp -a scripts/generated/. /var/lib/fraisier/tp/scaffold/"
+            in copies[0].command[-1]
+        )
+
+    def test_webhook_env_file_is_not_persisted(self, tmp_path):
+        """It holds FRAISIER_WEBHOOK_SECRET and state_dir is world-readable.
+
+        Its only install target is /etc/fraisier/{project}.webhook.env at 0640
+        (``_plan_env_files``), and the deploy path's renderer never writes it
+        into state_dir either.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        copies = [
+            a for a in actions if a.category == "scaffold" and "cp" in a.command[-1]
+        ]
+        assert (
+            "rm -f /var/lib/fraisier/tp/scaffold/fraisier-tp.webhook.env"
+            in copies[0].command[-1]
+        )
+
+    def test_persisted_tree_is_chowned_to_deploy_user(self, tmp_path):
+        """`cp -a` preserves the operator's ownership; deploy_user must own it."""
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        chowns = [
+            a
+            for a in actions
+            if a.category == "scaffold" and a.command[:3] == ["sudo", "chown", "-R"]
+        ]
+        assert len(chowns) == 1
+        assert chowns[0].command[3:] == [
+            "fraisier:fraisier",
+            "/var/lib/fraisier/tp/scaffold",
+        ]
+
+    def test_copy_ordered_after_the_directory_that_receives_it(self, tmp_path):
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+        actions = setup.plan()
+
+        mkdir_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.command[:3] == ["sudo", "mkdir", "-p"]
+            and a.command[3] == "/var/lib/fraisier/tp/scaffold"
+        )
+        copy_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.category == "scaffold" and "cp" in a.command[-1]
+        )
+        chown_idx = next(
+            i
+            for i, a in enumerate(actions)
+            if a.category == "scaffold" and a.command[:3] == ["sudo", "chown", "-R"]
+        )
+        assert mkdir_idx < copy_idx < chown_idx
+
+    def test_install_sources_still_resolve_against_output_dir(self, tmp_path):
+        """Option 2, not Option 1 — the review-then-install loop is unchanged.
+
+        `setup` renders into a CWD-relative tree the operator inspects and
+        installs what they just read; `state_dir` is added as what the machine
+        consumes, not substituted as the install source.
+        """
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        setup = ServerSetup(config, FakeRunner())
+
+        sources = [
+            *setup._plan_sudoers(),
+            *setup._plan_app_services(),
+            *setup._plan_webhook_service(),
+            *setup._plan_env_files(),
+            *setup._plan_nginx(),
+        ]
+        installs = [a for a in sources if a.command[1] in {"cp", "install"}]
+        assert len(installs) == 6
+        for action in installs:
+            src = action.command[-2]
+            assert src.startswith("scripts/generated/"), action.description
+
+    def test_persisted_tree_supplies_the_helpers_allowed_script(self, tmp_path):
+        """The copied tree carries exactly the path baked into the helper unit.
+
+        The unit's ExecStart argument is ``{state_dir}/install.sh``
+        (``renderer.py:936-941``) and the daemon exits 1 at startup when that
+        path is absent (``scaffold_install_helper.py:228-230``).  `install.sh`
+        renders at the *root* of the tree `setup` copies, so copying
+        ``output_dir/.`` into ``state_dir/`` is what closes the gap — this is
+        the assertion that makes the two command strings above mean something.
+        """
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        config = _make_config(tmp_path, MINIMAL_CONFIG)
+        renderer = ScaffoldRenderer(config)
+        renderer.output_dir = tmp_path / "generated"
+        renderer.render()
+
+        assert (renderer.output_dir / "install.sh").is_file()
+        unit = (
+            renderer.output_dir
+            / "systemd"
+            / "fraisier-tp-scaffold-install-helper.service"
+        ).read_text()
+        assert "/var/lib/fraisier/tp/scaffold/install.sh" in unit
 
 
 class TestPlanSymlinks:

--- a/tests/test_sudoers_command_path.py
+++ b/tests/test_sudoers_command_path.py
@@ -212,3 +212,68 @@ class TestSudoersValidatedBeforeInstall:
         content = _render_install_sh(tmp_path)
 
         assert "File was not installed." in content
+
+
+class TestCmndArgumentsMatchTheInvocation:
+    """The rendered `Cmnd` must authorise the argv the deploy path builds (#294).
+
+    `sudoers.j2` used to append ` *` to every rule. Verified against sudo
+    1.9.17p2's own policy engine (`sudo -l`, which checks without executing): a
+    trailing ` *` requires *at least one* further argument, so a rule
+    `/usr/bin/uv sync --frozen *` does **not** match an invocation of
+    `/usr/bin/uv sync --frozen`. `mixins.py:211` appends nothing after
+    `install.command`, so the rule never authorised the `sudo -u` fallback.
+    """
+
+    def test_no_trailing_wildcard(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+
+        assert not _cmnd_line(content).rstrip().endswith(" *")
+
+    def test_argument_tail_is_exactly_the_configured_command(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+
+        authorised = _cmnd_line(content).split("NOPASSWD:", 1)[1].strip()
+        assert authorised == "/usr/local/bin/uv sync --frozen"
+
+    def test_authorised_cmnd_equals_what_the_deployer_hands_to_sudo(
+        self, tmp_path, monkeypatch
+    ):
+        """The drift guard: render and invoke from the same `install:` block.
+
+        Nothing previously tied the two sides together — `grep NOPASSWD tests/`
+        hit only synthetic strings — which is how #294 survived.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from fraisier.deployers.api import APIDeployer
+
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/local/bin/uv" if cmd == "uv" else None
+        )
+        content = _render_sudoers(tmp_path, "[uv, sync, --frozen]")
+        authorised = _cmnd_line(content).split("NOPASSWD:", 1)[1].strip()
+
+        deployer = APIDeployer(
+            {
+                "app_path": "/var/www/prod",
+                "install": {"command": ["uv", "sync", "--frozen"], "user": "appuser"},
+            }
+        )
+        deployer.runner = MagicMock()
+        with patch(
+            "fraisier.deployers.mixins.shutil.which", return_value="/usr/local/bin/uv"
+        ):
+            deployer._install_dependencies()
+
+        argv = deployer.runner.run.call_args[0][0]
+        assert argv[:4] == ["sudo", "-H", "-u", "appuser"]
+        assert " ".join(argv[4:]) == authorised

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.50.1"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #284, #294, #296, #303.

Consolidates PRs #300, #301, #302 and #304 — which each carried their own version bump (v0.51.0–v0.54.0) — into **one release, v0.52.0**. The four fix commits are unchanged and kept separate so each stays `git revert`-able. Those four PRs are superseded and closed; their bodies hold the detailed write-ups.

## ⚠️ Read first: #296 changes the status of nearly every failed deployment

A failed deploy that reverted the tree and restarted the service now reports `rolled_back` instead of `failed`. The automatic restore git-reverts on **every** failure with a previous SHA, migrations or not — so most deploy failures on a box with history are in this case.

- **Alerting that tests `state == "failed"` stops seeing most failed deploys.** Test membership in `status.FAILURE_STATES` instead — that set exists for this reason and has since v0.49.0.
- **`fraisier ops` history stats shift** from "Failed" to "Rolled back". The deploy is still recorded as unsuccessful.
- Zero internal consumer changes: `cli/_info.py`, `cli/ops.py`, `notifications/base.py` and the webhook already handle `rolled_back`.

## What's in it

| Commit | Issue | Summary |
|---|---|---|
| `91f1738` | #284 | `fraisier setup` persists its rendered tree into `scaffold.state_dir`, so the scaffold-install-helper socket is valid immediately instead of only after the first config-changing deploy |
| `2931664` | #294 | The sudoers `Cmnd` trailing ` *` never matched — the `sudo -u` install fallback has **never** been authorised for any project |
| `5ae3399` | #296 | A git-only revert reports `ROLLED_BACK` (the compatibility change above) |
| `2858153` | #303 | `__pycache__` sweeps match any foreign owner, not just root — plus the operator advice that mirrors them |
| `4e966b7` | — | Version bump, consolidated CHANGELOG, and a correction to v0.50.1's notes |

Two findings worth surfacing, both settled by probing rather than reasoning:

- **#294** was settled against sudo's own policy engine (1.9.17p2) using `sudo -l`, which checks the policy without executing. The real invocation reported NO MATCH; a control with a trailing argument matched; both negative controls behaved. Re-verified after the fix against the fragment fraisier actually renders.
- **#303** was demonstrated against real foreign-owned files: given a venv with one owner-written and one third-identity `__pycache__`, the old `-user root` predicate removed **neither**.

## The correction

v0.50.1's notes claimed existing `__pycache__` residue was already cleared by the stale-cache sweep. For the residue that entry is about, it was not — the app-venv sweep filtered `-user root` only. The v0.50.1 entry now carries an inline correction with the manual command, rather than being silently rewritten.

## Operators must re-run scaffold

This release changes three generated artifacts — the sudoers fragment, `install.sh`'s sweeps, and (via `setup`) the scaffold state tree:

```sh
fraisier scaffold && sudo fraisier scaffold-install --yes
```

## What this does not fix

Each fix's limitations are listed in full in the CHANGELOG. The main ones:

- **#294 verified on sudo 1.9.17p2 only**, and it is a *tightening* — the rule now authorises exactly the configured `install.command`, so a hand-run `sudo -u <user> uv sync --frozen --offline` stops working. Nothing automated did so.
- **#284's copy is unconditional, not a sync** — nothing prunes `state_dir`, and `setup` still installs from `output_dir`, so the two trees can diverge if hand-edited.
- **#296 changed only the automatic restore.** The explicit `rollback()` paths and the timeout path are untouched, and `fraisier status` still cannot distinguish a database rollback from a git-only revert.
- **#303 clears residue; it does not stop every writer.** A process invoked outside systemd is still unconstrained — the leading candidate for #286's residue, and why #286 closed without a code cause found.

## Verification

- 4427 passed, 7 skipped, 1 deselected — 4435 collected vs main's 4410, i.e. +25, all new (8 from #284, 3 from #294, 6 from #296, 8 from #303)
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27
- Rendered `install.sh` passes `bash -n`

**Rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)