### PR TITLE
feat(doctor): recommend uv sync --compile-bytecode, and check for it (#298)

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -102,6 +102,54 @@ DATABASE_ADMIN_URL=postgresql://postgres@/postgres?host=/var/run/postgresql
 `hooks:` blocks (expanded at fire time by their dispatchers). Use `!envvar` for everything
 else — most consumers read the YAML value literally and will not expand `${VAR}`.
 
+### Bytecode and startup time
+
+If your `install.command` is `uv sync`, add `--compile-bytecode`:
+
+```yaml
+install:
+  command: [uv, sync, --frozen, --compile-bytecode]
+  user: myapp
+```
+
+**Why.** `uv sync` does not byte-compile by default, and since v0.50.1 every
+generated app unit sets `Environment=PYTHONDONTWRITEBYTECODE=1` — so without the
+flag the venv holds no `.pyc` and nothing ever writes one. Every service start
+then recompiles the whole imported dependency tree from source.
+
+Measured on a FastAPI + SQLAlchemy + psycopg app (49 MB site-packages, plus a
+612 KB app package), median of 11 runs:
+
+| install | app unit | median start |
+|---|---|---|
+| `uv sync` | `PYTHONDONTWRITEBYTECODE=1` | **1005 ms** |
+| `uv sync --compile-bytecode` | `PYTHONDONTWRITEBYTECODE=1` | **612 ms** |
+| both compiled (no env var) | — | 565 ms |
+
+`--compile-bytecode` recovers ~88% of the difference for **+151 ms** on a fresh
+`uv sync`, +62 ms on a no-op re-sync, and +19 MB of disk. The residual ~47 ms is
+your own app package, which `uv` does not compile because an editable project's
+source lives outside the venv. The cost scales with source volume, not package
+count — on this hardware roughly 13 MB of source per second.
+
+**The two settings compose; they do not conflict.** `PYTHONDONTWRITEBYTECODE`
+disables bytecode *writing* only — a cache already on disk is still read. So the
+`.pyc` are written once, at install time, by the **install user**, and the app
+process never writes any. That is strictly safer than the pre-v0.50.1 behaviour:
+the third-identity `__pycache__` that blocked `uv sync --frozen` can no longer
+appear at all. Those install-user-owned `.pyc` are also excluded from the
+stale-cache sweep, which only removes caches owned by someone *other* than the
+venv's owner.
+
+`fraisier doctor` warns when a `uv sync` install command is missing the flag —
+see [`install_compile_bytecode`](doctor.md#check-catalog). It is advisory: this
+is startup latency, not correctness.
+
+**When not to bother.** A short-lived or rarely-restarted service, or a small
+dependency tree, will not notice 400 ms. Measure your own startup before
+changing anything — the numbers above are one app on one machine, and the ratios
+transfer better than the milliseconds.
+
 ---
 
 ## Token providers for authenticated smoke tests

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -34,6 +34,14 @@ passed.
 | `fraises_yaml_resolves` | every reachable `!envvar` resolves to a set var | no | export the missing variables or move them to `~/.config/fraisier/secrets.env` |
 | `secrets_env_readable` | `~/.config/fraisier/secrets.env` exists and is mode 0600 | no | `chmod 600 ~/.config/fraisier/secrets.env` |
 | `helper_sudoers` | `/etc/sudoers.d/<project>` exists and is mode 0440 | no | `fraisier scaffold-install` |
+| `install_compile_bytecode` | a `uv sync` `install.command` passes `--compile-bytecode` | no | add `--compile-bytecode` to `install.command` — see [bytecode and startup time](deployment-guide.md#bytecode-and-startup-time) |
+
+`install_compile_bytecode` is **advisory** — it returns `warn`, never `fail`,
+because the cost is startup latency rather than correctness. It resolves
+`install:` the way the scaffold renderer does (per-environment overrides the
+per-fraise default), and returns `skip` when no `uv sync` command is configured
+at all — a project installing with `npm ci` or `poetry install` has nothing for
+this check to say.
 
 ## Safety notes
 

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -245,6 +245,78 @@ def _check_helper_sudoers(config: FraisierConfig | None) -> CheckResult:
     return CheckResult("helper_sudoers", "pass", f"{path} (mode 0440)")
 
 
+def _is_uv_sync(command: list[str]) -> bool:
+    """True when *command* invokes ``uv sync``, absolute path or not."""
+    if len(command) < 2:
+        return False
+    return Path(command[0]).name == "uv" and command[1] == "sync"
+
+
+@register_check("install_compile_bytecode")
+def _check_install_compile_bytecode(config: FraisierConfig | None) -> CheckResult:
+    """Warn when ``uv sync`` installs a venv nothing will ever byte-compile.
+
+    ``uv sync`` does not compile by default, and since v0.50.1 every app unit
+    sets ``PYTHONDONTWRITEBYTECODE=1`` (#292) — so without
+    ``--compile-bytecode`` at install time the venv holds no ``.pyc`` and none
+    is ever written, making every service start recompile all of
+    site-packages. Measured at ~434 ms per start on a 49 MB site-packages app
+    (#298).
+
+    The two settings compose rather than conflict: ``PYTHONDONTWRITEBYTECODE``
+    blocks *writes* only, so a cache laid down at install time is still read.
+    The ``.pyc`` are owned by the install user, which is also what keeps them
+    clear of the stale-cache sweep (#303) and of the ownership hazard #292 is
+    about.
+
+    Advisory only — ``warn``, never ``fail``. It costs startup time, not
+    correctness.
+    """
+    name = "install_compile_bytecode"
+    fraises = getattr(config, "fraises", None) if config is not None else None
+    if not fraises:
+        return CheckResult(name, "skip", "no fraises in config")
+
+    missing: list[str] = []
+    checked = 0
+    for fraise_name, fraise in fraises.items():
+        if not isinstance(fraise, dict):
+            continue
+        fraise_install = fraise.get("install") or {}
+        environments = fraise.get("environments") or {}
+        if not isinstance(environments, dict):
+            continue
+        for env_name, env_config in environments.items():
+            # env-level `install:` overrides the fraise-level default, the same
+            # resolution the scaffold renderer uses when it bakes the sudoers
+            # rule and the install-helper allowlist.
+            env_install = (
+                env_config.get("install") if isinstance(env_config, dict) else None
+            )
+            install = env_install or fraise_install
+            command = install.get("command") or [] if isinstance(install, dict) else []
+            if not isinstance(command, list) or not _is_uv_sync(command):
+                continue
+            checked += 1
+            if "--compile-bytecode" not in command:
+                missing.append(f"{fraise_name}/{env_name}")
+
+    if not checked:
+        return CheckResult(name, "skip", "no `uv sync` install command configured")
+    if missing:
+        return CheckResult(
+            name,
+            "warn",
+            f"`uv sync` without --compile-bytecode: {', '.join(sorted(missing))}"
+            " — every service start recompiles site-packages",
+            fix_hint=(
+                "add --compile-bytecode to install.command "
+                "(see https://github.com/fraiseql/fraisier/issues/298)"
+            ),
+        )
+    return CheckResult(name, "pass", f"{checked} `uv sync` command(s) compile bytecode")
+
+
 # ---------------------------------------------------------------------------
 # Public runner
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -163,3 +163,145 @@ class TestCli:
         r = _invoke(["doctor", "--check", "python_version"])
         # python_version always passes on this CI matrix.
         assert r.exit_code == 0
+
+
+class TestInstallCompileBytecodeCheck:
+    """`uv sync` without --compile-bytecode leaves the venv uncompiled (#298).
+
+    Since v0.50.1 every app unit sets PYTHONDONTWRITEBYTECODE=1, so nothing
+    ever writes the cache at runtime either. Measured on a 49 MB site-packages
+    app: ~434 ms of avoidable recompilation on every single start. The two
+    settings compose — PYTHONDONTWRITEBYTECODE only blocks *writes*, so a cache
+    laid down at install time is still read.
+    """
+
+    class _Cfg:
+        """Minimal stand-in for FraisierConfig's fraise iteration."""
+
+        def __init__(self, command, *, install_user="appuser"):
+            install = {"command": command}
+            if install_user:
+                install["user"] = install_user
+            self._f = {
+                "api": {
+                    "install": install,
+                    "environments": {"production": {"app_path": "/var/www/api"}},
+                }
+            }
+
+        @property
+        def fraises(self):
+            return self._f
+
+    def _run(self, cfg):
+        return doctor.DOCTOR_CHECKS["install_compile_bytecode"].fn(cfg)
+
+    def test_registered(self):
+        assert "install_compile_bytecode" in doctor.DOCTOR_CHECKS
+
+    def test_warns_for_uv_sync_without_the_flag(self):
+        result = self._run(self._Cfg(["uv", "sync", "--frozen"]))
+
+        assert result.status == "warn"
+        assert "api" in result.detail
+        assert result.fix_hint is not None
+        assert "--compile-bytecode" in result.fix_hint
+
+    def test_passes_when_the_flag_is_present(self):
+        result = self._run(self._Cfg(["uv", "sync", "--frozen", "--compile-bytecode"]))
+
+        assert result.status == "pass"
+
+    def test_skips_non_uv_install_commands(self):
+        """poetry/npm/pip say nothing about uv's bytecode behaviour.
+
+        `skip`, not `pass` — nothing was checked, and the doctor framework
+        already uses skip for inapplicable checks (see helper_sudoers). Skip
+        counts as pass for the exit code.
+        """
+        for cmd in (
+            ["npm", "ci"],
+            ["poetry", "install"],
+            ["pip", "install", "-e", "."],
+        ):
+            result = self._run(self._Cfg(cmd))
+            assert result.status == "skip", f"{cmd} should not warn: {result.detail}"
+
+    def test_matches_an_absolute_uv_path(self):
+        """install.command[0] is often resolved to an absolute path."""
+        result = self._run(self._Cfg(["/usr/local/bin/uv", "sync", "--frozen"]))
+
+        assert result.status == "warn"
+
+    def test_skips_uv_subcommands_other_than_sync(self):
+        """`uv run` does not create the venv, so it says nothing about .pyc."""
+        result = self._run(self._Cfg(["uv", "run", "something"]))
+
+        assert result.status == "skip"
+
+    def test_skips_without_a_config(self):
+        assert self._run(None).status == "skip"
+
+    def test_skips_when_no_install_command_configured(self):
+        class _Empty:
+            def __init__(self):
+                self.fraises = {"api": {"environments": {"production": {}}}}
+
+        assert self._run(_Empty()).status == "skip"
+
+
+class TestInstallCompileBytecodeEnvLevel:
+    """`install:` may be set per-environment, overriding the fraise level.
+
+    `renderer.py:372` resolves it as `env_config.get("install") or fraise_install`,
+    so a check that only reads the fraise level misses these entirely.
+    """
+
+    def _run(self, cfg):
+        return doctor.DOCTOR_CHECKS["install_compile_bytecode"].fn(cfg)
+
+    def _cfg(self, fraise_install, env_install):
+        class _Cfg:
+            def __init__(self):
+                self.fraises = {
+                    "api": {
+                        **({"install": fraise_install} if fraise_install else {}),
+                        "environments": {
+                            "production": {
+                                "app_path": "/var/www/api",
+                                **({"install": env_install} if env_install else {}),
+                            }
+                        },
+                    }
+                }
+
+        return _Cfg()
+
+    def test_warns_on_env_level_install_command(self):
+        result = self._run(
+            self._cfg(None, {"command": ["uv", "sync", "--frozen"], "user": "appuser"})
+        )
+
+        assert result.status == "warn"
+        assert "api" in result.detail
+
+    def test_env_level_overrides_a_compliant_fraise_level(self):
+        """Env-level wins, so a compliant fraise default must not mask it."""
+        result = self._run(
+            self._cfg(
+                {"command": ["uv", "sync", "--frozen", "--compile-bytecode"]},
+                {"command": ["uv", "sync", "--frozen"]},
+            )
+        )
+
+        assert result.status == "warn"
+
+    def test_env_level_compliant_overrides_a_warning_fraise_level(self):
+        result = self._run(
+            self._cfg(
+                {"command": ["uv", "sync", "--frozen"]},
+                {"command": ["uv", "sync", "--frozen", "--compile-bytecode"]},
+            )
+        )
+
+        assert result.status == "pass"


### PR DESCRIPTION
Closes #298.

The [measurements](https://github.com/fraiseql/fraisier/issues/298#issuecomment-5109620587) were posted earlier; this executes the recommendation. **Adopt `uv sync --compile-bytecode`; do not build `PYTHONPYCACHEPREFIX`.**

## Why this option

Measured on a FastAPI + SQLAlchemy + psycopg app (49 MB site-packages + a 612 KB app package), median of 11 runs:

| regime | median start |
|---|---|
| `uv sync`, `PYTHONDONTWRITEBYTECODE=1` — **v0.50.1 today** | **1005 ms** |
| `uv sync --compile-bytecode`, same env var | **612 ms** |
| everything compiled (pre-v0.50.1 steady state) | 565 ms |
| `PYTHONPYCACHEPREFIX` warm | 561 ms |
| `PYTHONPYCACHEPREFIX` cold | 1260 ms |

`--compile-bytecode` recovers ~88% of v0.50.1's regression for **+151 ms** on a fresh sync, +62 ms on a no-op re-sync, +19 MB disk. The prefix approach buys a further ~47 ms in exchange for a state directory, a chown to an identity scaffold does not otherwise manage, a `ReadWritePaths` entry, an uninstall sweep and a config surface — and pays 1260 ms on a cold prefix. Not worth a feature.

## The finding that decided it

**`PYTHONDONTWRITEBYTECODE` disables bytecode *writing* only.** With a valid cache on disk Python still reads it. So the two settings compose rather than compete, and the combination is strictly better than either alone:

- the `.pyc` are written once, at install time, by the **install user**;
- the app, running as `service.user`, reads them and writes nothing;
- so the third-identity `__pycache__` behind #292/#196 can never appear.

This corrects #298's own framing, which presented `--compile-bytecode` as *narrowing* the hazard rather than closing it. Nobody has to adopt it alone — v0.50.1 stays exactly as it is.

It also composes with #303's sweep, which I verified rather than assumed: the sweep removes caches owned by someone *other* than the venv owner, and `uv sync` runs as that owner. Against a rendered `install.sh` for a config with `install.user: installer`:

```
find "/var/www/demo/.venv" -name "__pycache__" ! -user "installer" -type d -exec rm -rf {} +
```

The compiled cache is excluded. Had it not been, this recommendation would have been self-defeating.

## Changes

`install.command` is entirely operator-supplied, so this is **guidance plus a check**, not a behaviour change:

- **New advisory doctor check `install_compile_bytecode`** — `warn`, never `fail`, since the cost is latency and not correctness. It resolves `install:` the way the scaffold renderer does (per-environment overrides per-fraise), and returns `skip` when no `uv sync` command exists at all — a project on `npm ci` has nothing for it to say.
- **`docs/deployment-guide.md`** — a "Bytecode and startup time" section with the measured table, why the settings compose, and when *not* to bother.
- **`docs/doctor.md`** — catalog row plus the advisory/skip semantics.

## What this does not do

- **It does not change any default.** Nobody's `install.command` is rewritten; the check only warns.
- **It says nothing about non-uv installers.** `poetry`/`pip`/`npm` have their own compilation behaviour and are skipped.
- **The residual ~47 ms is your own app package**, which `uv` does not compile — an editable project's source lives outside the venv. That share scales with source volume, so an app with several MB of its own source should re-measure before assuming these ratios hold. The docs say so.
- **One machine, tmpfs, warm page cache.** The ratios transfer; the milliseconds do not.

## Verification

- 4439 passed, 7 skipped (+11 collected, all new; 11 of 11 confirmed failing before the check existed)
- Exercised against a **real `FraisierConfig`**, not only the test doubles — which is how the per-environment `install:` gap was caught, since my first implementation read only the fraise level
- `ruff check .` clean; `ruff format --check .` clean on 412 files; `ty check` unchanged at 27

No version bump — this adds an advisory check and docs. Squash-merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)