### PR TITLE
test+ci: drive the ty floor to zero, then make CI actually hold it there

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,9 +81,8 @@ jobs:
       run: uv run ruff format --check .
 
   type-check:
-    name: Type Check (Advisory)
+    name: Type Check (Required for Release)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python
@@ -95,10 +94,10 @@ jobs:
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
-    - name: Install ty
-      run: uv tool install ty
+    - name: Install dependencies
+      run: uv sync
     - name: Run ty
-      run: ty check fraisier/ || echo "Type check warnings (non-blocking)"
+      run: uv run ty check
 
   security:
     name: Security (Required for Release)

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -106,12 +106,15 @@ jobs:
         python-version: '3.12'
     - name: Install uv
       uses: astral-sh/setup-uv@v7
-    - name: Install ty
-      run: uv tool install ty
+    - name: Install dependencies
+      run: uv sync
+    # Whole repo, not just fraisier/ — the local pre-commit hook checks
+    # everything, and a source-only gate is why 27 diagnostics accumulated in
+    # tests/ while CI stayed green. Blocking: the floor is zero, so any
+    # diagnostic is a regression.
     - name: Run ty type check
-      run: ty check fraisier/
+      run: uv run ty check
       timeout-minutes: 5
-      continue-on-error: true
 
   security:
     name: Security
@@ -155,8 +158,9 @@ jobs:
             echo "Lint checks failed"
             exit 1
           fi
-          if [[ "${{ needs.type-check.result }}" == "failure" ]]; then
-            echo "Type check has warnings (non-blocking)"
+          if [[ "${{ needs.type-check.result }}" != "success" ]]; then
+            echo "Type check failed"
+            exit 1
           fi
           if [[ "${{ needs.security.result }}" != "success" ]]; then
             echo "Security checks failed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
   "pytest-cov>=6.0.0,<7.0",
   "psycopg[binary]>=3.1.0,<4.0",
   "ruff>=0.3.0,<1.0",
+  "ty==0.0.27",
   "httpx>=0.27.0,<1.0",
   "testcontainers[postgres]>=4.0.0",
 ]
@@ -155,6 +156,11 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=6.3.0",
     "ruff>=0.16.0",
+    # Pinned exactly, not floored: ty is 0.0.x and any release can introduce
+    # new diagnostics. A zero-diagnostic gate only means something against a
+    # known checker, so upgrades are a deliberate lockfile change rather than
+    # a silent break that hits each developer on a different day.
+    "ty==0.0.27",
     # Optional integration targets — tests for these strategies/servers
     # are gated by importorskip; installing them in the dev group lets
     # the CI suite cover the integration code paths.

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -64,7 +64,7 @@ def _discover_socket_dir() -> str | None:
 def socket_dir() -> str:
     resolved = _discover_socket_dir()
     if resolved is None:
-        pytest.skip("local PostgreSQL with createdb privilege not available")
+        pytest.skip("local PostgreSQL with createdb privilege not available")  # ty: ignore[too-many-positional-arguments]
     return resolved
 
 

--- a/tests/test_apply_unit_diffs_via_helper.py
+++ b/tests/test_apply_unit_diffs_via_helper.py
@@ -28,6 +28,7 @@ from fraisier.scheduled_install import (
     _build_helper_manifest,
     apply_unit_diffs_via_helper,
 )
+from fraisier.unit_installer_protocol import InstallFileOp
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -77,6 +78,9 @@ def test_build_manifest_emits_install_file_op_for_absent_diff(tmp_path: Path) ->
     manifest = _build_helper_manifest([diff], force=False, resolved_config_path=None)
     assert len(manifest.operations) == 1
     op = manifest.operations[0]
+    # operations is list[InstallFileOp | WriteMarkerOp]; this test is about the
+    # install op specifically, so narrow rather than assume.
+    assert isinstance(op, InstallFileOp)
     assert op.source_path == str(install.source_path)
     assert op.dest_path == str(install.dest_path)
     assert op.mode == "0644"
@@ -361,5 +365,6 @@ def test_apply_report_rejected_reason_surfaces_helper_message(tmp_path: Path) ->
         [diff],
     )
     assert isinstance(report, ApplyReport)
+    assert report.rejected_reason is not None
     assert "dest parent" in report.rejected_reason
     assert "allowlisted" in report.rejected_reason

--- a/tests/test_auto_install_policy.py
+++ b/tests/test_auto_install_policy.py
@@ -97,4 +97,4 @@ def test_parse_rejects_non_mapping_auto_install_block() -> None:
 def test_policy_is_frozen() -> None:
     policy = AutoInstallPolicy()
     with pytest.raises(Exception):  # noqa: B017
