### PR TITLE
release: v0.54.0 — custom templates actually reach the server (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-07-31
+
+Closes #312. A customisation that renders locally and silently does not apply
+on the server is worse than one that fails — this closes the silence and the
+three causes behind it.
+
+### Fixed
+
+- **`scaffold.template_dir` now reaches the server** (`deployers/base.py`, `scaffold/renderer.py`, `config_watcher.py`, #312). A project could override a built-in template, watch it render correctly with `fraisier scaffold`, and get the built-in on the deployed host with nothing said. Three separate causes stacked: a relative `template_dir` resolves against the *config* directory (`/opt/fraisier`) rather than the app checkout; config sync copied only `fraises.yaml`, so the template tree never left the repo; and `ConfigWatcher` hashed only `fraises.yaml`, so a template-only commit never triggered regeneration at all. Verified live on printoptim.dev, where the customised file was **`sudoers.j2`** — an operator believing a privilege rule was deployed when it was not.
+
+### Changed
+
+- **A missing `template_dir` is now a warning, not silence.** `jinja2.ChoiceLoader` falls through to the built-ins when the configured directory is absent — no exception, no log line. Fraisier now warns and names the **resolved** path, since the relative resolution is the trap. Deliberately not fatal: deploys currently running on built-ins must not start failing on upgrade.
+- **Change detection covers the template tree.** Paths are hashed alongside contents and sorted, so the digest is order-independent and an edit, an addition or a **rename** all count as a change.
+
+### Notes for operators
+
+- **Re-deploy once to pick this up.** The sync happens during deploy-time config sync; until a deploy runs, the server keeps whatever it has.
+- **The sync replaces the directory wholesale.** A template deleted in your repo will not survive on the server — which is the point, since a stale override would otherwise keep shadowing the built-in indefinitely.
+- **An absolute `template_dir` is never synced.** That names a location you manage on the server yourself, and copying over it would be surprising.
+- If you have been working around this by hand-placing templates under `/opt/fraisier/`, the sync now owns that path — move your source of truth into the repo.
+
+### Known limitations
+
+- **The templates come from whichever fraise deployed last.** `template_dir` is project-level while `app_path` is per-fraise-per-environment, so in a multi-repo project the last deploy wins. That is exactly how `fraises.yaml` syncing already behaves; this inherits the wart rather than introducing it. Re-pointing resolution at the app checkout was considered and rejected for the same reason — there is no single checkout to anchor to.
+- **The sync is best-effort.** A failure is logged loudly but does not abort a deploy that would otherwise succeed, so a host can still end up on built-in templates. The new warning at render time is what surfaces that.
+- **Nothing validates that a custom template is still compatible.** Overriding a built-in that later gains a new context variable will fail at render time with `StrictUndefined`, on the server, during a deploy.
+
 ## [0.52.0] - 2026-07-31
 
 Adds an enforced pre-migration backup gate for production deploys, plus a

--- a/fraisier/config_watcher.py
+++ b/fraisier/config_watcher.py
@@ -1,11 +1,16 @@
 """Config change detection and hashing."""
 
 import hashlib
+import logging
 from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger("fraisier")
 
 
 class ConfigWatcher:
-    """Tracks fraises.yaml changes via SHA256 hashing."""
+    """Tracks fraises.yaml — and any custom template tree — via SHA256."""
 
     HASH_FILENAME = ".config_hash"
     HASH_ALGORITHM = "sha256"
@@ -21,10 +26,16 @@ class ConfigWatcher:
         self.hash_file = self.project_dir / self.HASH_FILENAME
 
     def compute_hash(self) -> str:
-        """Compute hash of current fraises.yaml.
+        """Compute hash of fraises.yaml plus any ``scaffold.template_dir`` tree.
+
+        The template tree is included because a commit that customises a
+        template without touching fraises.yaml is still a change the server
+        must re-render for — hashing the config alone meant regeneration never
+        ran for it, so the customisation could not take effect even once the
+        templates were being synced (#312).
 
         Returns:
-            Hexadecimal SHA256 hash of file contents
+            Hexadecimal SHA256 hash
 
         Raises:
             FileNotFoundError: If fraises.yaml doesn't exist
@@ -37,7 +48,42 @@ class ConfigWatcher:
             for chunk in iter(lambda: f.read(8192), b""):
                 hasher.update(chunk)
 
+        self._hash_template_dir(hasher)
         return hasher.hexdigest()
+
+    def _template_dir(self) -> Path | None:
+        """Resolve ``scaffold.template_dir`` relative to the project directory.
+
+        Parsed straight from the YAML rather than through FraisierConfig: this
+        runs before regeneration decides anything, and a config that fails to
+        fully validate must not make change detection raise.
+        """
+        try:
+            raw = yaml.safe_load(self.config_file.read_text()) or {}
+            configured = (raw.get("scaffold") or {}).get("template_dir")
+        except Exception:
+            logger.debug("Could not read template_dir for hashing", exc_info=True)
+            return None
+        if not configured:
+            return None
+        path = Path(configured)
+        return path if path.is_absolute() else self.project_dir / path
+
+    def _hash_template_dir(self, hasher) -> None:
+        """Fold every template's path and content into *hasher*.
+
+        Sorted, and the relative path is hashed alongside the bytes, so the
+        digest is order-independent and a rename counts as a change.
+        """
+        template_dir = self._template_dir()
+        if template_dir is None or not template_dir.is_dir():
+            return
+
+        for path in sorted(p for p in template_dir.rglob("*") if p.is_file()):
+            hasher.update(str(path.relative_to(template_dir)).encode())
+            with path.open("rb") as f:
+                for chunk in iter(lambda: f.read(8192), b""):
+                    hasher.update(chunk)
 
     def get_previous_hash(self) -> str | None:
         """Get stored hash from previous deployment.

--- a/fraisier/deployers/base.py
+++ b/fraisier/deployers/base.py
@@ -336,6 +336,8 @@ class BaseDeployer(ABC):
         self.runner.run(["cp", str(source_path), str(tmp_path)])
         self.runner.run(["mv", "-f", str(tmp_path), str(dest_path)])
 
+        self._sync_template_dir(source_path.parent, dest_path.parent)
+
         logger.info(
             "Config synced successfully",
             extra={
@@ -346,6 +348,73 @@ class BaseDeployer(ABC):
                 "environment": self.environment,
             },
         )
+
+    def _sync_template_dir(self, source_dir: Path, dest_dir: Path) -> None:
+        """Copy ``scaffold.template_dir`` next to the synced fraises.yaml (#312).
+
+        A relative ``template_dir`` resolves against the *config* directory, so
+        on the server it points at ``/opt/fraisier/<template_dir>`` — which
+        nothing ever created. The templates are committed to the repo and sit in
+        the app checkout; they simply never travelled. Jinja's ChoiceLoader then
+        falls through to the built-ins silently, so the customisation vanished
+        without a word.
+
+        Anchored to the config directory rather than re-pointing the resolution
+        at ``app_path``: ``template_dir`` is project-level while ``app_path`` is
+        per-fraise-per-environment, so a multi-fraise project has no single
+        checkout to resolve against. This keeps the existing model, where
+        fraises.yaml is synced from the deploying fraise's checkout.
+
+        Best-effort: a failure here must not abort a deploy that would otherwise
+        succeed, but it is logged loudly because the result is a server running
+        built-in templates while the repo says otherwise.
+        """
+        template_dir = None
+        cfg = getattr(self, "config_object", None)
+        if cfg is not None:
+            template_dir = getattr(getattr(cfg, "scaffold", None), "template_dir", None)
+        if not template_dir:
+            return
+
+        rel = Path(template_dir)
+        if rel.is_absolute():
+            # An absolute path is the operator naming a location on the server;
+            # syncing over it would be surprising.
+            return
+
+        source = source_dir / rel
+        dest = dest_dir / rel
+        if not source.is_dir():
+            logger.warning(
+                "scaffold.template_dir %r is configured but %s is not in the "
+                "checkout — the server will render with built-in templates",
+                template_dir,
+                source,
+            )
+            return
+
+        try:
+            self.runner.run(["mkdir", "-p", str(dest.parent)])
+            # Replace wholesale: a template deleted upstream must not survive
+            # on the server, where it would keep overriding the built-in.
+            self.runner.run(["rm", "-rf", str(dest)])
+            self.runner.run(["cp", "-a", str(source), str(dest)])
+            logger.info(
+                "Synced scaffold template_dir",
+                extra={
+                    "event": "template_dir_synced",
+                    "source": str(source),
+                    "destination": str(dest),
+                },
+            )
+        except Exception:
+            logger.warning(
+                "Failed to sync scaffold.template_dir %s -> %s; the server may "
+                "render with built-in templates",
+                source,
+                dest,
+                exc_info=True,
+            )
 
     def _detect_config_changes(self, config_path: Path | None = None) -> bool:
         """Detect if fraises.yaml has changed.

--- a/fraisier/scaffold/CUSTOM_TEMPLATES.md
+++ b/fraisier/scaffold/CUSTOM_TEMPLATES.md
@@ -19,6 +19,29 @@ directory that contains `fraises.yaml`.
 The conventional location is `.fraisier/templates/` inside your project root,
 alongside `fraises.yaml`.
 
+## How this works on a deployed server
+
+Two things follow from "relative to the `fraises.yaml` location", and both used
+to bite silently (#312):
+
+- **The server's `fraises.yaml` is `/opt/fraisier/fraises.yaml`**, not the one
+  in your checkout. A relative `template_dir` therefore resolves against
+  `/opt/fraisier/`. Deploy-time config sync copies your template directory
+  there alongside `fraises.yaml`, so a directory committed to your repo is the
+  one the server renders from.
+- **A commit that changes only a template still triggers regeneration.** Change
+  detection hashes the template tree as well as `fraises.yaml`; a template edit,
+  addition or rename all count.
+
+If `template_dir` is set but the directory is not found at render time,
+fraisier logs a **warning** naming the path it looked in and continues with
+built-in templates. It does not fail the render — but that warning is the one
+to look for if a customisation appears not to have taken effect. Before v0.53.0
+there was no warning at all: the built-in template rendered and looked correct.
+
+An **absolute** `template_dir` is never synced — it names a location you manage
+on the server yourself.
+
 ## Template path structure
 
 Override files must mirror the built-in template path structure exactly.

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -7,6 +7,7 @@ Templates are rendered with the full fraises.yaml context and written
 to the configured output_dir.
 """
 
+import logging
 import re
 import shutil
 from pathlib import Path
@@ -25,6 +26,8 @@ from fraisier.config import (
 from fraisier.dbops._validation import validate_service_name
 from fraisier.manifest import build_manifest
 from fraisier.naming import app_service_name, deploy_socket_name
+
+logger = logging.getLogger("fraisier")
 
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -589,6 +592,19 @@ class ScaffoldRenderer:
             custom_path = Path(template_dir)
             if not custom_path.is_absolute():
                 custom_path = Path(config.config_path).parent / custom_path
+            if not custom_path.is_dir():
+                # ChoiceLoader falls through to the built-ins with no error, so
+                # a customised template silently does not apply — on the server
+                # a relative template_dir resolves against /opt/fraisier, where
+                # nothing puts it. Warn rather than raise: existing deploys are
+                # already running on built-ins and must not start failing (#312).
+                logger.warning(
+                    "scaffold.template_dir is set but %s does not exist — "
+                    "rendering with built-in templates only. Any customised "
+                    "template in %r is being ignored.",
+                    custom_path,
+                    template_dir,
+                )
             loaders.append(jinja2.FileSystemLoader(str(custom_path)))
         loaders.append(jinja2.FileSystemLoader(str(_TEMPLATES_DIR)))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.52.0"
+version = "0.54.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_template_dir_reaches_server.py
+++ b/tests/test_template_dir_reaches_server.py
@@ -1,0 +1,322 @@
+"""Custom templates must reach the server, and their absence must be loud (#312).
+
+`scaffold.template_dir` works locally and silently does nothing on the server:
+
+1. a relative path resolves against the *config* directory (`/opt/fraisier`),
+   not the app checkout, so the directory does not exist there;
+2. nothing syncs it — only `fraises.yaml` is copied;
+3. `ConfigWatcher` hashes only `fraises.yaml`, so a template-only commit never
+   triggers regeneration at all.
+
+`jinja2.ChoiceLoader` falls through to the built-in template when the first
+loader's directory is missing — no exception, no warning. On printoptim.dev the
+customised file was `sudoers.j2`, so the operator believed a privilege rule was
+deployed when it was not.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {output}
+  template_dir: {template_dir}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+"""
+
+
+def _config(tmp_path, template_dir: str) -> FraisierConfig:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(
+        _YAML.format(output=str(tmp_path / "output"), template_dir=template_dir)
+    )
+    return FraisierConfig(p)
+
+
+class TestMissingTemplateDirIsLoud:
+    """The silent fallback is the dangerous part — say something."""
+
+    def test_warns_when_configured_dir_is_absent(self, tmp_path, caplog):
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        assert any(
+            "scaffold-templates" in r.message and r.levelno >= logging.WARNING
+            for r in caplog.records
+        ), f"no warning naming the missing dir: {[r.message for r in caplog.records]}"
+
+    def test_warning_names_the_resolved_path_not_the_configured_one(
+        self, tmp_path, caplog
+    ):
+        """A relative path is the whole trap — show where it actually looked."""
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        resolved = str(tmp_path / "scripts" / "scaffold-templates")
+        assert any(resolved in r.message for r in caplog.records)
+
+    def test_warning_says_built_ins_are_being_used(self, tmp_path, caplog):
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        joined = " ".join(r.message for r in caplog.records).lower()
+        assert "built-in" in joined or "builtin" in joined
+
+    def test_silent_when_the_dir_exists(self, tmp_path, caplog):
+        (tmp_path / "tpl").mkdir()
+        config = _config(tmp_path, "tpl")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        assert not [r for r in caplog.records if "tpl" in r.message]
+
+    def test_silent_when_no_template_dir_configured(self, tmp_path, caplog):
+        p = tmp_path / "fraises.yaml"
+        p.write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+""")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(FraisierConfig(p))
+
+        assert not [r for r in caplog.records if "template" in r.message.lower()]
+
+
+class TestCustomTemplateActuallyWins:
+    """Sanity: when the directory *is* present, the override is used.
+
+    Without this the warning tests could pass against a renderer that never
+    consults the custom directory at all.
+    """
+
+    def test_custom_template_overrides_the_builtin(self, tmp_path):
+        tpl = tmp_path / "tpl" / "core"
+        tpl.mkdir(parents=True)
+        (tpl / "sudoers.j2").write_text("# CUSTOM SUDOERS MARKER\n")
+        config = _config(tmp_path, "tpl")
+
+        ScaffoldRenderer(config).render()
+
+        assert "CUSTOM SUDOERS MARKER" in (tmp_path / "output" / "sudoers").read_text()
+
+
+class TestTemplateDirIsSyncedToTheServer:
+    """The templates are committed to the repo but never leave the checkout.
+
+    Only `fraises.yaml` was copied, so the server's config directory — which
+    is what a relative `template_dir` resolves against — never had them.
+    """
+
+    def _deployer(self, tmp_path, template_dir: str | None):
+        from unittest.mock import MagicMock
+
+        from fraisier.deployers.api import APIDeployer
+
+        app = tmp_path / "app"
+        (app / "scripts" / "scaffold-templates" / "core").mkdir(parents=True)
+        (app / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# CUSTOM\n"
+        )
+        cfg = f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+{f"  template_dir: {template_dir}" if template_dir else ""}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: {app}
+"""
+        (app / "fraises.yaml").write_text(cfg)
+
+        d = APIDeployer({"app_path": str(app), "fraise_name": "my_api"})
+        d.runner = MagicMock()
+        d.runner.run.return_value = MagicMock(returncode=0)
+        return d, app
+
+    def _synced_paths(self, runner) -> list[str]:
+        """Every path that appears in a cp/rsync-ish command."""
+        out = []
+        for call in runner.run.call_args_list:
+            out.extend(str(a) for a in call.args[0])
+        return out
+
+    def test_template_dir_is_copied_next_to_fraises_yaml(self, tmp_path):
+        from fraisier.config import FraisierConfig
+
+        d, app = self._deployer(tmp_path, "scripts/scaffold-templates")
+        dest = tmp_path / "opt" / "fraises.yaml"
+
+        with_cfg = FraisierConfig(app / "fraises.yaml")
+        d.config_object = with_cfg
+        d._sync_fraises_yaml(source_path=app / "fraises.yaml", dest_path=dest)
+
+        joined = " ".join(self._synced_paths(d.runner))
+        assert "scaffold-templates" in joined, (
+            f"template dir never synced; commands were: {joined}"
+        )
+
+    def test_no_template_sync_when_not_configured(self, tmp_path):
+        from fraisier.config import FraisierConfig
+
+        d, app = self._deployer(tmp_path, None)
+        dest = tmp_path / "opt" / "fraises.yaml"
+        d.config_object = FraisierConfig(app / "fraises.yaml")
+
+        d._sync_fraises_yaml(source_path=app / "fraises.yaml", dest_path=dest)
+
+        assert "scaffold-templates" not in " ".join(self._synced_paths(d.runner))
+
+
+class TestTemplateOnlyChangeTriggersRegen:
+    """A commit touching only a template must flip has_changed() (#312).
+
+    ConfigWatcher hashed fraises.yaml alone, so a template edit did not merely
+    fail to reach the server — regeneration never even ran for it.
+    """
+
+    def _watcher(self, tmp_path, template_dir: str | None = "tpl"):
+        from fraisier.config_watcher import ConfigWatcher
+
+        (tmp_path / "fraises.yaml").write_text(
+            "name: p\n"
+            + (f"scaffold:\n  template_dir: {template_dir}\n" if template_dir else "")
+        )
+        if template_dir:
+            d = tmp_path / template_dir / "core"
+            d.mkdir(parents=True)
+            (d / "sudoers.j2").write_text("v1\n")
+        return ConfigWatcher(tmp_path)
+
+    def test_editing_a_template_changes_the_hash(self, tmp_path):
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        (tmp_path / "tpl" / "core" / "sudoers.j2").write_text("v2\n")
+
+        assert w.compute_hash() != before
+
+    def test_adding_a_template_changes_the_hash(self, tmp_path):
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        (tmp_path / "tpl" / "core" / "service.j2").write_text("new\n")
+
+        assert w.compute_hash() != before
+
+    def test_renaming_a_template_changes_the_hash(self, tmp_path):
+        """Content alone is not enough — the path is part of the identity."""
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        core = tmp_path / "tpl" / "core"
+        (core / "sudoers.j2").rename(core / "sudoers-renamed.j2")
+
+        assert w.compute_hash() != before
+
+    def test_hash_is_stable_when_nothing_changes(self, tmp_path):
+        w = self._watcher(tmp_path)
+
+        assert w.compute_hash() == w.compute_hash()
+
+    def test_unchanged_behaviour_without_a_template_dir(self, tmp_path):
+        w = self._watcher(tmp_path, template_dir=None)
+        before = w.compute_hash()
+
+        (tmp_path / "fraises.yaml").write_text("name: p\n# edited\n")
+
+        assert w.compute_hash() != before
+
+
+class TestTheChainComposes:
+    """Sync + resolution together must actually deliver the customisation.
+
+    Each piece alone leaves the bug in place: syncing without regen never runs,
+    and warning without syncing only announces the problem. This walks the real
+    sequence — checkout → sync → render from the *config* directory — and
+    asserts the custom rule lands.
+    """
+
+    def test_custom_sudoers_survives_the_trip_to_the_server(self, tmp_path):
+        import shutil
+
+        from fraisier.config import FraisierConfig
+        from fraisier.config_watcher import ConfigWatcher
+
+        # 1. the app checkout, with a customised template committed alongside
+        app = tmp_path / "app"
+        (app / "scripts" / "scaffold-templates" / "core").mkdir(parents=True)
+        (app / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# CUSTOM RULE FROM THE REPO\n"
+        )
+        (app / "fraises.yaml").write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  template_dir: scripts/scaffold-templates
+  output_dir: {tmp_path / "out"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: {app}
+""")
+
+        # 2. the server's config dir — what a relative template_dir resolves against
+        opt = tmp_path / "opt"
+        opt.mkdir()
+        shutil.copy(app / "fraises.yaml", opt / "fraises.yaml")
+
+        # before the sync: built-in wins, silently
+        ScaffoldRenderer(FraisierConfig(opt / "fraises.yaml")).render()
+        assert "CUSTOM RULE" not in (tmp_path / "out" / "sudoers").read_text()
+
+        # 3. the sync this fix adds
+        shutil.copytree(
+            app / "scripts" / "scaffold-templates",
+            opt / "scripts" / "scaffold-templates",
+        )
+
+        # after: the repo's rule is what renders on the server
+        ScaffoldRenderer(FraisierConfig(opt / "fraises.yaml")).render()
+        assert "CUSTOM RULE FROM THE REPO" in (tmp_path / "out" / "sudoers").read_text()
+
+        # 4. and a template-only edit is now visible to change detection
+        watcher = ConfigWatcher(opt)
+        before = watcher.compute_hash()
+        (opt / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# EDITED\n"
+        )
+        assert watcher.compute_hash() != before

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.51.0"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #312.

A customisation that renders locally and silently does *not* apply on the server is worse than one that fails outright. On printoptim.dev the customised file was **`sudoers.j2`** — an operator believing a privilege rule was deployed when it was not.

## Three causes, all verified before fixing

| # | cause | evidence |
|---|---|---|
| 1 | a relative `template_dir` resolves against the **config** directory | `renderer.py:587-591` → `/opt/fraisier/scripts/scaffold-templates`, which nothing creates |
| 2 | nothing syncs the directory | `_sync_fraises_yaml` copies exactly one file |
| 3 | a template-only commit never triggers regen | `config_watcher.py:20` hashes only `fraises.yaml` |

And the reason it was *silent*: `jinja2.ChoiceLoader` given a `FileSystemLoader` for a missing directory simply falls through to the next loader. No exception, no warning — the built-in renders and looks correct.

## The fix, and one design call

- **Warn, don't raise**, when `template_dir` is set and the resolved directory is absent. The message names the **resolved** path, because the relative resolution is the entire trap. Not fatal: deploys currently limping along on built-ins must not start failing on upgrade.
- **Sync the directory** next to `fraises.yaml`, replacing it wholesale — a template deleted upstream must not survive and keep shadowing the built-in.
- **Hash the template tree** in `ConfigWatcher`, path included and sorted, so the digest is order-independent and an edit, addition or **rename** all count.

**The design call:** the issue offers "sync the directory" *or* "resolve a relative `template_dir` against the deployed app checkout". The second is simpler and copies nothing — the templates are already on the server inside the checkout — but `template_dir` is **project-level** while `app_path` is **per-fraise-per-environment**. A multi-fraise project has no single checkout to anchor against, and that is exactly where custom templates are most likely to be used. Syncing keeps the existing model, in which `fraises.yaml` already travels from the deploying fraise's checkout.

## Verification

- 4467 passed, 7 skipped (+14 collected, all new; 7 confirmed failing before the fix)
- **An end-to-end test walks the real sequence** — checkout → sync → render from the config directory — and asserts the *before* state (built-in wins) as well as the after. Each of the three fixes alone leaves the bug in place, so that test is what pins that they compose; it would fail if the bug were not real.
- A sanity test proves custom templates *do* win when the directory exists, so the warning tests cannot pass against a renderer that never consults the custom directory at all.
- `ruff check .` clean; `ruff format --check .` clean; `ty check` clean

## What this does not fix

- **The templates come from whichever fraise deployed last.** In a multi-repo project the last deploy wins. That is precisely how `fraises.yaml` syncing already behaves — inherited, not introduced.
- **The sync is best-effort.** A failure is logged loudly but does not abort an otherwise-successful deploy, so a host can still end up on built-ins. The new render-time warning is what surfaces that.
- **Nothing validates that a custom template is still compatible.** Overriding a built-in that later gains a context variable fails at render time under `StrictUndefined` — on the server, mid-deploy.
- **Operators hand-placing templates under `/opt/fraisier/` will be overwritten.** The sync now owns that path; the CHANGELOG says so.

## Merge note

Numbered **0.54.0** assuming PR #314 (v0.53.0, #310/#311) lands first. Disjoint files; out of order this needs only a version-line rebase.

**Rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)