### PR TITLE
release: v0.53.0 — a restore can no longer run on top of a deploy (#310, #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-07-31
+
+Closes #310 and #311 — the two halves of one production incident. On
+printoptim.dev at 2026-07-30 00:00 UTC the staging-restore timer fired **on top
+of an in-flight deploy**, stopped the API service and terminated every
+connection to the staging database. The deploy's `pg_restore` died with
+`FATAL: terminating connection due to administrator command`, the deploy
+reported FAILED, and staging was left half-restored.
+
+Two independent defects had to line up for that: the timer fired at a moment
+nobody had scheduled it for, and nothing stopped a restore running concurrently
+with a deploy.
+
+### Fixed
+
+- **`db restore` now holds the deployment lock** (`cli/db.py`, #310). `fraisier.locking` has always provided per-fraise mutual exclusion and the webhook wraps every deployment in `deployment_lock(fraise)` — but the `db restore` CLI never acquired it, so a timer-, cron- or hand-driven restore ran completely unsynchronised with deploys of the same fraise. It now takes the same lock, over the whole live restore.
+- **The staging-restore timer no longer fires twice a day** (`core/restore-staging.timer.j2`, #311). The template carried both `OnCalendar=daily` and `OnCalendar=*-*-* 02:00:00` under a comment promising 2 AM. `OnCalendar=` **accumulates** — per `systemd.timer(5)` the trigger list is reset only when the *empty* string is assigned — so the unit also fired at 00:00. Confirmed live: `systemctl list-timers` showed LAST 02:00 / NEXT 00:00 on the same unit, which a single-trigger timer cannot do.
+
+### Added
+
+- **`fraisier db restore --skip-if-locked`** — exit 0 with a clear line instead of failing when a deploy holds the lock. The generated `restore-staging.service` passes it: a concurrent staging deploy is itself restoring from production, so a collision means the work is already being done. Without this the new lock would convert a harmless overlap into a nightly failed unit.
+
+### Notes for operators
+
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`.** Both fixes are in generated units; the installed copies keep the old behaviour until you do. If you applied the `flock` drop-in from #310 as an interim mitigation, it can be removed after this — it is harmless if left.
+- **`--dry-run` does not take the lock.** It mutates nothing, so a running deploy will not veto a plan preview.
+- **A lock that cannot be evaluated is an error, not a skip.** If the lock directory is missing or unwritable, `db restore` fails with a message naming it — even under `--skip-if-locked`. "I cannot tell whether a deploy is running" must never be treated as "no deploy is running". `/run/fraisier` is tmpfs and is created by the webhook unit's `RuntimeDirectory=`, so after a reboot it appears when the webhook starts; `restore-staging.service` already depended on that directory for its systemctl socket, so this is not a new requirement.
+
+### Known limitations
+
+- **Only `db restore` was given the lock.** The other `db` subcommands (`exec`, `reset`, `migrate`, `build`) still run unsynchronised. `restore` is the one that stops the service and terminates connections, so it is the one that destroyed a deploy — but the same class of collision is reachable through `db reset`, and closing that is a separate change with its own blast radius.
+- **The lock is per-fraise and per-host.** Two hosts serving the same fraise coordinate only under the `database` lock backend, unchanged here.
+- **Nothing recreates `/run/fraisier` for a timer that fires while the webhook is stopped.** The failure is now legible rather than a traceback, but it is still a failure.
+
 ## [0.52.0] - 2026-07-31
 
 Adds an enforced pre-migration backup gate for production deploys, plus a

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -514,6 +514,14 @@ def db_preflight(ctx: click.Context, fraise: str, env: str, fmt: str) -> None:
     default=None,
     help="Prefer backups compressed with this algorithm (overrides config)",
 )
+@click.option(
+    "--skip-if-locked",
+    is_flag=True,
+    help=(
+        "Exit 0 instead of failing when a deploy holds the lock. "
+        "For timer units, where a skipped nightly restore is a non-event."
+    ),
+)
 @click.pass_context
 def db_restore(
     ctx: click.Context,
@@ -525,11 +533,16 @@ def db_restore(
     skip_preflight: bool,
     jobs: int | None,
     preferred_compression: str | None,
+    skip_if_locked: bool,
 ) -> None:
     """Restore staging database from a production backup.
 
     Stops the service, runs pg_restore, creates a rollback template,
     applies pending migrations, and restarts the service.
+
+    Holds the same per-fraise deployment lock the webhook uses, so a restore
+    and a deploy of the same fraise can never interleave. --dry-run does not
+    take the lock, since it changes nothing.
 
     \b
     Examples:
@@ -621,88 +634,123 @@ def db_restore(
         return
 
     # --- live run ---
-    runner = LocalRunner()
-    svc_mgr = (
-        get_service_manager(runner, config._config)
-        if systemd_service and not no_service_restart
-        else None
-    )
-
-    from fraisier.config.schema import PreflightConfig
-
-    preflight_cfg = db_cfg.get("preflight") or {}
-    preflight = PreflightConfig(
-        enabled=bool(preflight_cfg.get("enabled", True)),
-        timeout_seconds=int(preflight_cfg.get("timeout_seconds", 120)),
-    )
-
-    strategy = RestoreMigrateStrategy(
-        RestoreConfig(
-            db_name=db_name,
-            backup_dir=_Path(restore_cfg.get("backup_dir", ".")),
-            backup_pattern=restore_cfg.get("backup_pattern", "*.dump"),
-            max_age_hours=float(restore_cfg.get("max_age_hours", 48.0)),
-            target_owner=restore_cfg.get("target_owner"),
-            create_template=bool(restore_cfg.get("create_template", False)),
-            template_name=restore_cfg.get("template_name"),
-            min_tables=int(restore_cfg.get("min_tables", 0)),
-            jobs=jobs if jobs is not None else int(restore_cfg.get("jobs", 1)),
-            preferred_compression=(
-                preferred_compression
-                if preferred_compression is not None
-                else restore_cfg.get("preferred_compression")
-            ),
-            backup_path=from_backup,
-            preflight=preflight,
-        ),
-        admin_url=admin_url,
-        service_manager=svc_mgr,
-        service_name=systemd_service,
-    )
+    # Hold the same per-fraise lock the webhook takes (#310). A timer-, cron- or
+    # hand-driven restore stops the service and terminates every connection to
+    # the database; without this it can do that underneath an in-flight deploy
+    # of the same fraise, killing its pg_restore and leaving the DB half-done.
+    from fraisier.errors import DeploymentLockError
+    from fraisier.locking import deployment_lock
 
     try:
-        result = strategy.execute(
-            confiture_config,
-            migrations_dir=app_path / "db" / "migrations",
-            skip_preflight=skip_preflight,
-        )
-    except DatabaseError as exc:
-        if svc_mgr and systemd_service:
-            msg = f"[yellow]Restarting {systemd_service} after error...[/yellow]"
-            console.print(msg)
-            svc_mgr.restart(systemd_service)
-        console.print(f"[red]Restore failed:[/red] {exc}")
-        raise SystemExit(1) from exc
+        with deployment_lock(fraise):
+            runner = LocalRunner()
+            svc_mgr = (
+                get_service_manager(runner, config._config)
+                if systemd_service and not no_service_restart
+                else None
+            )
 
-    if not result.success:
-        errors = ", ".join(result.errors)
-        console.print(f"[red]Restore failed:[/red] {errors}")
-        raise SystemExit(1)
+            from fraisier.config.schema import PreflightConfig
 
-    msg = f"{result.migrations_applied} migration(s) applied"
-    console.print(f"[green]Restore complete:[/green] {msg}")
-    if result.total_duration_seconds > 0:
+            preflight_cfg = db_cfg.get("preflight") or {}
+            preflight = PreflightConfig(
+                enabled=bool(preflight_cfg.get("enabled", True)),
+                timeout_seconds=int(preflight_cfg.get("timeout_seconds", 120)),
+            )
+
+            strategy = RestoreMigrateStrategy(
+                RestoreConfig(
+                    db_name=db_name,
+                    backup_dir=_Path(restore_cfg.get("backup_dir", ".")),
+                    backup_pattern=restore_cfg.get("backup_pattern", "*.dump"),
+                    max_age_hours=float(restore_cfg.get("max_age_hours", 48.0)),
+                    target_owner=restore_cfg.get("target_owner"),
+                    create_template=bool(restore_cfg.get("create_template", False)),
+                    template_name=restore_cfg.get("template_name"),
+                    min_tables=int(restore_cfg.get("min_tables", 0)),
+                    jobs=jobs if jobs is not None else int(restore_cfg.get("jobs", 1)),
+                    preferred_compression=(
+                        preferred_compression
+                        if preferred_compression is not None
+                        else restore_cfg.get("preferred_compression")
+                    ),
+                    backup_path=from_backup,
+                    preflight=preflight,
+                ),
+                admin_url=admin_url,
+                service_manager=svc_mgr,
+                service_name=systemd_service,
+            )
+
+            try:
+                result = strategy.execute(
+                    confiture_config,
+                    migrations_dir=app_path / "db" / "migrations",
+                    skip_preflight=skip_preflight,
+                )
+            except DatabaseError as exc:
+                if svc_mgr and systemd_service:
+                    msg = (
+                        f"[yellow]Restarting {systemd_service} after error...[/yellow]"
+                    )
+                    console.print(msg)
+                    svc_mgr.restart(systemd_service)
+                console.print(f"[red]Restore failed:[/red] {exc}")
+                raise SystemExit(1) from exc
+
+            if not result.success:
+                errors = ", ".join(result.errors)
+                console.print(f"[red]Restore failed:[/red] {errors}")
+                raise SystemExit(1)
+
+            msg = f"{result.migrations_applied} migration(s) applied"
+            console.print(f"[green]Restore complete:[/green] {msg}")
+            if result.total_duration_seconds > 0:
+                console.print(
+                    f"  Restore: {result.restore_duration_seconds:.1f}s"
+                    f" | Migration: {result.migration_duration_seconds:.1f}s"
+                    f" | Total: {result.total_duration_seconds:.1f}s"
+                )
+
+            # Re-apply configured grant scripts. The restore strategy restores with
+            # pg_restore --no-owner --no-acl, so without this the restored DB is
+            # grantless for every non-owner role — the deploy path already does this
+            # via _run_post_migrate, the standalone CLI path did not (issue #273).
+            from fraisier import post_migrate
+            from fraisier.errors import DeploymentError
+
+            try:
+                post_migrate.run_configured_post_migrate(
+                    db_cfg,
+                    app_path=app_path,
+                    runner=runner,
+                )
+            except DeploymentError as exc:
+                console.print(f"[red]post_migrate failed:[/red] {exc}")
+                raise SystemExit(1) from exc
+    except DeploymentLockError as exc:
+        if skip_if_locked:
+            # Timer units pass this: a skipped nightly restore is a non-event,
+            # since a concurrent staging deploy is itself restoring from prod.
+            console.print(f"[yellow]Skipping restore:[/yellow] {exc}")
+            return
+        console.print(f"[red]Error:[/red] {exc}")
         console.print(
-            f"  Restore: {result.restore_duration_seconds:.1f}s"
-            f" | Migration: {result.migration_duration_seconds:.1f}s"
-            f" | Total: {result.total_duration_seconds:.1f}s"
+            "  A deploy is in progress for this fraise. Retry once it finishes, "
+            "or pass --skip-if-locked (used by the generated timer unit)."
         )
-
-    # Re-apply configured grant scripts. The restore strategy restores with
-    # pg_restore --no-owner --no-acl, so without this the restored DB is
-    # grantless for every non-owner role — the deploy path already does this
-    # via _run_post_migrate, the standalone CLI path did not (issue #273).
-    from fraisier import post_migrate
-    from fraisier.errors import DeploymentError
-
-    try:
-        post_migrate.run_configured_post_migrate(
-            db_cfg,
-            app_path=app_path,
-            runner=runner,
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        # The lock could not be evaluated at all — /run/fraisier is tmpfs and is
+        # created by the webhook unit's RuntimeDirectory=. Deliberately not
+        # covered by --skip-if-locked: "I cannot tell whether a deploy is
+        # running" must never be treated as "no deploy is running".
+        console.print(f"[red]Error:[/red] cannot acquire the deployment lock: {exc}")
+        console.print(
+            "  The lock directory (default /run/fraisier) must exist and be "
+            "writable by this user. It is created by the webhook unit and by "
+            "`fraisier setup`; after a reboot it appears when the webhook starts."
         )
-    except DeploymentError as exc:
-        console.print(f"[red]post_migrate failed:[/red] {exc}")
         raise SystemExit(1) from exc
 
 

--- a/fraisier/scaffold/templates/core/restore-staging.service.j2
+++ b/fraisier/scaffold/templates/core/restore-staging.service.j2
@@ -14,7 +14,10 @@ Environment=FRAISIER_SYSTEMCTL_SOCKET=/run/fraisier/systemctl-{{ project_name }}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% if env_config.get('database', {}).get('strategy') == 'restore_migrate' %}
 {% if 'staging' in env_name or 'stage' in env_name %}
-ExecStart={{ fraisier_bin }} --config {{ scaffold.config_path }} db restore {{ fraise.name }} {{ env_name }}
+# --skip-if-locked: a deploy of this fraise holds the same lock, and a deploy
+# is itself restoring staging from production — so a collision means the work
+# is already being done. Exit 0 rather than failing the unit nightly (#310).
+ExecStart={{ fraisier_bin }} --config {{ scaffold.config_path }} db restore {{ fraise.name }} {{ env_name }} --skip-if-locked
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/fraisier/scaffold/templates/core/restore-staging.timer.j2
+++ b/fraisier/scaffold/templates/core/restore-staging.timer.j2
@@ -3,8 +3,10 @@ Description=Timer for nightly {{ project_name }} staging database restore from p
 After=network.target
 
 [Timer]
-# Run at 2 AM local time daily
-OnCalendar=daily
+# Run at 2 AM local time daily.
+# Exactly one OnCalendar=: systemd *accumulates* non-empty assignments and
+# resets the list only for the empty string, so adding `OnCalendar=daily`
+# here would schedule a second, undocumented 00:00 run (#311).
 OnCalendar=*-*-* 02:00:00
 Persistent=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.52.0"
+version = "0.53.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,35 @@ def _reset_rate_limiter():
 
 
 @pytest.fixture(autouse=True)
+def _isolated_lock_dir(tmp_path, monkeypatch):
+    """Keep deployment locks out of /run/fraisier.
+
+    ``file_deployment_lock`` mkdirs its lock directory, which needs root for the
+    real ``/run/fraisier`` and does not exist at all on most dev machines. Any
+    code path that takes a deployment lock — the webhook, and ``db restore``
+    since #310 — would otherwise fail in tests for purely environmental reasons.
+
+    Redirected at the single choke point rather than at each source of the path:
+    the directory arrives variously from ``DEFAULT_LOCK_DIR``, the
+    ``DeploymentConfig`` schema default, and a hardcoded literal in the config
+    loader. Only a ``/run/`` path is rewritten, so a directory a test supplies
+    itself is honoured and ``test_file_lock.py`` keeps controlling its own.
+    """
+    from fraisier import locking
+
+    real = locking.file_deployment_lock
+    safe = tmp_path / ".locks"
+
+    def _redirected(fraise_name, lock_dir=None):
+        if lock_dir is None or str(lock_dir).startswith("/run/"):
+            lock_dir = safe
+        return real(fraise_name, lock_dir=lock_dir)
+
+    monkeypatch.setattr(locking, "file_deployment_lock", _redirected)
+    monkeypatch.setattr(locking, "DEFAULT_LOCK_DIR", safe)
+
+
+@pytest.fixture(autouse=True)
 def _reset_delivery_dedupe():
     """Clear webhook delivery-ID dedupe store between tests."""
     from fraisier.git.github import _delivery_dedupe

--- a/tests/test_db_restore_locking.py
+++ b/tests/test_db_restore_locking.py
@@ -1,0 +1,236 @@
+"""`db restore` must hold the deployment lock (#310).
+
+`fraisier.locking` gives per-fraise mutual exclusion and the webhook wraps every
+deployment in ``deployment_lock(fraise)``. The `db restore` CLI never acquired
+it, so a timer-, cron- or hand-driven restore ran completely unsynchronised
+with deploys of the same fraise.
+
+Incident (printoptim.dev, 2026-07-30 00:00 UTC): the staging-restore timer fired
+mid-deploy, stopped the API service and terminated every connection to the
+staging database — killing the in-flight deploy's pg_restore
+(``FATAL: terminating connection due to administrator command``) and leaving
+staging half-restored. The timer firing at midnight at all was #311.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fraisier.cli.main import main
+from fraisier.errors import DeploymentLockError
+
+_ADMIN_URL = "postgresql:///postgres?host=/var/run/postgresql"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def restore_config():
+    config = MagicMock()
+    config.get_fraise.return_value = {"type": "api", "description": "Test API"}
+    config.get_fraise_environment.return_value = {
+        "type": "api",
+        "app_path": "/var/www/api",
+        "systemd_service": "api.staging.service",
+        "database": {
+            "name": "mydb_staging",
+            "strategy": "restore_migrate",
+            "admin_url": _ADMIN_URL,
+            "confiture_config": "confiture.yaml",
+            "restore": {
+                "backup_dir": "/backup/production",
+                "backup_pattern": "*.dump",
+                "max_age_hours": 48.0,
+                "create_template": True,
+                "min_tables": 100,
+            },
+        },
+    }
+    config._config = {"backup": {}}
+    config.deployment = MagicMock()
+    config.deployment.get_strategy.return_value = "restore_migrate"
+    config.list_fraises_detailed.return_value = []
+    with patch("fraisier.cli.main.get_config", return_value=config):
+        yield config
+
+
+def _invoke(runner, args, *, lock_side_effect=None):
+    """Run `db restore`, stubbing everything below the lock."""
+    result_mock = MagicMock(
+        success=True,
+        migrations_applied=0,
+        total_duration_seconds=0.0,
+        restore_duration_seconds=0.0,
+        migration_duration_seconds=0.0,
+    )
+    lock = MagicMock()
+    if lock_side_effect is not None:
+        lock.side_effect = lock_side_effect
+
+    with (
+        patch("fraisier.locking.deployment_lock", lock),
+        patch("fraisier.dbops.guard.is_external_db", return_value=False),
+        patch(
+            "fraisier.strategies.RestoreMigrateStrategy.execute",
+            return_value=result_mock,
+        ) as mock_execute,
+        patch("fraisier.systemd.SystemdServiceManager"),
+        patch("fraisier.dbops.restore.find_latest_backup", return_value="/b/x.dump"),
+        patch("fraisier.dbops.restore.validate_backup_age"),
+        patch("fraisier.post_migrate.run_configured_post_migrate", return_value=None),
+    ):
+        res = runner.invoke(main, args)
+    return res, lock, mock_execute
+
+
+class TestRestoreTakesTheDeploymentLock:
+    def test_lock_is_acquired_for_the_fraise(self, runner, restore_config):
+        res, lock, _ = _invoke(runner, ["db", "restore", "api", "staging"])
+
+        assert lock.called, f"deployment_lock never acquired (exit {res.exit_code})"
+        assert lock.call_args.args[0] == "api"
+
+    def test_restore_runs_while_holding_it(self, runner, restore_config):
+        """The lock must wrap the mutation, not merely be taken and dropped."""
+        _, lock, mock_execute = _invoke(runner, ["db", "restore", "api", "staging"])
+
+        assert lock.return_value.__enter__.called
+        assert mock_execute.called
+
+
+class TestLockedBehaviour:
+    def test_errors_when_a_deploy_holds_the_lock(self, runner, restore_config):
+        """Default: refuse loudly rather than interleave with a deploy."""
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging"],
+            lock_side_effect=DeploymentLockError("Deploy already running for api"),
+        )
+
+        assert res.exit_code != 0
+        assert not mock_execute.called, "restore ran despite the lock being held"
+
+    def test_skip_if_locked_exits_zero_without_restoring(self, runner, restore_config):
+        """For timer units: a skipped nightly restore is a non-event.
+
+        A concurrent staging deploy is itself restoring from production, so
+        failing the timer would page someone over a no-op.
+        """
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=DeploymentLockError("Deploy already running for api"),
+        )
+
+        assert res.exit_code == 0, res.output
+        assert not mock_execute.called
+        assert "skip" in res.output.lower()
+
+    def test_skip_if_locked_does_not_mask_an_unlocked_failure(
+        self, runner, restore_config
+    ):
+        """The flag suppresses lock contention only, never a real error."""
+        res, _, _ = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=RuntimeError("disk on fire"),
+        )
+
+        assert res.exit_code != 0
+
+
+class TestDryRunIsNotBlocked:
+    def test_dry_run_does_not_take_the_lock(self, runner, restore_config):
+        """A dry run mutates nothing, so a running deploy must not veto it."""
+        res, lock, mock_execute = _invoke(
+            runner, ["db", "restore", "api", "staging", "--dry-run"]
+        )
+
+        assert res.exit_code == 0, res.output
+        assert not lock.called
+        assert not mock_execute.called
+
+
+class TestTimerUnitPassesTheFlag:
+    """The generated unit must opt into the skip, or the timer just fails nightly.
+
+    Without `--skip-if-locked` the new lock turns a harmless collision into a
+    failed systemd unit and a paged operator — the fix would trade a silent
+    corruption for a noisy false alarm.
+    """
+
+    def _service_text(self, tmp_path) -> str:
+        from fraisier.config import FraisierConfig
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        p = tmp_path / "fraises.yaml"
+        p.write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      staging:
+        app_path: /var/www/staging
+        database:
+          name: myapp_staging
+          strategy: restore_migrate
+""")
+        ScaffoldRenderer(FraisierConfig(p)).render()
+        return (tmp_path / "output" / "systemd" / "restore-staging.service").read_text()
+
+    def test_execstart_passes_skip_if_locked(self, tmp_path):
+        exec_lines = [
+            ln
+            for ln in self._service_text(tmp_path).splitlines()
+            if ln.startswith("ExecStart=")
+        ]
+        assert len(exec_lines) == 1
+        assert "--skip-if-locked" in exec_lines[0]
+
+    def test_execstart_still_invokes_db_restore(self, tmp_path):
+        """The flag must be added to the restore call, not replace it."""
+        exec_lines = [
+            ln
+            for ln in self._service_text(tmp_path).splitlines()
+            if ln.startswith("ExecStart=")
+        ]
+        assert "db restore" in exec_lines[0]
+
+
+class TestUnusableLockIsNotSilentlySkipped:
+    """A lock that cannot be taken at all is an error, never a skip.
+
+    `/run/fraisier` is tmpfs, created by the webhook unit's
+    `RuntimeDirectory=fraisier`. If it is absent, acquiring raises OSError
+    rather than DeploymentLockError — that means "I could not tell whether a
+    deploy is running", which must never be treated as "no deploy is running".
+    """
+
+    def test_oserror_fails_even_with_skip_if_locked(self, runner, restore_config):
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=PermissionError(13, "Permission denied", "/run/fraisier"),
+        )
+
+        assert res.exit_code != 0, "an unusable lock must not read as 'nothing running'"
+        assert not mock_execute.called
+
+    def test_oserror_message_names_the_lock_directory(self, runner, restore_config):
+        res, _, _ = _invoke(
+            runner,
+            ["db", "restore", "api", "staging"],
+            lock_side_effect=PermissionError(13, "Permission denied", "/run/fraisier"),
+        )
+
+        assert "/run/fraisier" in res.output

--- a/tests/test_restore_staging_timer.py
+++ b/tests/test_restore_staging_timer.py
@@ -1,0 +1,72 @@
+"""The nightly staging restore must fire once, at the advertised hour (#311).
+
+`OnCalendar=` accumulates: systemd resets the trigger list only when the *empty*
+string is assigned, so two non-empty assignments give two triggers. The template
+carried both `OnCalendar=daily` (00:00) and `OnCalendar=*-*-* 02:00:00` under a
+comment promising 2 AM, so it fired twice a day.
+
+That was not merely redundant. On printoptim.dev (2026-07-30) the undocumented
+midnight fire landed on an in-flight deploy and killed it — the other half of
+that collision is the missing deployment lock (#310).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {output}
+fraises:
+  my_api:
+    type: api
+    environments:
+      staging:
+        app_path: /var/www/staging
+        database:
+          name: myapp_staging
+          strategy: restore_migrate
+"""
+
+
+@pytest.fixture
+def timer_text(tmp_path) -> str:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(_YAML.format(output=str(tmp_path / "output")))
+    ScaffoldRenderer(FraisierConfig(p)).render()
+    return (tmp_path / "output" / "systemd" / "restore-staging.timer").read_text()
+
+
+def _oncalendar_lines(text: str) -> list[str]:
+    return [
+        ln.strip() for ln in text.splitlines() if ln.strip().startswith("OnCalendar=")
+    ]
+
+
+class TestRestoreStagingTimerFiresOnce:
+    def test_exactly_one_oncalendar_directive(self, timer_text):
+        """Two non-empty OnCalendar= assignments mean two triggers, not an override."""
+        lines = _oncalendar_lines(timer_text)
+
+        assert len(lines) == 1, f"timer fires {len(lines)} times a day: {lines}"
+
+    def test_the_single_trigger_is_the_advertised_hour(self, timer_text):
+        """The comment promises 2 AM; the directive must agree with it."""
+        assert _oncalendar_lines(timer_text) == ["OnCalendar=*-*-* 02:00:00"]
+
+    def test_no_bare_daily_shorthand(self, timer_text):
+        """`daily` expands to 00:00 — the midnight fire behind the #310 collision.
+
+        Checks the *directives*, not the raw text: the template comment names
+        `OnCalendar=daily` deliberately, to explain the trap it documents.
+        """
+        assert "OnCalendar=daily" not in _oncalendar_lines(timer_text)
+
+    def test_persistent_is_kept(self, timer_text):
+        """A missed run must still catch up; only the extra trigger goes."""
+        assert "Persistent=true" in timer_text

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.51.0"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #310, closes #311.

*(Keyword repeated per reference — `Closes #A, #B` closes only #A.)*

## One incident, two defects

printoptim.dev, 2026-07-30 00:00 UTC: the staging-restore timer fired **on top of an in-flight deploy**, stopped the API service and terminated every connection to the staging database. The deploy's `pg_restore` died with `FATAL: terminating connection due to administrator command`, the deploy reported FAILED, and staging was left half-restored.

Two independent defects had to line up:

| | defect |
|---|---|
| **#311** | the timer fired at a moment nobody had scheduled it for |
| **#310** | nothing stopped a restore running concurrently with a deploy |

Either one alone is survivable. Together they cost a deploy and a database.

## #311 — the timer fired twice a day

`restore-staging.timer.j2` carried both `OnCalendar=daily` and `OnCalendar=*-*-* 02:00:00` under a comment promising 2 AM.

`OnCalendar=` **accumulates**. Verified against `systemd.timer(5)`, which states the trigger list is reset only when the **empty** string is assigned — meaningful only if non-empty assignments add. And confirmed live: `systemctl list-timers` showed **LAST 02:00 / NEXT 00:00** on the same unit, which a single-trigger timer cannot do.

One line removed. `Persistent=true` kept, so a missed run still catches up.

## #310 — `db restore` never took the lock

Verified before fixing: `deployment_lock` call sites are `webhook.py:318`, `cli/version.py:956` and `daemon.py:250` — the issue names the first two, the third exists too. `cli/db.py` had none.

The live-restore body now runs inside `deployment_lock(fraise)`. **Most of the diff is the resulting re-indentation**; the substance is the `with`, two `except` arms, and the new flag.

Three decisions worth reviewing:

- **`--skip-if-locked` exits 0**, and the generated `restore-staging.service` passes it. A concurrent staging deploy is itself restoring from production, so a collision means the work is already being done. Without this, the new lock converts a harmless overlap into a nightly failed unit and a paged operator — trading silent corruption for a noisy false alarm.
- **`--dry-run` does not take the lock.** It mutates nothing, so a running deploy must not veto a plan preview.
- **`OSError` is deliberately *not* covered by `--skip-if-locked`.** If the lock cannot be evaluated at all, that means "I cannot tell whether a deploy is running", which must never be silently treated as "no deploy is running". Clear message naming the directory, exit 1. Two tests pin this.

## Test isolation, which the change forced

Taking a real lock broke 14 existing tests: `/run/fraisier` does not exist on a dev machine and `mkdir` needs root. Rather than edit 14 tests, an autouse fixture keeps deployment locks out of `/run`. The directory arrives from **three** different places — `DEFAULT_LOCK_DIR`, the `DeploymentConfig` schema default, and a hardcoded literal in the config loader — so it is redirected at the single choke point instead of chasing each source. A directory a test supplies itself is honoured, so `test_file_lock.py` still controls its own.

## What this does not fix

- **Only `db restore` got the lock.** `db exec`, `reset`, `migrate` and `build` still run unsynchronised. `restore` is the one that stops the service and terminates connections, so it is the one that destroyed a deploy — but the same class of collision is reachable via `db reset`, and closing that is a separate change with its own blast radius.
- **The lock is per-fraise, per-host.** Cross-host coordination still requires the `database` backend, unchanged here.
- **Nothing recreates `/run/fraisier` for a timer firing while the webhook is stopped.** The failure is now legible rather than a traceback, but it is still a failure. Not a new dependency: `restore-staging.service` already read `FRAISIER_SYSTEMCTL_SOCKET` from that directory.

## Verification

- 4467 passed, 7 skipped (+14 collected, all new; 7 confirmed failing before the fix, and the #311 guards confirmed failing against the old template)
- Rendered artifacts inspected, not just templates: one `OnCalendar=` at 02:00, and `ExecStart` carrying `--skip-if-locked`
- `ruff check .` clean; `ruff format --check .` clean on 442 files; `ty check` clean

Version bump rolled in per convention. Minor, not patch — `--skip-if-locked` is a new user-facing option.

**Rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)