### PR TITLE
test(install-helper): the full-suite 'flake' was argv-dependence, not ordering

### DIFF
--- a/tests/test_install_helper.py
+++ b/tests/test_install_helper.py
@@ -302,6 +302,12 @@ class TestMainConnectionErrorLogging:
         ]
 
         with (
+            # main() parses sys.argv for its allowed command. Without this the
+            # test reads *pytest's* command line: any argument at all happens to
+            # satisfy it, but a bare `pytest` leaves argv[1:] empty and main()
+            # exits 1 before reaching the accept loop. The sibling tests in
+            # TestMain patch argv for the same reason.
+            patch("sys.argv", ["fraisier-install-helper", "uv", "sync", "--frozen"]),
             patch.dict("os.environ", {"LISTEN_FDS": "1"}, clear=False),
             patch.object(install_helper.socket, "fromfd", return_value=fake_sock),
             patch.object(install_helper, "_handle_connection", side_effect=boom),


### PR DESCRIPTION
Removes the `--deselect` that regression sweeps in this repo have carried for months.

## It was never a flake

Carried in the project handoff as *"one pre-existing test flakes under full-suite ordering; deselect it for regression sweeps."* Three parts of that are false:

1. **Not flaky** — it fails deterministically.
2. **Not ordering** — it passes in isolation, in its own file, *and* in the full suite. What varies is not what runs before it.
3. **The deselect was never necessary** — any pytest argument makes it pass, including the `--deselect` flag itself.

## What actually happens

`install_helper.main()` is a console-script entry point, so it parses its own command line (`fraisier/install_helper.py:219`):

```python
deploy_uid, allowed_command = extract_deploy_uid(sys.argv[1:])
if not allowed_command:
    logger.error("Usage: …")
    sys.exit(1)
```

The test called `main()` without patching `sys.argv`, so it read **pytest's**:

| invocation | `sys.argv[1:]` | result |
|---|---|---|
| `uv run pytest -q` | `['-q']` | truthy → **passes** |
| `uv run pytest -q --deselect …` | several | truthy → **passes** |
| `uv run pytest tests/…::node` | node id | truthy → **passes** |
| **`uv run pytest`** | `[]` | falsy → `sys.exit(1)` → **fails** |

`pyproject.toml` sets `testpaths = ["tests"]`, so a bare `pytest` runs the whole suite with no arguments — and that is the form the methodology's quick reference uses. Hence "intermittent": it tracked how the suite happened to be invoked that day, which is exactly the kind of variation that reads as flakiness.

## Test bug, not source bug

`main()` reading `sys.argv` is correct for an entry point. The three sibling tests in `TestMain` (`:253`, `:264`, `:275`) already patch `sys.argv`, and so does the analogous systemctl-helper test (`test_systemctl_helper.py:459`). This one test was the outlier. One-line fix, with a comment naming why.

## Verification

| | before | after |
|---|---|---|
| `uv run pytest` (bare — the failing form) | **1 failed**, 4427 passed | **4428 passed**, 7 skipped |
| `uv run pytest -q` | 4428 passed | 4428 passed |

- Isolated repro under `sys.argv = ['pytest']`: `SystemExit: 1` at `install_helper.py:226` before, passes after.
- The pre-fix bare run failed on **exactly one** test — which is also the proof that no other test in the suite is argv-sensitive.
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27.

## No release

Tests are not packaged (`[tool.hatch.build.targets.wheel] packages = ["fraisier"]`), so this changes nothing shipped. No version bump — squash-merge is fine here rather than the rebase-merge used for multi-commit release bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)