### PR TITLE
release: v0.53.0 — restore/deploy collision closed, custom templates reach the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-07-31
+
+Closes #310, #311 and #312 — all three found by running fraisier in anger on
+printoptim.dev, and all three of the same shape: **something silently did not
+happen, and nothing said so.**
+
+Two of them are the halves of one incident. On 2026-07-30 at 00:00 UTC the
+staging-restore timer fired **on top of an in-flight deploy**, stopped the API
+service and terminated every connection to the staging database. The deploy's
+`pg_restore` died with `FATAL: terminating connection due to administrator
+command`, the deploy reported FAILED, and staging was left half-restored. Two
+independent defects had to line up for that: the timer fired at an hour nobody
+had scheduled, and nothing stopped a restore running concurrently with a deploy.
+
+### Fixed
+
+- **`db restore` now holds the deployment lock** (`cli/db.py`, #310). `fraisier.locking` has always provided per-fraise mutual exclusion and the webhook wraps every deployment in `deployment_lock(fraise)` — but the `db restore` CLI never acquired it, so a timer-, cron- or hand-driven restore ran completely unsynchronised with deploys of the same fraise. It now takes the same lock, across the whole live restore.
+- **The staging-restore timer no longer fires twice a day** (`core/restore-staging.timer.j2`, #311). The template carried both `OnCalendar=daily` and `OnCalendar=*-*-* 02:00:00` under a comment promising 2 AM. `OnCalendar=` **accumulates** — per `systemd.timer(5)` the trigger list resets only when the *empty* string is assigned — so the unit also fired at 00:00. Confirmed live: `systemctl list-timers` showed LAST 02:00 / NEXT 00:00 on the same unit, which a single-trigger timer cannot do.
+- **`scaffold.template_dir` now reaches the server** (`deployers/base.py`, `scaffold/renderer.py`, `config_watcher.py`, #312). A project could override a built-in template, watch it render correctly with `fraisier scaffold`, and get the built-in on the deployed host with nothing said. Three causes stacked: a relative `template_dir` resolves against the *config* directory (`/opt/fraisier`) rather than the app checkout; config sync copied only `fraises.yaml`, so the template tree never left the repo; and `ConfigWatcher` hashed only `fraises.yaml`, so a template-only commit never triggered regeneration at all. Verified live, where the customised file was **`sudoers.j2`** — an operator believing a privilege rule was deployed when it was not.
+
+### Added
+
+- **`fraisier db restore --skip-if-locked`** — exit 0 with a clear line instead of failing when a deploy holds the lock. The generated `restore-staging.service` passes it: a concurrent staging deploy is itself restoring from production, so a collision means the work is already being done. Without this the new lock would convert a harmless overlap into a nightly failed unit.
+
+### Changed
+
+- **A missing `template_dir` is now a warning, not silence** (#312). `jinja2.ChoiceLoader` falls through to the built-ins when the configured directory is absent — no exception, no log line. Fraisier now warns and names the **resolved** path, since the relative resolution is the trap. Deliberately not fatal: deploys currently running on built-ins must not start failing on upgrade.
+- **Change detection covers the template tree** (#312). Paths are hashed alongside contents and sorted, so the digest is order-independent and an edit, an addition or a **rename** all count as a change.
+
+### Notes for operators
+
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`, then deploy once.** #310 and #311 live in generated units; #312's template sync happens during deploy-time config sync. Until both, hosts keep the old behaviour.
+- If you applied the `flock` drop-in from #310 as an interim mitigation, it can be removed — it is harmless if left.
+- **`--dry-run` does not take the lock.** It mutates nothing, so a running deploy will not veto a plan preview.
+- **A lock that cannot be evaluated is an error, not a skip.** If the lock directory is missing or unwritable, `db restore` fails with a message naming it — even under `--skip-if-locked`. "I cannot tell whether a deploy is running" must never be treated as "no deploy is running". `/run/fraisier` is tmpfs, created by the webhook unit's `RuntimeDirectory=`; `restore-staging.service` already depended on it for its systemctl socket, so this is not a new requirement.
+- **The template sync replaces the directory wholesale.** A template deleted in your repo will not survive on the server — the point, since a stale override would otherwise shadow the built-in indefinitely. An **absolute** `template_dir` is never synced; that names a location you manage yourself. If you have been hand-placing templates under `/opt/fraisier/`, move your source of truth into the repo.
+
+### Known limitations
+
+- **Only `db restore` was given the lock.** The other `db` subcommands (`exec`, `reset`, `migrate`, `build`) still run unsynchronised. `restore` is the one that stops the service and terminates connections, so it is the one that destroyed a deploy — but the same class of collision is reachable through `db reset`, and closing that is a separate change with its own blast radius.
+- **The lock is per-fraise and per-host.** Cross-host coordination still requires the `database` lock backend, unchanged here.
+- **Nothing recreates `/run/fraisier` for a timer firing while the webhook is stopped.** The failure is now legible rather than a traceback, but it is still a failure.
+- **Custom templates come from whichever fraise deployed last.** `template_dir` is project-level while `app_path` is per-fraise-per-environment, so in a multi-repo project the last deploy wins. That is exactly how `fraises.yaml` syncing already behaves; this inherits the wart rather than introducing it. Re-anchoring resolution at the app checkout was considered and rejected for the same reason.
+- **The template sync is best-effort.** A failure is logged loudly but does not abort an otherwise-successful deploy, so a host can still end up on built-ins; the new render-time warning is what surfaces that.
+- **Nothing validates that a custom template is still compatible.** Overriding a built-in that later gains a context variable fails at render time under `StrictUndefined` — on the server, mid-deploy.
+
 ## [0.52.0] - 2026-07-31
 
 Adds an enforced pre-migration backup gate for production deploys, plus a

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -514,6 +514,14 @@ def db_preflight(ctx: click.Context, fraise: str, env: str, fmt: str) -> None:
     default=None,
     help="Prefer backups compressed with this algorithm (overrides config)",
 )
+@click.option(
+    "--skip-if-locked",
+    is_flag=True,
+    help=(
+        "Exit 0 instead of failing when a deploy holds the lock. "
+        "For timer units, where a skipped nightly restore is a non-event."
+    ),
+)
 @click.pass_context
 def db_restore(
     ctx: click.Context,
@@ -525,11 +533,16 @@ def db_restore(
     skip_preflight: bool,
     jobs: int | None,
     preferred_compression: str | None,
+    skip_if_locked: bool,
 ) -> None:
     """Restore staging database from a production backup.
 
     Stops the service, runs pg_restore, creates a rollback template,
     applies pending migrations, and restarts the service.
+
+    Holds the same per-fraise deployment lock the webhook uses, so a restore
+    and a deploy of the same fraise can never interleave. --dry-run does not
+    take the lock, since it changes nothing.
 
     \b
     Examples:
@@ -621,88 +634,123 @@ def db_restore(
         return
 
     # --- live run ---
-    runner = LocalRunner()
-    svc_mgr = (
-        get_service_manager(runner, config._config)
-        if systemd_service and not no_service_restart
-        else None
-    )
-
-    from fraisier.config.schema import PreflightConfig
-
-    preflight_cfg = db_cfg.get("preflight") or {}
-    preflight = PreflightConfig(
-        enabled=bool(preflight_cfg.get("enabled", True)),
-        timeout_seconds=int(preflight_cfg.get("timeout_seconds", 120)),
-    )
-
-    strategy = RestoreMigrateStrategy(
-        RestoreConfig(
-            db_name=db_name,
-            backup_dir=_Path(restore_cfg.get("backup_dir", ".")),
-            backup_pattern=restore_cfg.get("backup_pattern", "*.dump"),
-            max_age_hours=float(restore_cfg.get("max_age_hours", 48.0)),
-            target_owner=restore_cfg.get("target_owner"),
-            create_template=bool(restore_cfg.get("create_template", False)),
-            template_name=restore_cfg.get("template_name"),
-            min_tables=int(restore_cfg.get("min_tables", 0)),
-            jobs=jobs if jobs is not None else int(restore_cfg.get("jobs", 1)),
-            preferred_compression=(
-                preferred_compression
-                if preferred_compression is not None
-                else restore_cfg.get("preferred_compression")
-            ),
-            backup_path=from_backup,
-            preflight=preflight,
-        ),
-        admin_url=admin_url,
-        service_manager=svc_mgr,
-        service_name=systemd_service,
-    )
+    # Hold the same per-fraise lock the webhook takes (#310). A timer-, cron- or
+    # hand-driven restore stops the service and terminates every connection to
+    # the database; without this it can do that underneath an in-flight deploy
+    # of the same fraise, killing its pg_restore and leaving the DB half-done.
+    from fraisier.errors import DeploymentLockError
+    from fraisier.locking import deployment_lock
 
     try:
-        result = strategy.execute(
-            confiture_config,
-            migrations_dir=app_path / "db" / "migrations",
-            skip_preflight=skip_preflight,
-        )
-    except DatabaseError as exc:
-        if svc_mgr and systemd_service:
-            msg = f"[yellow]Restarting {systemd_service} after error...[/yellow]"
-            console.print(msg)
-            svc_mgr.restart(systemd_service)
-        console.print(f"[red]Restore failed:[/red] {exc}")
-        raise SystemExit(1) from exc
+        with deployment_lock(fraise):
+            runner = LocalRunner()
+            svc_mgr = (
+                get_service_manager(runner, config._config)
+                if systemd_service and not no_service_restart
+                else None
+            )
 
-    if not result.success:
-        errors = ", ".join(result.errors)
-        console.print(f"[red]Restore failed:[/red] {errors}")
-        raise SystemExit(1)
+            from fraisier.config.schema import PreflightConfig
 
-    msg = f"{result.migrations_applied} migration(s) applied"
-    console.print(f"[green]Restore complete:[/green] {msg}")
-    if result.total_duration_seconds > 0:
+            preflight_cfg = db_cfg.get("preflight") or {}
+            preflight = PreflightConfig(
+                enabled=bool(preflight_cfg.get("enabled", True)),
+                timeout_seconds=int(preflight_cfg.get("timeout_seconds", 120)),
+            )
+
+            strategy = RestoreMigrateStrategy(
+                RestoreConfig(
+                    db_name=db_name,
+                    backup_dir=_Path(restore_cfg.get("backup_dir", ".")),
+                    backup_pattern=restore_cfg.get("backup_pattern", "*.dump"),
+                    max_age_hours=float(restore_cfg.get("max_age_hours", 48.0)),
+                    target_owner=restore_cfg.get("target_owner"),
+                    create_template=bool(restore_cfg.get("create_template", False)),
+                    template_name=restore_cfg.get("template_name"),
+                    min_tables=int(restore_cfg.get("min_tables", 0)),
+                    jobs=jobs if jobs is not None else int(restore_cfg.get("jobs", 1)),
+                    preferred_compression=(
+                        preferred_compression
+                        if preferred_compression is not None
+                        else restore_cfg.get("preferred_compression")
+                    ),
+                    backup_path=from_backup,
+                    preflight=preflight,
+                ),
+                admin_url=admin_url,
+                service_manager=svc_mgr,
+                service_name=systemd_service,
+            )
+
+            try:
+                result = strategy.execute(
+                    confiture_config,
+                    migrations_dir=app_path / "db" / "migrations",
+                    skip_preflight=skip_preflight,
+                )
+            except DatabaseError as exc:
+                if svc_mgr and systemd_service:
+                    msg = (
+                        f"[yellow]Restarting {systemd_service} after error...[/yellow]"
+                    )
+                    console.print(msg)
+                    svc_mgr.restart(systemd_service)
+                console.print(f"[red]Restore failed:[/red] {exc}")
+                raise SystemExit(1) from exc
+
+            if not result.success:
+                errors = ", ".join(result.errors)
+                console.print(f"[red]Restore failed:[/red] {errors}")
+                raise SystemExit(1)
+
+            msg = f"{result.migrations_applied} migration(s) applied"
+            console.print(f"[green]Restore complete:[/green] {msg}")
+            if result.total_duration_seconds > 0:
+                console.print(
+                    f"  Restore: {result.restore_duration_seconds:.1f}s"
+                    f" | Migration: {result.migration_duration_seconds:.1f}s"
+                    f" | Total: {result.total_duration_seconds:.1f}s"
+                )
+
+            # Re-apply configured grant scripts. The restore strategy restores with
+            # pg_restore --no-owner --no-acl, so without this the restored DB is
+            # grantless for every non-owner role — the deploy path already does this
+            # via _run_post_migrate, the standalone CLI path did not (issue #273).
+            from fraisier import post_migrate
+            from fraisier.errors import DeploymentError
+
+            try:
+                post_migrate.run_configured_post_migrate(
+                    db_cfg,
+                    app_path=app_path,
+                    runner=runner,
+                )
+            except DeploymentError as exc:
+                console.print(f"[red]post_migrate failed:[/red] {exc}")
+                raise SystemExit(1) from exc
+    except DeploymentLockError as exc:
+        if skip_if_locked:
+            # Timer units pass this: a skipped nightly restore is a non-event,
+            # since a concurrent staging deploy is itself restoring from prod.
+            console.print(f"[yellow]Skipping restore:[/yellow] {exc}")
+            return
+        console.print(f"[red]Error:[/red] {exc}")
         console.print(
-            f"  Restore: {result.restore_duration_seconds:.1f}s"
-            f" | Migration: {result.migration_duration_seconds:.1f}s"
-            f" | Total: {result.total_duration_seconds:.1f}s"
+            "  A deploy is in progress for this fraise. Retry once it finishes, "
+            "or pass --skip-if-locked (used by the generated timer unit)."
         )
-
-    # Re-apply configured grant scripts. The restore strategy restores with
-    # pg_restore --no-owner --no-acl, so without this the restored DB is
-    # grantless for every non-owner role — the deploy path already does this
-    # via _run_post_migrate, the standalone CLI path did not (issue #273).
-    from fraisier import post_migrate
-    from fraisier.errors import DeploymentError
-
-    try:
-        post_migrate.run_configured_post_migrate(
-            db_cfg,
-            app_path=app_path,
-            runner=runner,
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        # The lock could not be evaluated at all — /run/fraisier is tmpfs and is
+        # created by the webhook unit's RuntimeDirectory=. Deliberately not
+        # covered by --skip-if-locked: "I cannot tell whether a deploy is
+        # running" must never be treated as "no deploy is running".
+        console.print(f"[red]Error:[/red] cannot acquire the deployment lock: {exc}")
+        console.print(
+            "  The lock directory (default /run/fraisier) must exist and be "
+            "writable by this user. It is created by the webhook unit and by "
+            "`fraisier setup`; after a reboot it appears when the webhook starts."
         )
-    except DeploymentError as exc:
-        console.print(f"[red]post_migrate failed:[/red] {exc}")
         raise SystemExit(1) from exc
 
 

--- a/fraisier/config_watcher.py
+++ b/fraisier/config_watcher.py
@@ -1,11 +1,16 @@
 """Config change detection and hashing."""
 
 import hashlib
+import logging
 from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger("fraisier")
 
 
 class ConfigWatcher:
-    """Tracks fraises.yaml changes via SHA256 hashing."""
+    """Tracks fraises.yaml — and any custom template tree — via SHA256."""
 
     HASH_FILENAME = ".config_hash"
     HASH_ALGORITHM = "sha256"
@@ -21,10 +26,16 @@ class ConfigWatcher:
         self.hash_file = self.project_dir / self.HASH_FILENAME
 
     def compute_hash(self) -> str:
-        """Compute hash of current fraises.yaml.
+        """Compute hash of fraises.yaml plus any ``scaffold.template_dir`` tree.
+
+        The template tree is included because a commit that customises a
+        template without touching fraises.yaml is still a change the server
+        must re-render for — hashing the config alone meant regeneration never
+        ran for it, so the customisation could not take effect even once the
+        templates were being synced (#312).
 
         Returns:
-            Hexadecimal SHA256 hash of file contents
+            Hexadecimal SHA256 hash
 
         Raises:
             FileNotFoundError: If fraises.yaml doesn't exist
@@ -37,7 +48,42 @@ class ConfigWatcher:
             for chunk in iter(lambda: f.read(8192), b""):
                 hasher.update(chunk)
 
+        self._hash_template_dir(hasher)
         return hasher.hexdigest()
+
+    def _template_dir(self) -> Path | None:
+        """Resolve ``scaffold.template_dir`` relative to the project directory.
+
+        Parsed straight from the YAML rather than through FraisierConfig: this
+        runs before regeneration decides anything, and a config that fails to
+        fully validate must not make change detection raise.
+        """
+        try:
+            raw = yaml.safe_load(self.config_file.read_text()) or {}
+            configured = (raw.get("scaffold") or {}).get("template_dir")
+        except Exception:
+            logger.debug("Could not read template_dir for hashing", exc_info=True)
+            return None
+        if not configured:
+            return None
+        path = Path(configured)
+        return path if path.is_absolute() else self.project_dir / path
+
+    def _hash_template_dir(self, hasher) -> None:
+        """Fold every template's path and content into *hasher*.
+
+        Sorted, and the relative path is hashed alongside the bytes, so the
+        digest is order-independent and a rename counts as a change.
+        """
+        template_dir = self._template_dir()
+        if template_dir is None or not template_dir.is_dir():
+            return
+
+        for path in sorted(p for p in template_dir.rglob("*") if p.is_file()):
+            hasher.update(str(path.relative_to(template_dir)).encode())
+            with path.open("rb") as f:
+                for chunk in iter(lambda: f.read(8192), b""):
+                    hasher.update(chunk)
 
     def get_previous_hash(self) -> str | None:
         """Get stored hash from previous deployment.

--- a/fraisier/deployers/base.py
+++ b/fraisier/deployers/base.py
@@ -336,6 +336,8 @@ class BaseDeployer(ABC):
         self.runner.run(["cp", str(source_path), str(tmp_path)])
         self.runner.run(["mv", "-f", str(tmp_path), str(dest_path)])
 
+        self._sync_template_dir(source_path.parent, dest_path.parent)
+
         logger.info(
             "Config synced successfully",
             extra={
@@ -346,6 +348,73 @@ class BaseDeployer(ABC):
                 "environment": self.environment,
             },
         )
+
+    def _sync_template_dir(self, source_dir: Path, dest_dir: Path) -> None:
+        """Copy ``scaffold.template_dir`` next to the synced fraises.yaml (#312).
+
+        A relative ``template_dir`` resolves against the *config* directory, so
+        on the server it points at ``/opt/fraisier/<template_dir>`` — which
+        nothing ever created. The templates are committed to the repo and sit in
+        the app checkout; they simply never travelled. Jinja's ChoiceLoader then
+        falls through to the built-ins silently, so the customisation vanished
+        without a word.
+
+        Anchored to the config directory rather than re-pointing the resolution
+        at ``app_path``: ``template_dir`` is project-level while ``app_path`` is
+        per-fraise-per-environment, so a multi-fraise project has no single
+        checkout to resolve against. This keeps the existing model, where
+        fraises.yaml is synced from the deploying fraise's checkout.
+
+        Best-effort: a failure here must not abort a deploy that would otherwise
+        succeed, but it is logged loudly because the result is a server running
+        built-in templates while the repo says otherwise.
+        """
+        template_dir = None
+        cfg = getattr(self, "config_object", None)
+        if cfg is not None:
+            template_dir = getattr(getattr(cfg, "scaffold", None), "template_dir", None)
+        if not template_dir:
+            return
+
+        rel = Path(template_dir)
+        if rel.is_absolute():
+            # An absolute path is the operator naming a location on the server;
+            # syncing over it would be surprising.
+            return
+
+        source = source_dir / rel
+        dest = dest_dir / rel
+        if not source.is_dir():
+            logger.warning(
+                "scaffold.template_dir %r is configured but %s is not in the "
+                "checkout — the server will render with built-in templates",
+                template_dir,
+                source,
+            )
+            return
+
+        try:
+            self.runner.run(["mkdir", "-p", str(dest.parent)])
+            # Replace wholesale: a template deleted upstream must not survive
+            # on the server, where it would keep overriding the built-in.
+            self.runner.run(["rm", "-rf", str(dest)])
+            self.runner.run(["cp", "-a", str(source), str(dest)])
+            logger.info(
+                "Synced scaffold template_dir",
+                extra={
+                    "event": "template_dir_synced",
+                    "source": str(source),
+                    "destination": str(dest),
+                },
+            )
+        except Exception:
+            logger.warning(
+                "Failed to sync scaffold.template_dir %s -> %s; the server may "
+                "render with built-in templates",
+                source,
+                dest,
+                exc_info=True,
+            )
 
     def _detect_config_changes(self, config_path: Path | None = None) -> bool:
         """Detect if fraises.yaml has changed.

--- a/fraisier/scaffold/CUSTOM_TEMPLATES.md
+++ b/fraisier/scaffold/CUSTOM_TEMPLATES.md
@@ -19,6 +19,29 @@ directory that contains `fraises.yaml`.
 The conventional location is `.fraisier/templates/` inside your project root,
 alongside `fraises.yaml`.
 
+## How this works on a deployed server
+
+Two things follow from "relative to the `fraises.yaml` location", and both used
+to bite silently (#312):
+
+- **The server's `fraises.yaml` is `/opt/fraisier/fraises.yaml`**, not the one
+  in your checkout. A relative `template_dir` therefore resolves against
+  `/opt/fraisier/`. Deploy-time config sync copies your template directory
+  there alongside `fraises.yaml`, so a directory committed to your repo is the
+  one the server renders from.
+- **A commit that changes only a template still triggers regeneration.** Change
+  detection hashes the template tree as well as `fraises.yaml`; a template edit,
+  addition or rename all count.
+
+If `template_dir` is set but the directory is not found at render time,
+fraisier logs a **warning** naming the path it looked in and continues with
+built-in templates. It does not fail the render — but that warning is the one
+to look for if a customisation appears not to have taken effect. Before v0.53.0
+there was no warning at all: the built-in template rendered and looked correct.
+
+An **absolute** `template_dir` is never synced — it names a location you manage
+on the server yourself.
+
 ## Template path structure
 
 Override files must mirror the built-in template path structure exactly.

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -7,6 +7,7 @@ Templates are rendered with the full fraises.yaml context and written
 to the configured output_dir.
 """
 
+import logging
 import re
 import shutil
 from pathlib import Path
@@ -25,6 +26,8 @@ from fraisier.config import (
 from fraisier.dbops._validation import validate_service_name
 from fraisier.manifest import build_manifest
 from fraisier.naming import app_service_name, deploy_socket_name
+
+logger = logging.getLogger("fraisier")
 
 _SAFE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -589,6 +592,19 @@ class ScaffoldRenderer:
             custom_path = Path(template_dir)
             if not custom_path.is_absolute():
                 custom_path = Path(config.config_path).parent / custom_path
+            if not custom_path.is_dir():
+                # ChoiceLoader falls through to the built-ins with no error, so
+                # a customised template silently does not apply — on the server
+                # a relative template_dir resolves against /opt/fraisier, where
+                # nothing puts it. Warn rather than raise: existing deploys are
+                # already running on built-ins and must not start failing (#312).
+                logger.warning(
+                    "scaffold.template_dir is set but %s does not exist — "
+                    "rendering with built-in templates only. Any customised "
+                    "template in %r is being ignored.",
+                    custom_path,
+                    template_dir,
+                )
             loaders.append(jinja2.FileSystemLoader(str(custom_path)))
         loaders.append(jinja2.FileSystemLoader(str(_TEMPLATES_DIR)))
 

--- a/fraisier/scaffold/templates/core/restore-staging.service.j2
+++ b/fraisier/scaffold/templates/core/restore-staging.service.j2
@@ -14,7 +14,10 @@ Environment=FRAISIER_SYSTEMCTL_SOCKET=/run/fraisier/systemctl-{{ project_name }}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% if env_config.get('database', {}).get('strategy') == 'restore_migrate' %}
 {% if 'staging' in env_name or 'stage' in env_name %}
-ExecStart={{ fraisier_bin }} --config {{ scaffold.config_path }} db restore {{ fraise.name }} {{ env_name }}
+# --skip-if-locked: a deploy of this fraise holds the same lock, and a deploy
+# is itself restoring staging from production — so a collision means the work
+# is already being done. Exit 0 rather than failing the unit nightly (#310).
+ExecStart={{ fraisier_bin }} --config {{ scaffold.config_path }} db restore {{ fraise.name }} {{ env_name }} --skip-if-locked
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/fraisier/scaffold/templates/core/restore-staging.timer.j2
+++ b/fraisier/scaffold/templates/core/restore-staging.timer.j2
@@ -3,8 +3,10 @@ Description=Timer for nightly {{ project_name }} staging database restore from p
 After=network.target
 
 [Timer]
-# Run at 2 AM local time daily
-OnCalendar=daily
+# Run at 2 AM local time daily.
+# Exactly one OnCalendar=: systemd *accumulates* non-empty assignments and
+# resets the list only for the empty string, so adding `OnCalendar=daily`
+# here would schedule a second, undocumented 00:00 run (#311).
 OnCalendar=*-*-* 02:00:00
 Persistent=true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.52.0"
+version = "0.53.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,35 @@ def _reset_rate_limiter():
 
 
 @pytest.fixture(autouse=True)
+def _isolated_lock_dir(tmp_path, monkeypatch):
+    """Keep deployment locks out of /run/fraisier.
+
+    ``file_deployment_lock`` mkdirs its lock directory, which needs root for the
+    real ``/run/fraisier`` and does not exist at all on most dev machines. Any
+    code path that takes a deployment lock — the webhook, and ``db restore``
+    since #310 — would otherwise fail in tests for purely environmental reasons.
+
+    Redirected at the single choke point rather than at each source of the path:
+    the directory arrives variously from ``DEFAULT_LOCK_DIR``, the
+    ``DeploymentConfig`` schema default, and a hardcoded literal in the config
+    loader. Only a ``/run/`` path is rewritten, so a directory a test supplies
+    itself is honoured and ``test_file_lock.py`` keeps controlling its own.
+    """
+    from fraisier import locking
+
+    real = locking.file_deployment_lock
+    safe = tmp_path / ".locks"
+
+    def _redirected(fraise_name, lock_dir=None):
+        if lock_dir is None or str(lock_dir).startswith("/run/"):
+            lock_dir = safe
+        return real(fraise_name, lock_dir=lock_dir)
+
+    monkeypatch.setattr(locking, "file_deployment_lock", _redirected)
+    monkeypatch.setattr(locking, "DEFAULT_LOCK_DIR", safe)
+
+
+@pytest.fixture(autouse=True)
 def _reset_delivery_dedupe():
     """Clear webhook delivery-ID dedupe store between tests."""
     from fraisier.git.github import _delivery_dedupe

--- a/tests/test_db_restore_locking.py
+++ b/tests/test_db_restore_locking.py
@@ -1,0 +1,236 @@
+"""`db restore` must hold the deployment lock (#310).
+
+`fraisier.locking` gives per-fraise mutual exclusion and the webhook wraps every
+deployment in ``deployment_lock(fraise)``. The `db restore` CLI never acquired
+it, so a timer-, cron- or hand-driven restore ran completely unsynchronised
+with deploys of the same fraise.
+
+Incident (printoptim.dev, 2026-07-30 00:00 UTC): the staging-restore timer fired
+mid-deploy, stopped the API service and terminated every connection to the
+staging database — killing the in-flight deploy's pg_restore
+(``FATAL: terminating connection due to administrator command``) and leaving
+staging half-restored. The timer firing at midnight at all was #311.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fraisier.cli.main import main
+from fraisier.errors import DeploymentLockError
+
+_ADMIN_URL = "postgresql:///postgres?host=/var/run/postgresql"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def restore_config():
+    config = MagicMock()
+    config.get_fraise.return_value = {"type": "api", "description": "Test API"}
+    config.get_fraise_environment.return_value = {
+        "type": "api",
+        "app_path": "/var/www/api",
+        "systemd_service": "api.staging.service",
+        "database": {
+            "name": "mydb_staging",
+            "strategy": "restore_migrate",
+            "admin_url": _ADMIN_URL,
+            "confiture_config": "confiture.yaml",
+            "restore": {
+                "backup_dir": "/backup/production",
+                "backup_pattern": "*.dump",
+                "max_age_hours": 48.0,
+                "create_template": True,
+                "min_tables": 100,
+            },
+        },
+    }
+    config._config = {"backup": {}}
+    config.deployment = MagicMock()
+    config.deployment.get_strategy.return_value = "restore_migrate"
+    config.list_fraises_detailed.return_value = []
+    with patch("fraisier.cli.main.get_config", return_value=config):
+        yield config
+
+
+def _invoke(runner, args, *, lock_side_effect=None):
+    """Run `db restore`, stubbing everything below the lock."""
+    result_mock = MagicMock(
+        success=True,
+        migrations_applied=0,
+        total_duration_seconds=0.0,
+        restore_duration_seconds=0.0,
+        migration_duration_seconds=0.0,
+    )
+    lock = MagicMock()
+    if lock_side_effect is not None:
+        lock.side_effect = lock_side_effect
+
+    with (
+        patch("fraisier.locking.deployment_lock", lock),
+        patch("fraisier.dbops.guard.is_external_db", return_value=False),
+        patch(
+            "fraisier.strategies.RestoreMigrateStrategy.execute",
+            return_value=result_mock,
+        ) as mock_execute,
+        patch("fraisier.systemd.SystemdServiceManager"),
+        patch("fraisier.dbops.restore.find_latest_backup", return_value="/b/x.dump"),
+        patch("fraisier.dbops.restore.validate_backup_age"),
+        patch("fraisier.post_migrate.run_configured_post_migrate", return_value=None),
+    ):
+        res = runner.invoke(main, args)
+    return res, lock, mock_execute
+
+
+class TestRestoreTakesTheDeploymentLock:
+    def test_lock_is_acquired_for_the_fraise(self, runner, restore_config):
+        res, lock, _ = _invoke(runner, ["db", "restore", "api", "staging"])
+
+        assert lock.called, f"deployment_lock never acquired (exit {res.exit_code})"
+        assert lock.call_args.args[0] == "api"
+
+    def test_restore_runs_while_holding_it(self, runner, restore_config):
+        """The lock must wrap the mutation, not merely be taken and dropped."""
+        _, lock, mock_execute = _invoke(runner, ["db", "restore", "api", "staging"])
+
+        assert lock.return_value.__enter__.called
+        assert mock_execute.called
+
+
+class TestLockedBehaviour:
+    def test_errors_when_a_deploy_holds_the_lock(self, runner, restore_config):
+        """Default: refuse loudly rather than interleave with a deploy."""
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging"],
+            lock_side_effect=DeploymentLockError("Deploy already running for api"),
+        )
+
+        assert res.exit_code != 0
+        assert not mock_execute.called, "restore ran despite the lock being held"
+
+    def test_skip_if_locked_exits_zero_without_restoring(self, runner, restore_config):
+        """For timer units: a skipped nightly restore is a non-event.
+
+        A concurrent staging deploy is itself restoring from production, so
+        failing the timer would page someone over a no-op.
+        """
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=DeploymentLockError("Deploy already running for api"),
+        )
+
+        assert res.exit_code == 0, res.output
+        assert not mock_execute.called
+        assert "skip" in res.output.lower()
+
+    def test_skip_if_locked_does_not_mask_an_unlocked_failure(
+        self, runner, restore_config
+    ):
+        """The flag suppresses lock contention only, never a real error."""
+        res, _, _ = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=RuntimeError("disk on fire"),
+        )
+
+        assert res.exit_code != 0
+
+
+class TestDryRunIsNotBlocked:
+    def test_dry_run_does_not_take_the_lock(self, runner, restore_config):
+        """A dry run mutates nothing, so a running deploy must not veto it."""
+        res, lock, mock_execute = _invoke(
+            runner, ["db", "restore", "api", "staging", "--dry-run"]
+        )
+
+        assert res.exit_code == 0, res.output
+        assert not lock.called
+        assert not mock_execute.called
+
+
+class TestTimerUnitPassesTheFlag:
+    """The generated unit must opt into the skip, or the timer just fails nightly.
+
+    Without `--skip-if-locked` the new lock turns a harmless collision into a
+    failed systemd unit and a paged operator — the fix would trade a silent
+    corruption for a noisy false alarm.
+    """
+
+    def _service_text(self, tmp_path) -> str:
+        from fraisier.config import FraisierConfig
+        from fraisier.scaffold.renderer import ScaffoldRenderer
+
+        p = tmp_path / "fraises.yaml"
+        p.write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      staging:
+        app_path: /var/www/staging
+        database:
+          name: myapp_staging
+          strategy: restore_migrate
+""")
+        ScaffoldRenderer(FraisierConfig(p)).render()
+        return (tmp_path / "output" / "systemd" / "restore-staging.service").read_text()
+
+    def test_execstart_passes_skip_if_locked(self, tmp_path):
+        exec_lines = [
+            ln
+            for ln in self._service_text(tmp_path).splitlines()
+            if ln.startswith("ExecStart=")
+        ]
+        assert len(exec_lines) == 1
+        assert "--skip-if-locked" in exec_lines[0]
+
+    def test_execstart_still_invokes_db_restore(self, tmp_path):
+        """The flag must be added to the restore call, not replace it."""
+        exec_lines = [
+            ln
+            for ln in self._service_text(tmp_path).splitlines()
+            if ln.startswith("ExecStart=")
+        ]
+        assert "db restore" in exec_lines[0]
+
+
+class TestUnusableLockIsNotSilentlySkipped:
+    """A lock that cannot be taken at all is an error, never a skip.
+
+    `/run/fraisier` is tmpfs, created by the webhook unit's
+    `RuntimeDirectory=fraisier`. If it is absent, acquiring raises OSError
+    rather than DeploymentLockError — that means "I could not tell whether a
+    deploy is running", which must never be treated as "no deploy is running".
+    """
+
+    def test_oserror_fails_even_with_skip_if_locked(self, runner, restore_config):
+        res, _, mock_execute = _invoke(
+            runner,
+            ["db", "restore", "api", "staging", "--skip-if-locked"],
+            lock_side_effect=PermissionError(13, "Permission denied", "/run/fraisier"),
+        )
+
+        assert res.exit_code != 0, "an unusable lock must not read as 'nothing running'"
+        assert not mock_execute.called
+
+    def test_oserror_message_names_the_lock_directory(self, runner, restore_config):
+        res, _, _ = _invoke(
+            runner,
+            ["db", "restore", "api", "staging"],
+            lock_side_effect=PermissionError(13, "Permission denied", "/run/fraisier"),
+        )
+
+        assert "/run/fraisier" in res.output

--- a/tests/test_restore_staging_timer.py
+++ b/tests/test_restore_staging_timer.py
@@ -1,0 +1,72 @@
+"""The nightly staging restore must fire once, at the advertised hour (#311).
+
+`OnCalendar=` accumulates: systemd resets the trigger list only when the *empty*
+string is assigned, so two non-empty assignments give two triggers. The template
+carried both `OnCalendar=daily` (00:00) and `OnCalendar=*-*-* 02:00:00` under a
+comment promising 2 AM, so it fired twice a day.
+
+That was not merely redundant. On printoptim.dev (2026-07-30) the undocumented
+midnight fire landed on an in-flight deploy and killed it — the other half of
+that collision is the missing deployment lock (#310).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {output}
+fraises:
+  my_api:
+    type: api
+    environments:
+      staging:
+        app_path: /var/www/staging
+        database:
+          name: myapp_staging
+          strategy: restore_migrate
+"""
+
+
+@pytest.fixture
+def timer_text(tmp_path) -> str:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(_YAML.format(output=str(tmp_path / "output")))
+    ScaffoldRenderer(FraisierConfig(p)).render()
+    return (tmp_path / "output" / "systemd" / "restore-staging.timer").read_text()
+
+
+def _oncalendar_lines(text: str) -> list[str]:
+    return [
+        ln.strip() for ln in text.splitlines() if ln.strip().startswith("OnCalendar=")
+    ]
+
+
+class TestRestoreStagingTimerFiresOnce:
+    def test_exactly_one_oncalendar_directive(self, timer_text):
+        """Two non-empty OnCalendar= assignments mean two triggers, not an override."""
+        lines = _oncalendar_lines(timer_text)
+
+        assert len(lines) == 1, f"timer fires {len(lines)} times a day: {lines}"
+
+    def test_the_single_trigger_is_the_advertised_hour(self, timer_text):
+        """The comment promises 2 AM; the directive must agree with it."""
+        assert _oncalendar_lines(timer_text) == ["OnCalendar=*-*-* 02:00:00"]
+
+    def test_no_bare_daily_shorthand(self, timer_text):
+        """`daily` expands to 00:00 — the midnight fire behind the #310 collision.
+
+        Checks the *directives*, not the raw text: the template comment names
+        `OnCalendar=daily` deliberately, to explain the trap it documents.
+        """
+        assert "OnCalendar=daily" not in _oncalendar_lines(timer_text)
+
+    def test_persistent_is_kept(self, timer_text):
+        """A missed run must still catch up; only the extra trigger goes."""
+        assert "Persistent=true" in timer_text

--- a/tests/test_template_dir_reaches_server.py
+++ b/tests/test_template_dir_reaches_server.py
@@ -1,0 +1,322 @@
+"""Custom templates must reach the server, and their absence must be loud (#312).
+
+`scaffold.template_dir` works locally and silently does nothing on the server:
+
+1. a relative path resolves against the *config* directory (`/opt/fraisier`),
+   not the app checkout, so the directory does not exist there;
+2. nothing syncs it — only `fraises.yaml` is copied;
+3. `ConfigWatcher` hashes only `fraises.yaml`, so a template-only commit never
+   triggers regeneration at all.
+
+`jinja2.ChoiceLoader` falls through to the built-in template when the first
+loader's directory is missing — no exception, no warning. On printoptim.dev the
+customised file was `sudoers.j2`, so the operator believed a privilege rule was
+deployed when it was not.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {output}
+  template_dir: {template_dir}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+"""
+
+
+def _config(tmp_path, template_dir: str) -> FraisierConfig:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(
+        _YAML.format(output=str(tmp_path / "output"), template_dir=template_dir)
+    )
+    return FraisierConfig(p)
+
+
+class TestMissingTemplateDirIsLoud:
+    """The silent fallback is the dangerous part — say something."""
+
+    def test_warns_when_configured_dir_is_absent(self, tmp_path, caplog):
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        assert any(
+            "scaffold-templates" in r.message and r.levelno >= logging.WARNING
+            for r in caplog.records
+        ), f"no warning naming the missing dir: {[r.message for r in caplog.records]}"
+
+    def test_warning_names_the_resolved_path_not_the_configured_one(
+        self, tmp_path, caplog
+    ):
+        """A relative path is the whole trap — show where it actually looked."""
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        resolved = str(tmp_path / "scripts" / "scaffold-templates")
+        assert any(resolved in r.message for r in caplog.records)
+
+    def test_warning_says_built_ins_are_being_used(self, tmp_path, caplog):
+        config = _config(tmp_path, "scripts/scaffold-templates")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        joined = " ".join(r.message for r in caplog.records).lower()
+        assert "built-in" in joined or "builtin" in joined
+
+    def test_silent_when_the_dir_exists(self, tmp_path, caplog):
+        (tmp_path / "tpl").mkdir()
+        config = _config(tmp_path, "tpl")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(config)
+
+        assert not [r for r in caplog.records if "tpl" in r.message]
+
+    def test_silent_when_no_template_dir_configured(self, tmp_path, caplog):
+        p = tmp_path / "fraises.yaml"
+        p.write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {tmp_path / "output"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+""")
+
+        with caplog.at_level(logging.WARNING):
+            ScaffoldRenderer(FraisierConfig(p))
+
+        assert not [r for r in caplog.records if "template" in r.message.lower()]
+
+
+class TestCustomTemplateActuallyWins:
+    """Sanity: when the directory *is* present, the override is used.
+
+    Without this the warning tests could pass against a renderer that never
+    consults the custom directory at all.
+    """
+
+    def test_custom_template_overrides_the_builtin(self, tmp_path):
+        tpl = tmp_path / "tpl" / "core"
+        tpl.mkdir(parents=True)
+        (tpl / "sudoers.j2").write_text("# CUSTOM SUDOERS MARKER\n")
+        config = _config(tmp_path, "tpl")
+
+        ScaffoldRenderer(config).render()
+
+        assert "CUSTOM SUDOERS MARKER" in (tmp_path / "output" / "sudoers").read_text()
+
+
+class TestTemplateDirIsSyncedToTheServer:
+    """The templates are committed to the repo but never leave the checkout.
+
+    Only `fraises.yaml` was copied, so the server's config directory — which
+    is what a relative `template_dir` resolves against — never had them.
+    """
+
+    def _deployer(self, tmp_path, template_dir: str | None):
+        from unittest.mock import MagicMock
+
+        from fraisier.deployers.api import APIDeployer
+
+        app = tmp_path / "app"
+        (app / "scripts" / "scaffold-templates" / "core").mkdir(parents=True)
+        (app / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# CUSTOM\n"
+        )
+        cfg = f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+{f"  template_dir: {template_dir}" if template_dir else ""}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: {app}
+"""
+        (app / "fraises.yaml").write_text(cfg)
+
+        d = APIDeployer({"app_path": str(app), "fraise_name": "my_api"})
+        d.runner = MagicMock()
+        d.runner.run.return_value = MagicMock(returncode=0)
+        return d, app
+
+    def _synced_paths(self, runner) -> list[str]:
+        """Every path that appears in a cp/rsync-ish command."""
+        out = []
+        for call in runner.run.call_args_list:
+            out.extend(str(a) for a in call.args[0])
+        return out
+
+    def test_template_dir_is_copied_next_to_fraises_yaml(self, tmp_path):
+        from fraisier.config import FraisierConfig
+
+        d, app = self._deployer(tmp_path, "scripts/scaffold-templates")
+        dest = tmp_path / "opt" / "fraises.yaml"
+
+        with_cfg = FraisierConfig(app / "fraises.yaml")
+        d.config_object = with_cfg
+        d._sync_fraises_yaml(source_path=app / "fraises.yaml", dest_path=dest)
+
+        joined = " ".join(self._synced_paths(d.runner))
+        assert "scaffold-templates" in joined, (
+            f"template dir never synced; commands were: {joined}"
+        )
+
+    def test_no_template_sync_when_not_configured(self, tmp_path):
+        from fraisier.config import FraisierConfig
+
+        d, app = self._deployer(tmp_path, None)
+        dest = tmp_path / "opt" / "fraises.yaml"
+        d.config_object = FraisierConfig(app / "fraises.yaml")
+
+        d._sync_fraises_yaml(source_path=app / "fraises.yaml", dest_path=dest)
+
+        assert "scaffold-templates" not in " ".join(self._synced_paths(d.runner))
+
+
+class TestTemplateOnlyChangeTriggersRegen:
+    """A commit touching only a template must flip has_changed() (#312).
+
+    ConfigWatcher hashed fraises.yaml alone, so a template edit did not merely
+    fail to reach the server — regeneration never even ran for it.
+    """
+
+    def _watcher(self, tmp_path, template_dir: str | None = "tpl"):
+        from fraisier.config_watcher import ConfigWatcher
+
+        (tmp_path / "fraises.yaml").write_text(
+            "name: p\n"
+            + (f"scaffold:\n  template_dir: {template_dir}\n" if template_dir else "")
+        )
+        if template_dir:
+            d = tmp_path / template_dir / "core"
+            d.mkdir(parents=True)
+            (d / "sudoers.j2").write_text("v1\n")
+        return ConfigWatcher(tmp_path)
+
+    def test_editing_a_template_changes_the_hash(self, tmp_path):
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        (tmp_path / "tpl" / "core" / "sudoers.j2").write_text("v2\n")
+
+        assert w.compute_hash() != before
+
+    def test_adding_a_template_changes_the_hash(self, tmp_path):
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        (tmp_path / "tpl" / "core" / "service.j2").write_text("new\n")
+
+        assert w.compute_hash() != before
+
+    def test_renaming_a_template_changes_the_hash(self, tmp_path):
+        """Content alone is not enough — the path is part of the identity."""
+        w = self._watcher(tmp_path)
+        before = w.compute_hash()
+
+        core = tmp_path / "tpl" / "core"
+        (core / "sudoers.j2").rename(core / "sudoers-renamed.j2")
+
+        assert w.compute_hash() != before
+
+    def test_hash_is_stable_when_nothing_changes(self, tmp_path):
+        w = self._watcher(tmp_path)
+
+        assert w.compute_hash() == w.compute_hash()
+
+    def test_unchanged_behaviour_without_a_template_dir(self, tmp_path):
+        w = self._watcher(tmp_path, template_dir=None)
+        before = w.compute_hash()
+
+        (tmp_path / "fraises.yaml").write_text("name: p\n# edited\n")
+
+        assert w.compute_hash() != before
+
+
+class TestTheChainComposes:
+    """Sync + resolution together must actually deliver the customisation.
+
+    Each piece alone leaves the bug in place: syncing without regen never runs,
+    and warning without syncing only announces the problem. This walks the real
+    sequence — checkout → sync → render from the *config* directory — and
+    asserts the custom rule lands.
+    """
+
+    def test_custom_sudoers_survives_the_trip_to_the_server(self, tmp_path):
+        import shutil
+
+        from fraisier.config import FraisierConfig
+        from fraisier.config_watcher import ConfigWatcher
+
+        # 1. the app checkout, with a customised template committed alongside
+        app = tmp_path / "app"
+        (app / "scripts" / "scaffold-templates" / "core").mkdir(parents=True)
+        (app / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# CUSTOM RULE FROM THE REPO\n"
+        )
+        (app / "fraises.yaml").write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  template_dir: scripts/scaffold-templates
+  output_dir: {tmp_path / "out"}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: {app}
+""")
+
+        # 2. the server's config dir — what a relative template_dir resolves against
+        opt = tmp_path / "opt"
+        opt.mkdir()
+        shutil.copy(app / "fraises.yaml", opt / "fraises.yaml")
+
+        # before the sync: built-in wins, silently
+        ScaffoldRenderer(FraisierConfig(opt / "fraises.yaml")).render()
+        assert "CUSTOM RULE" not in (tmp_path / "out" / "sudoers").read_text()
+
+        # 3. the sync this fix adds
+        shutil.copytree(
+            app / "scripts" / "scaffold-templates",
+            opt / "scripts" / "scaffold-templates",
+        )
+
+        # after: the repo's rule is what renders on the server
+        ScaffoldRenderer(FraisierConfig(opt / "fraises.yaml")).render()
+        assert "CUSTOM RULE FROM THE REPO" in (tmp_path / "out" / "sudoers").read_text()
+
+        # 4. and a template-only edit is now visible to change detection
+        watcher = ConfigWatcher(opt)
+        before = watcher.compute_hash()
+        (opt / "scripts" / "scaffold-templates" / "core" / "sudoers.j2").write_text(
+            "# EDITED\n"
+        )
+        assert watcher.compute_hash() != before

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.51.0"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #310, closes #311, closes #312.

Consolidates PRs #314 and #315 — which carried v0.53.0 and v0.54.0 separately — into **one release**. The three fix commits are unchanged and kept separate so each stays `git revert`-able. Those two PRs are superseded and closed; their bodies hold the detailed write-ups.

## What the three have in common

All found by running fraisier in anger on printoptim.dev, and all the same shape: **something silently did not happen, and nothing said so.**

| commit | issue | summary |
|---|---|---|
| `3ca5fb7` | #311 | the staging-restore timer fired at 00:00 *and* 02:00 — `OnCalendar=` accumulates |
| `956b7fa` | #310 | `db restore` took no deployment lock, so a restore could run on top of a deploy |
| `a308638` | #312 | `scaffold.template_dir` never reached the server; template-only commits never triggered regen |
| `(release)` | — | version bump + consolidated CHANGELOG |

## Two of them are one incident

2026-07-30, 00:00 UTC: the restore timer fired **on top of an in-flight deploy**, stopped the API service and terminated every connection to the staging database. The deploy's `pg_restore` died with `FATAL: terminating connection due to administrator command`; the deploy reported FAILED and staging was left half-restored.

Two independent defects had to line up. A midnight restore that hits no deploy is merely redundant; an unlocked restore at 02:00 usually misses the deploy window. **The conjunction is what cost a database** — which is why both halves are fixed here rather than just the cheap one.

## Verified, not assumed

- **#311** — `systemd.timer(5)` states the trigger list resets only on the *empty* string, which is meaningful only if non-empty assignments accumulate. Confirmed live: `systemctl list-timers` showed LAST 02:00 / NEXT 00:00 on one unit, impossible with a single trigger.
- **#310** — `deployment_lock` call sites traced to `webhook.py:318`, `cli/version.py:956`, `daemon.py:250`. The issue names the first two; the third exists too. `cli/db.py` had none.
- **#312** — all three causes traced to specific lines, and an end-to-end test walks checkout → sync → render asserting the *before* state (built-in wins) as well as the after. Each of the three sub-fixes alone leaves the bug in place; that test is what pins that they compose.

## Decisions beyond what the issues proposed

- **`--dry-run` does not take the lock.** It mutates nothing, so a running deploy must not veto a plan preview.
- **`OSError` is not covered by `--skip-if-locked`.** "I cannot tell whether a deploy is running" must never be read as "no deploy is running". Clear message, exit 1, two tests.
- **A missing `template_dir` warns rather than raises.** Making it fatal would break every deploy currently limping along on built-ins.
- **The template directory is synced, not re-anchored at the app checkout.** `template_dir` is project-level while `app_path` is per-fraise-per-environment, so a multi-fraise project has no single checkout to resolve against — ambiguous exactly where custom templates are most likely.

## Operators must re-scaffold *and* deploy

```sh
fraisier scaffold && sudo fraisier scaffold-install --yes   # #310, #311 live in generated units
# then one deploy — #312's template sync runs during deploy-time config sync
```

## What this does not fix

Full list in the CHANGELOG. The ones worth knowing:

- **Only `db restore` got the lock.** `db exec`, `reset`, `migrate` and `build` still run unsynchronised; `db reset` can reach the same collision class.
- **Custom templates come from whichever fraise deployed last** in a multi-repo project — exactly how `fraises.yaml` syncing already behaves, inherited rather than introduced.
- **Nothing recreates `/run/fraisier` for a timer firing while the webhook is stopped.** The failure is legible now, but still a failure.

## Verification

- 4481 passed, 7 skipped — **4488 collected vs main's 4460**, i.e. +28, all new (4 from #311, 10 from #310, 14 from #312)
- `ruff check .` clean; `ruff format --check .` clean on 443 files; `ty check` clean
- Rendered artifacts inspected, not just templates: one `OnCalendar=` at 02:00, `ExecStart` carrying `--skip-if-locked`

**Rebase-merge**, per the repo's convention for multi-commit bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)