### PR TITLE
feat(strategies): verified pre-migration dump gate for the migrate strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Verified pre-migration dump gate for the `migrate` strategy** (`database.pre_migrate_dump`). When enabled and migrations are pending, `MigrateStrategy` takes a `pg_dump` of the target database and verifies it (`pg_restore --list` TOC read + size-sanity against the previous dump, reusing the backup runner's truncation guards) **before** applying anything. A dump that cannot be produced or fails verification aborts the deploy with the schema untouched — *no fresh verified dump ⇒ no migration* — bounding production RPO to the moment immediately before the deploy instead of the last scheduled backup. Config: `enabled`, `output_dir` (required), `compression` (default `zstd:9`), `jobs`, `min_free_gb`, `retention_hours` (pruning runs only after a successful dump). No-op deploys (nothing pending) skip the dump. Note: the pre-existing `backup_before_deploy` key only ever affected the dry-run display; this gate is the enforced replacement.
+
 ## [0.51.0] - 2026-07-29
 
 Four fixes that had been carried as separate branches, released together.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -665,6 +665,11 @@ environments:
       database_url: !envvar DATABASE_URL
       strategy: apply
       backup_before_deploy: true
+      pre_migrate_dump:          # enforced gate: dump+verify BEFORE migrating,
+        enabled: true            # abort the deploy if the dump fails
+        output_dir: /var/backups/myapp/pre_migrate
+        min_free_gb: 20
+        retention_hours: 168
       post_migrate:
         - sql_dir: db/7_grant/
           on_error: halt

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -111,6 +111,17 @@ fraises:
           name: myapp_production
           strategy: apply  # safe migrations only, never drop
           backup_before_deploy: true
+          # Verified pre-migration dump gate: when enabled and migrations are
+          # pending, a pg_dump is taken and verified (TOC + size sanity)
+          # BEFORE anything is applied. Dump fails => deploy aborts with the
+          # schema untouched ("no fresh verified dump => no migration").
+          # pre_migrate_dump:
+          #   enabled: true
+          #   output_dir: /var/backups/myapp/pre_migrate
+          #   compression: zstd:9    # pg_dump --compress spec
+          #   jobs: 1                # >1 switches to directory-format -Fd -j N
+          #   min_free_gb: 20        # abort if output_dir has less free space
+          #   retention_hours: 168   # prune older gate dumps after a SUCCESSFUL dump
           # Optional post-migration SQL hooks (#204). Each entry has
           # exactly one of `sql_dir` or `sql_file`; on_error is `halt`
           # (default — abort before restart) or `warn` (log + continue).

--- a/fraisier/cli/_helpers.py
+++ b/fraisier/cli/_helpers.py
@@ -223,6 +223,11 @@ def _print_dry_run(
         db_strategy = db.get("strategy", "none")
         if db.get("backup_before_deploy"):
             table.add_row("Backup", f"confiture preflight on {db_name}")
+        if (db.get("pre_migrate_dump") or {}).get("enabled"):
+            table.add_row(
+                "Dump gate",
+                f"verified pg_dump of {db_name} before migrate (abort on failure)",
+            )
         table.add_row(
             "Migration",
             f"confiture migrate up on {db_name} (strategy: {db_strategy})",

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -709,6 +709,9 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
                 kwargs["project_dir"] = Path(self.app_path)
             if self.database_config.get("app_version"):
                 kwargs["app_version"] = self.database_config["app_version"]
+        if resolved == "migrate" and self.database_config.get("pre_migrate_dump"):
+            kwargs["pre_migrate_dump"] = self.database_config["pre_migrate_dump"]
+            kwargs["db_name"] = self.database_config.get("name", "")
         if resolved == "restore_migrate":
             kwargs["restore_config"] = self.database_config.get("restore", {})
             kwargs["db_name"] = self.database_config.get("name", "")

--- a/fraisier/strategies/__init__.py
+++ b/fraisier/strategies/__init__.py
@@ -54,7 +54,10 @@ def get_strategy(name: str, **kwargs: Any) -> Strategy:
             ``db_name`` (str) and ``restore_config`` (dict from YAML).
     """
     if name == "migrate":
-        return MigrateStrategy()
+        return MigrateStrategy(
+            pre_migrate_dump=kwargs.get("pre_migrate_dump"),
+            db_name=kwargs.get("db_name", ""),
+        )
     if name == "rebuild":
         roles = kwargs.get("required_roles") or []
         project_dir = kwargs.get("project_dir")

--- a/fraisier/strategies/_core.py
+++ b/fraisier/strategies/_core.py
@@ -36,7 +36,108 @@ log = logging.getLogger(__name__)
 
 
 class MigrateStrategy(Strategy):
-    """Production: preflight → migrate up.  Rollback via migrate down."""
+    """Production: preflight → optional verified dump gate → migrate up.
+
+    When *pre_migrate_dump* is configured (``enabled: true``), a
+    ``pg_dump`` of the target database is taken and verified (TOC read +
+    size-sanity vs the previous dump, via :func:`fraisier.dbops.backup.
+    run_backup`) **before** any migration is applied.  If the dump cannot
+    be produced or fails verification, the deploy aborts with the
+    migrations untouched: *no fresh verified dump ⇒ no migration*.  This
+    bounds the recovery point to the moment immediately before the
+    deploy instead of the last scheduled backup.
+
+    The gate only fires when there are pending migrations — a no-op
+    deploy (nothing to apply) does not spend a full dump.
+
+    Config keys (``database.pre_migrate_dump`` in fraises.yaml):
+
+    - ``enabled`` (bool, default false)
+    - ``output_dir`` (str, required when enabled) — fast-local rollback path
+    - ``compression`` (str, default ``zstd:9``)
+    - ``jobs`` (int, default 1) — parallel dump workers (``-Fd -j N``)
+    - ``min_free_gb`` (int, optional) — abort if *output_dir* has less free
+    - ``retention_hours`` (int, optional) — prune older gate dumps in
+      *output_dir* after a **successful** dump (a failed dump never
+      deletes anything)
+    """
+
+    def __init__(
+        self,
+        *,
+        pre_migrate_dump: dict[str, Any] | None = None,
+        db_name: str = "",
+    ) -> None:
+        self._dump_config = pre_migrate_dump or {}
+        self._db_name = db_name
+        if self._dump_enabled:
+            if not self._dump_config.get("output_dir"):
+                msg = "pre_migrate_dump.enabled requires pre_migrate_dump.output_dir"
+                raise ValueError(msg)
+            if not db_name:
+                msg = "pre_migrate_dump.enabled requires the database name"
+                raise ValueError(msg)
+            validate_pg_identifier(db_name, "database name")
+
+    @property
+    def _dump_enabled(self) -> bool:
+        return bool(self._dump_config.get("enabled", False))
+
+    def _run_dump_gate(
+        self,
+        confiture_config: Path,
+        *,
+        migrations_dir: Path,
+        db_url: str | None,
+    ) -> str | None:
+        """Run the pre-migration dump gate.  Returns an error message to
+        abort the deploy, or None to proceed."""
+        from fraisier.dbops.backup import (
+            check_disk_space,
+            cleanup_old_backups,
+            run_backup,
+        )
+        from fraisier.dbops.confiture import has_pending
+
+        if not has_pending(
+            confiture_config, migrations_dir=migrations_dir, database_url=db_url
+        ):
+            log.info("pre_migrate_dump: no pending migrations — gate skipped")
+            return None
+
+        output_dir = self._dump_config["output_dir"]
+        min_free_gb = self._dump_config.get("min_free_gb")
+        if min_free_gb is not None and not check_disk_space(
+            output_dir, required_gb=int(min_free_gb)
+        ):
+            return (
+                f"pre-migration dump gate: less than {min_free_gb} GB free "
+                f"in {output_dir} — refusing to migrate without a fresh dump"
+            )
+
+        result = run_backup(
+            db_name=self._db_name,
+            output_dir=output_dir,
+            database_url=db_url or "",
+            compression=self._dump_config.get("compression", "zstd:9"),
+            mode="full",
+            jobs=int(self._dump_config.get("jobs", 1)),
+        )
+        if not result.success:
+            return (
+                "pre-migration dump gate failed — migrations NOT applied: "
+                f"{result.error}"
+            )
+
+        log.info("pre_migrate_dump: verified dump at %s", result.backup_path)
+        retention_hours = self._dump_config.get("retention_hours")
+        if retention_hours is not None:
+            removed = cleanup_old_backups(
+                Path(output_dir), retention_hours=int(retention_hours)
+            )
+            if removed:
+                log.info("pre_migrate_dump: pruned %d old dump(s)", len(removed))
+        return None
 
     def execute(
         self,
@@ -57,6 +158,13 @@ class MigrateStrategy(Strategy):
             allow_irreversible=allow_irreversible,
             database_url=db_url,
         )
+
+        if self._dump_enabled:
+            gate_error = self._run_dump_gate(
+                confiture_config, migrations_dir=migrations_dir, db_url=db_url
+            )
+            if gate_error:
+                return StrategyResult(success=False, errors=[gate_error])
 
         result = migrate_up(
             confiture_config,

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -1211,6 +1211,35 @@ class TestAPIDeployerRebuildAppVersion:
             deployer._resolve_strategy()
 
 
+class TestAPIDeployerPreMigrateDump:
+    """APIDeployer plumbs database.pre_migrate_dump through to MigrateStrategy."""
+
+    def test_wires_dump_config_and_db_name(self):
+        deployer = APIDeployer(
+            {
+                "app_path": "/tmp/x",
+                "database": {
+                    "strategy": "migrate",
+                    "name": "proddb",
+                    "pre_migrate_dump": {"enabled": True, "output_dir": "/b"},
+                },
+            }
+        )
+        strategy, *_ = deployer._resolve_strategy()
+        assert strategy._dump_enabled
+        assert strategy._db_name == "proddb"
+
+    def test_migrate_without_dump_config_stays_gateless(self):
+        deployer = APIDeployer(
+            {
+                "app_path": "/tmp/x",
+                "database": {"strategy": "migrate", "name": "proddb"},
+            }
+        )
+        strategy, *_ = deployer._resolve_strategy()
+        assert not strategy._dump_enabled
+
+
 class TestServiceFileStaleness:
     """_check_service_file_staleness warns when live unit differs from scaffold."""
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,6 +1,7 @@
 """Tests for deployment strategies (v0.3 confiture Python API)."""
 
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -177,6 +178,169 @@ class TestMigrateStrategy:
             database_url=None,
             hooks_config=None,
         )
+
+
+class TestMigrateStrategyPreMigrateDumpGate:
+    """Verified pre-migration dump gate: no fresh verified dump ⇒ no migration."""
+
+    DUMP_CFG: ClassVar[dict] = {"enabled": True, "output_dir": "/var/backups/gate"}
+
+    def _strategy(self, **overrides):
+        return MigrateStrategy(
+            pre_migrate_dump={**self.DUMP_CFG, **overrides}, db_name="proddb"
+        )
+
+    def test_enabled_requires_output_dir(self):
+        with pytest.raises(ValueError, match="output_dir"):
+            MigrateStrategy(pre_migrate_dump={"enabled": True}, db_name="proddb")
+
+    def test_enabled_requires_db_name(self):
+        with pytest.raises(ValueError, match="database name"):
+            MigrateStrategy(pre_migrate_dump=dict(self.DUMP_CFG))
+
+    def test_disabled_config_needs_no_db_name(self):
+        MigrateStrategy(pre_migrate_dump={"enabled": False})
+        MigrateStrategy()
+
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_default_strategy_never_dumps(self, mock_preflight, mock_up, mock_backup):
+        mock_up.return_value = MigrationResult(success=True, steps_applied=1)
+
+        result = MigrateStrategy().execute(CONFIG, migrations_dir=MDIR)
+
+        assert result.success
+        mock_backup.assert_not_called()
+
+    @patch("fraisier.dbops.confiture.has_pending", return_value=True)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_pending_migrations_dump_then_migrate(
+        self, mock_preflight, mock_up, mock_backup, mock_pending
+    ):
+        from fraisier.dbops.backup import BackupResult
+
+        mock_backup.return_value = BackupResult(
+            success=True, backup_path="/var/backups/gate/proddb_full_x.dump"
+        )
+        mock_up.return_value = MigrationResult(success=True, steps_applied=2)
+
+        result = self._strategy().execute(CONFIG, migrations_dir=MDIR)
+
+        assert result.success
+        assert result.migrations_applied == 2
+        mock_backup.assert_called_once_with(
+            db_name="proddb",
+            output_dir="/var/backups/gate",
+            database_url="",
+            compression="zstd:9",
+            mode="full",
+            jobs=1,
+        )
+
+    @patch("fraisier.dbops.confiture.has_pending", return_value=True)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_dump_failure_aborts_before_migrate(
+        self, mock_preflight, mock_up, mock_backup, mock_pending
+    ):
+        from fraisier.dbops.backup import BackupResult
+
+        mock_backup.return_value = BackupResult(
+            success=False, error="backup failed TOC verification: truncated"
+        )
+
+        result = self._strategy().execute(CONFIG, migrations_dir=MDIR)
+
+        assert not result.success
+        assert "migrations NOT applied" in result.errors[0]
+        assert "truncated" in result.errors[0]
+        mock_up.assert_not_called()
+
+    @patch("fraisier.dbops.confiture.has_pending", return_value=False)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_no_pending_skips_dump_and_proceeds(
+        self, mock_preflight, mock_up, mock_backup, mock_pending
+    ):
+        mock_up.return_value = MigrationResult(success=True, steps_applied=0)
+
+        result = self._strategy().execute(CONFIG, migrations_dir=MDIR)
+
+        assert result.success
+        mock_backup.assert_not_called()
+        mock_up.assert_called_once()
+
+    @patch("fraisier.dbops.confiture.has_pending", return_value=True)
+    @patch("fraisier.dbops.backup.check_disk_space", return_value=False)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_insufficient_disk_aborts_without_dumping(
+        self, mock_preflight, mock_up, mock_backup, mock_disk, mock_pending
+    ):
+        result = self._strategy(min_free_gb=100).execute(CONFIG, migrations_dir=MDIR)
+
+        assert not result.success
+        assert "100 GB free" in result.errors[0]
+        mock_backup.assert_not_called()
+        mock_up.assert_not_called()
+
+    @patch("fraisier.dbops.backup.cleanup_old_backups", return_value=["old.dump"])
+    @patch("fraisier.dbops.confiture.has_pending", return_value=True)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_retention_pruned_only_after_successful_dump(
+        self, mock_preflight, mock_up, mock_backup, mock_pending, mock_cleanup
+    ):
+        from fraisier.dbops.backup import BackupResult
+
+        mock_backup.return_value = BackupResult(success=True, backup_path="p.dump")
+        mock_up.return_value = MigrationResult(success=True, steps_applied=1)
+
+        result = self._strategy(retention_hours=72).execute(CONFIG, migrations_dir=MDIR)
+
+        assert result.success
+        mock_cleanup.assert_called_once_with(
+            Path("/var/backups/gate"), retention_hours=72
+        )
+
+    @patch("fraisier.dbops.backup.cleanup_old_backups")
+    @patch("fraisier.dbops.confiture.has_pending", return_value=True)
+    @patch("fraisier.dbops.backup.run_backup")
+    @patch("fraisier.strategies._core.migrate_up")
+    @patch("fraisier.strategies._core.preflight")
+    def test_failed_dump_never_prunes(
+        self, mock_preflight, mock_up, mock_backup, mock_pending, mock_cleanup
+    ):
+        from fraisier.dbops.backup import BackupResult
+
+        mock_backup.return_value = BackupResult(success=False, error="boom")
+
+        result = self._strategy(retention_hours=72).execute(CONFIG, migrations_dir=MDIR)
+
+        assert not result.success
+        mock_cleanup.assert_not_called()
+
+    def test_get_strategy_wires_dump_config(self):
+        strategy = get_strategy(
+            "migrate",
+            pre_migrate_dump={"enabled": True, "output_dir": "/b"},
+            db_name="proddb",
+        )
+        assert isinstance(strategy, MigrateStrategy)
+        assert strategy._dump_enabled
+        assert strategy._db_name == "proddb"
+
+    def test_get_strategy_default_has_gate_disabled(self):
+        strategy = get_strategy("migrate")
+        assert isinstance(strategy, MigrateStrategy)
+        assert not strategy._dump_enabled
 
 
 class TestRebuildStrategyValidation:


### PR DESCRIPTION
## What

Adds `database.pre_migrate_dump` — an **enforced, verified pre-migration dump gate** for the `migrate` (production) strategy. When enabled and migrations are pending, `MigrateStrategy` takes a `pg_dump` of the target database and verifies it (`pg_restore --list` TOC read + size-sanity vs the previous dump, reusing `dbops.backup.run_backup`'s truncation guards) **before** applying anything. If the dump cannot be produced or fails verification, the deploy aborts with the schema untouched.

**No fresh verified dump ⇒ no migration.**

## Why

On a migrate-only production environment, the current worst-case RPO is "the last scheduled backup" — and a silently failed/truncated backup (the #202 class) widens that window invisibly. This gate bounds RPO to *the moment immediately before the deploy*: every schema change is preceded by a dump proven readable and plausibly sized, sitting on a fast-local path ready for restore-from-dump rollback.

Designed as A4.1 of printoptim's backup/RPO remediation (printoptim_backend `docs/design/A3_A4_backup_immutability_and_migration_rpo.md`); the mechanism is generic.

## Config

```yaml
database:
  strategy: apply
  name: myapp_production
  pre_migrate_dump:
    enabled: true
    output_dir: /var/backups/myapp/pre_migrate
    compression: zstd:9    # default
    jobs: 1                # >1 → directory-format -Fd -j N
    min_free_gb: 20        # abort if output_dir has less free
    retention_hours: 168   # prune old gate dumps, only after a SUCCESSFUL dump
```

## Behavior details

- **No-op deploys skip the dump** — `has_pending()` is consulted first, so a promote with no schema change doesn't spend a full dump.
- **Disk-space refusal**: with `min_free_gb` set, insufficient space aborts *before* attempting the dump (better no deploy than no rollback path).
- **Retention never destroys the safety net**: pruning runs only after a successful verified dump; a failed dump deletes nothing.
- Wired through `get_strategy()` and `APIDeployer._resolve_strategy()`; the dry-run plan shows the gate.
- Constructor fails fast (`ValueError`) if enabled without `output_dir` or `database.name`.

## Note on `backup_before_deploy`

That existing key only ever affected the CLI dry-run *display* (`cli/_helpers.py`) — nothing in the deploy path reads it. This gate is the enforced replacement; the old key is left untouched for now.

## Verification

✅ 4453 passed, 7 skipped (full suite)
✅ ruff check + format clean
✅ ty check clean
✅ 11 new strategy-gate tests + 2 deployer wiring tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)