-        policy.on_drift = "overwrite"  # type: ignore[misc]
+        policy.on_drift = "overwrite"  # ty: ignore[invalid-assignment]

--- a/tests/test_auto_install_scheduled_units.py
+++ b/tests/test_auto_install_scheduled_units.py
@@ -167,7 +167,8 @@ def test_drift_overwrite_records_units_and_calls_with_force(
         "fraisier.scheduled_install.classify_unit", lambda _u: drifted_diff
     )
 
-    captured_force: list[bool] = []
+    # kwargs.get returns None when the key is absent — the list holds that too.
+    captured_force: list[bool | None] = []
 
     def fake_apply(diffs, **kwargs):
         captured_force.append(kwargs.get("force"))

--- a/tests/test_prune_orphans.py
+++ b/tests/test_prune_orphans.py
@@ -278,4 +278,4 @@ def test_prune_orphans_dataclass_is_frozen() -> None:
     """PrunePlan is frozen so plans can't be accidentally mutated downstream."""
     p = PrunePlan(kind="orphan", marker_path=__import__("pathlib").Path("/x"))
     with pytest.raises((AttributeError, Exception)):
-        p.kind = "stale_marker"  # type: ignore[misc]
+        p.kind = "stale_marker"  # ty: ignore[invalid-assignment]

--- a/tests/test_scheduled_install.py
+++ b/tests/test_scheduled_install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -20,20 +21,27 @@ from fraisier.scheduled_install import (
 
 
 class FakeRunner:
-    """Records every ``run`` call for assertion. Does NOT execute anything."""
+    """Records every ``run`` call for assertion. Does NOT execute anything.
+
+    The signature mirrors ``runners.CommandRunner`` exactly: it is a structural
+    stand-in for that Protocol, so a fake whose ``run`` returns a duck-typed
+    object rather than a real ``CompletedProcess`` is drift, not shorthand.
+    """
 
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
 
-    def run(self, cmd: list[str], **_kwargs: object) -> object:
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        timeout: int = 300,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         self.calls.append(list(cmd))
-
-        class _Completed:
-            returncode = 0
-            stdout = ""
-            stderr = ""
-
-        return _Completed()
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
 
 def _sandbox_dirs(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -350,7 +358,7 @@ def test_unit_diff_is_a_dataclass(tmp_path):
     assert diff.install is install
     assert diff.state in UnitState
     with pytest.raises((AttributeError, TypeError)):
-        diff.state = UnitState.ABSENT  # type: ignore[misc]
+        diff.state = UnitState.ABSENT  # ty: ignore[invalid-assignment]
 
 
 # -- Phase 3: apply (the only write-the-filesystem path) ---------------------
@@ -608,4 +616,4 @@ def test_apply_report_is_a_frozen_dataclass(tmp_path):
 
     assert isinstance(report, ApplyReport)
     with pytest.raises((AttributeError, TypeError)):
-        report.reloaded = False  # type: ignore[misc]
+        report.reloaded = False  # ty: ignore[invalid-assignment]

--- a/tests/test_unit_installer_protocol.py
+++ b/tests/test_unit_installer_protocol.py
@@ -103,7 +103,7 @@ def _manifest(*ops: InstallFileOp, post: tuple[object, ...] = ()) -> Manifest:
         version=1,
         deploy_id="test-deploy",
         operations=tuple(ops),
-        post_actions=tuple(post),  # type: ignore[arg-type]
+        post_actions=tuple(post),  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1098,7 +1098,7 @@ class TestSighupConfigReload:
         from fraisier import webhook
 
         if not hasattr(signal, "SIGHUP"):
-            pytest.skip("SIGHUP not available on this platform")
+            pytest.skip("SIGHUP not available on this platform")  # ty: ignore[too-many-positional-arguments]
 
         captured: dict[str, object] = {}
 
@@ -1120,7 +1120,7 @@ class TestSighupConfigReload:
             # Invoke the registered callback directly (deterministic — no
             # dependence on real signal-delivery timing) and prove it reloads.
             with patch("fraisier.webhook.reset_config") as mock_reset:
-                captured["cb"]()  # type: ignore[operator]
+                captured["cb"]()  # ty: ignore[call-non-callable]
                 assert mock_reset.called
 
             webhook._remove_sighup_reload(loop)
@@ -1139,7 +1139,7 @@ class TestSighupConfigReload:
         from fraisier import webhook
 
         if not hasattr(signal, "SIGHUP"):
-            pytest.skip("SIGHUP not available on this platform")
+            pytest.skip("SIGHUP not available on this platform")  # ty: ignore[too-many-positional-arguments]
 
         async def _run() -> None:
             loop = asyncio.get_running_loop()

--- a/uv.lock
+++ b/uv.lock
@@ -575,6 +575,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "testcontainers" },
+    { name = "ty" },
 ]
 graphql = [
     { name = "strawberry-graphql" },
@@ -597,6 +598,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "testcontainers" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -621,6 +623,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0,<1.0" },
     { name = "strawberry-graphql", marker = "extra == 'graphql'", specifier = ">=0.220.0,<1.0" },
     { name = "testcontainers", extras = ["postgres"], marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.27" },
     { name = "uvicorn", specifier = ">=0.27.0,<1.0" },
 ]
 provides-extras = ["all-databases", "dev", "graphql", "postgres", "mcp"]
@@ -635,6 +638,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.3.0" },
     { name = "ruff", specifier = ">=0.16.0" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+    { name = "ty", specifier = "==0.0.27" },
 ]
 
 [[package]]
@@ -1753,6 +1757,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/de/e5cf1f151cf52fe1189e42d03d90909d7d1354fdc0c1847cbb63a0baa3da/ty-0.0.27.tar.gz", hash = "sha256:d7a8de3421d92420b40c94fe7e7d4816037560621903964dd035cf9bd0204a73", size = 5424130, upload-time = "2026-03-31T19:07:20.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/20/2a9ea661758bd67f2bfd54ce9daacb5a26c56c5f8b49fbd9a43b365a8a7d/ty-0.0.27-py3-none-linux_armv6l.whl", hash = "sha256:eb14456b8611c9e8287aa9b633f4d2a0d9f3082a31796969e0b50bdda8930281", size = 10571211, upload-time = "2026-03-31T19:07:23.28Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b2/8887a51f705d075ddbe78ae7f0d4755ef48d0a90235f67aee289e9cee950/ty-0.0.27-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:02e662184703db7586118df611cf24a000d35dae38d950053d1dd7b6736fd2c4", size = 10427576, upload-time = "2026-03-31T19:07:15.499Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c3/79d88163f508fb709ce19bc0b0a66c7c64b53d372d4caa56172c3d9b3ae8/ty-0.0.27-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be5fc2899441f7f8f7ef40f9ffd006075a5ff6b06c44e8d2aa30e1b900c12f51", size = 9870359, upload-time = "2026-03-31T19:07:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/ed1b0db0e1e46b5ed4976bbfe0d1825faf003b4e3774ef28c785ed73e4bb/ty-0.0.27-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30231e652b14742a76b64755e54bf0cb1cd4c128bcaf625222e0ca92a2094887", size = 10380488, upload-time = "2026-03-31T19:07:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/20372f6d510b01570028433064880adec2f8abe68bf0c4603be61a560bef/ty-0.0.27-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a119b1168f64261b3205a37e40b5b6c4aac8fd58e4587988f4e4b22c3c79847", size = 10390248, upload-time = "2026-03-31T19:07:28.345Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/46b31a7311306be1a560f7f20fdc37b5bf718787f60626cd265d9b637554/ty-0.0.27-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e38f4e187b6975d2cbebf0f1eb1221f8f64f6e509bad14d7bb2a91afc97e4956", size = 10878479, upload-time = "2026-03-31T19:07:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ba/5231a2a1fb1cebe053a25de8fded95e1a30a1e77d3628a9e58487297bafc/ty-0.0.27-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a07b1a8fbb23844f6d22091275430d9ac617175f34aa99159b268193de210389", size = 11461232, upload-time = "2026-03-31T19:07:02.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/558abab3e1f6670493524f61280b4dfcc3219555f13889223e733381dfab/ty-0.0.27-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d3ec4033031f240836bb0337274bac5c49dde312c7c6d7575451ed719bf8ffa3", size = 11133002, upload-time = "2026-03-31T19:07:18.371Z" },
+    { url = "https://files.pythonhosted.org/packages/32/38/188c14a57f52160407ce62c6abb556011718fd0bcbe1dca690529ce84c46/ty-0.0.27-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:924a8849afd500d260bf5b7296165a05b7424fbb6b19113f30f3b999d682873f", size = 10986624, upload-time = "2026-03-31T19:07:13.066Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/667a71393f47d2cd6ba9ed07541b8df3eb63aab1f2ee658e77d91b8362fa/ty-0.0.27-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d8270026c07e7423a1b3a3fd065b46ed1478748f0662518b523b57744f3fa025", size = 10366721, upload-time = "2026-03-31T19:07:00.131Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/aa/8edafe41be898bda774249abc5be6edd733e53fb1777d59ea9331e38537d/ty-0.0.27-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e26e9735d3bdfd95d881111ad1cf570eab8188d8c3be36d6bcaad044d38984d8", size = 10412239, upload-time = "2026-03-31T19:07:05.297Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/8bafaed4a18d38264f46bdfc427de7ea2974cf9064e4e0bdb1b6e6c724e3/ty-0.0.27-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7c09cc9a699810609acc0090af8d0db68adaee6e60a7c3e05ab80cc954a83db7", size = 10573507, upload-time = "2026-03-31T19:06:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/63a8284a2fefd08ab56ecbad0fde7dd4b2d4045a31cf24c1d1fcd9643227/ty-0.0.27-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2d3e02853bb037221a456e034b1898aaa573e6374fbb53884e33cb7513ccb85a", size = 11090233, upload-time = "2026-03-31T19:07:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The local `ty` pre-commit hook failed on every run, on every branch, forever — `uv run ty check` exits 1 whenever any diagnostic exists, and the accepted floor was 27. A hook that always fails is how people learn to stop reading pre-commit output.

Two commits: remove the reason it failed, then make the result durable.

---

## 1. `test:` drive the floor to zero (`02a9c65`)

### Why CI never noticed

| gate | scope | blocking? |
|---|---|---|
| local `ty` hook | whole repo — `fraisier/` **and** `tests/` | yes, and always failed |
| CI `type-check` | `ty check fraisier/` — **source only** | no (`continue-on-error: true`) |
| pre-commit.ci | skipped (`ci.skip`) | n/a |

**All 27 diagnostics were in `tests/`. None in `fraisier/`.** The narrower gate passed while the wider one failed, and the mismatch read as "the hook is broken" rather than "the hook checks more".

### The floor was not 27 hard problems

| count | what | fix |
|---|---|---|
| **13** | `FakeRunner` no longer satisfied the `CommandRunner` **Protocol** — `run` returned `object`, not `CompletedProcess[str]` | conform the fake |
| 6 | `# type: ignore[...]` — **mypy** syntax, which ty does not honour, in a repo that forbids mypy | `# ty: ignore[...]` |
| 4 | un-narrowed unions; `in` against `str \| None` | `assert isinstance(...)` / `is not None` |
| 3 | `pytest.skip(...)` — genuine ty false positive | suppress, per precedent at `test_preflight_e2e.py:85` |
| 1 | `kwargs.get("force")` appended to `list[bool]` — can be `None` | widen the type |

Only the 3 `pytest.skip` cases suppress something correct. The largest cluster was **test-double drift**: a stand-in for a Protocol that had quietly stopped matching it — exactly the signal a type checker exists to give, sitting inside a number nobody re-derived. Tests only; nothing under `fraisier/` touched.

---

## 2. `ci:` make it hold (`4286e22`)

A floor of zero is worth nothing if nothing keeps it there. Three gaps did, each fatal on its own:

**ty was not a dependency at all.** `uv run ty check` resolved to whatever `ty` was on the developer's PATH — here a globally installed uv tool — while CI did `uv tool install ty`, i.e. latest at run time. Different unpinned checkers, and a fresh clone could not run the hook. Now `ty==0.0.27` in both dev sets, so `uv sync` suffices and everyone checks with the same binary.

Pinned **exactly**, not floored: ty is 0.0.x and any release can add diagnostics. A zero-diagnostic gate only means something against a known checker — upgrades should be a deliberate lockfile change, not a silent break reaching each developer on a different day.

**CI checked `fraisier/` only** — the divergence that let 27 diagnostics accumulate in `tests/` unseen. Both jobs now run `uv run ty check`: same command, scope and version as the hook.

**Neither workflow could fail on it.** quality-gate had `continue-on-error: true` and printed *"Type check has warnings (non-blocking)"*; publish named the job *"Advisory"* and swallowed the exit code with `|| echo`. Both now block — a type regression fails the PR, and a release cannot ship with one.

Deliberately untouched: `continue-on-error` on the two codecov uploads and the trivy scan. Those are third-party services whose flakiness should not fail a build.

---

## Verification

- **`pre-commit run --all-files`: ruff check, ruff format, ty, pytest — all Passed.** The actual goal.
- `uv run which ty` → `.venv/bin/ty` (was `~/.local/bin/ty`), version 0.0.27
- `ty check` exits 0 across the whole repo
- 4439 passed, 7 skipped — unchanged; `ruff check .` clean; `ruff format --check .` clean on 440 files
- Both workflow files parse; type-check steps confirmed as `['uv sync', 'uv run ty check']` with `continue-on-error` unset

## Note for reviewers

This PR **makes a previously non-blocking check able to fail your build**, in both CI and release. That is the point, and it is only safe because the floor is now zero — but it is a real change in what CI enforces, so it is worth a deliberate look rather than a rubber stamp.

No version bump: tests, dev dependencies and CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)