### PR TITLE
release: v0.53.1 — bootstrap uploads scaffold.template_dir too (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.1] - 2026-08-01
+
+Closes #318. Follow-up to #312: the deploy path carried `scaffold.template_dir`
+to the server, `bootstrap` did not.
+
+### Fixed
+
+- **`fraisier bootstrap` now uploads `scaffold.template_dir`** (`bootstrap.py`, #318). `_upload_config` uploaded exactly one file, so a freshly bootstrapped host had a `fraises.yaml` whose relative `template_dir` pointed at a directory nothing had created — the same single-file omission #312 fixed on the deploy path, at provisioning time instead. It now uploads the tree alongside the config, replacing it wholesale so a template deleted upstream cannot survive and keep shadowing a built-in.
+
+### Notes for operators
+
+- **Nothing was corrupted by this, and a bootstrap-then-deploy host was never affected.** Bootstrap renders its initial scaffold *locally*, where a relative `template_dir` resolves correctly, so the uploaded tree already carried your customisations; bootstrap never renders server-side; and the first deploy's config sync created the directory. The exposure was the window in between, where a hand-run `fraisier scaffold` on the box would silently render built-ins. Since v0.53.0 that case warns.
+- **`--dry-run` now names the template upload** in its plan, so the review surface still shows everything that will be written.
+- An **absolute** `template_dir` is still never uploaded — it names a location you manage on the server yourself.
+
+### Known limitations
+
+- **The upload is best-effort**, matching the deploy path: a failure is logged loudly but does not abort provisioning that would otherwise succeed. A host can still end up on built-in templates, and the render-time warning added in v0.53.0 is what surfaces that.
+- **`fraisier setup` is unaffected and unchanged.** It renders and installs locally and does not populate `/opt/fraisier`, so it has no template directory to carry.
+
 ## [0.53.0] - 2026-07-31
 
 Closes #310, #311 and #312 — all three found by running fraisier in anger on

--- a/fraisier/bootstrap.py
+++ b/fraisier/bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import shlex
 import subprocess
 import tempfile
@@ -39,6 +40,9 @@ def resolve_become_password(command: str) -> str:
         msg = "become_password_command failed (check become_password_command config)"
         raise RuntimeError(msg)
     return result.stdout.strip()
+
+
+logger = logging.getLogger("fraisier")
 
 
 @dataclass
@@ -272,21 +276,85 @@ class ServerBootstrapper:
             ],
         )
 
+    def _relative_template_dir(self) -> Path | None:
+        """The configured ``scaffold.template_dir``, if it is relative and present.
+
+        Absolute paths are skipped deliberately: they name a location the
+        operator manages on the server, and uploading over one would be
+        surprising. Mirrors ``GitDeployMixin._sync_template_dir`` (#312).
+        """
+        configured = getattr(self.config.scaffold, "template_dir", None)
+        if not configured:
+            return None
+        rel = Path(configured)
+        if rel.is_absolute():
+            return None
+        return rel
+
     def _upload_config(self) -> StepResult:
         name = "Upload fraises.yaml"
+        rel_templates = self._relative_template_dir()
+
         if self.dry_run:
             dst = self._FRAISIER_CONFIG_PATH
-            return StepResult(
-                name=name,
-                success=True,
-                command=f"scp {self.fraises_yaml_path} ...:{dst}",
-            )
+            command = f"scp {self.fraises_yaml_path} ...:{dst}"
+            if rel_templates is not None:
+                command += (
+                    f" + scp -r {rel_templates} ...:/opt/fraisier/{rel_templates}"
+                )
+            return StepResult(name=name, success=True, command=command)
+
         try:
             self.runner.run(["mkdir", "-p", "/opt/fraisier"])
             self.runner.upload(self.fraises_yaml_path, self._FRAISIER_CONFIG_PATH)
-            return StepResult(name=name, success=True)
         except subprocess.CalledProcessError as e:
             return StepResult(name=name, success=False, error=e.stderr or str(e))
+
+        self._upload_template_dir(rel_templates)
+        return StepResult(name=name, success=True)
+
+    def _upload_template_dir(self, rel_templates: Path | None) -> None:
+        """Carry ``scaffold.template_dir`` to the server config dir (#318).
+
+        A relative ``template_dir`` resolves against the *config* directory, so
+        on the server it means ``/opt/fraisier/<template_dir>``. Bootstrap
+        uploaded only fraises.yaml, leaving that path dangling until the first
+        deploy's config sync created it (#312). Bootstrap's own scaffold is
+        rendered locally, so the initial tree was correct — but any server-side
+        render in the meantime silently fell back to the built-ins.
+
+        Best-effort, matching the deploy path: provisioning that would
+        otherwise succeed must not fail over templates, but the failure is
+        logged loudly because the consequence is a host rendering built-ins
+        while the repo says otherwise.
+        """
+        if rel_templates is None:
+            return
+
+        source = Path(self.fraises_yaml_path).parent / rel_templates
+        dest = f"/opt/fraisier/{rel_templates}"
+        if not source.is_dir():
+            logger.warning(
+                "scaffold.template_dir is set but %s does not exist locally — "
+                "the server will render with built-in templates",
+                source,
+            )
+            return
+
+        try:
+            # Replace wholesale: a template deleted upstream must not survive
+            # on the server, where it would keep shadowing the built-in.
+            self.runner.run(["rm", "-rf", dest])
+            self.runner.run(["mkdir", "-p", dest])
+            self.runner.upload_tree(source, dest)
+        except Exception:
+            logger.warning(
+                "Failed to upload scaffold.template_dir %s -> %s; the server "
+                "may render with built-in templates",
+                source,
+                dest,
+                exc_info=True,
+            )
 
     def _upload_scaffold_files(self) -> tuple[StepResult, str]:
         name = "Upload scaffold files"

--- a/fraisier/scaffold/CUSTOM_TEMPLATES.md
+++ b/fraisier/scaffold/CUSTOM_TEMPLATES.md
@@ -39,6 +39,13 @@ built-in templates. It does not fail the render — but that warning is the one
 to look for if a customisation appears not to have taken effect. Before v0.53.0
 there was no warning at all: the built-in template rendered and looked correct.
 
+Both provisioning paths carry the directory: `fraisier bootstrap` uploads it
+alongside `fraises.yaml`, and every deploy re-syncs it from the checkout. Before
+v0.53.1 bootstrap uploaded only the config, so a freshly bootstrapped host had a
+dangling `template_dir` until its first deploy — the initial scaffold was still
+correct, because bootstrap renders it locally, but any server-side render in
+that window fell back to built-ins.
+
 An **absolute** `template_dir` is never synced — it names a location you manage
 on the server yourself.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.53.0"
+version = "0.53.1"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_bootstrap_template_dir.py
+++ b/tests/test_bootstrap_template_dir.py
@@ -1,0 +1,155 @@
+"""Bootstrap must upload scaffold.template_dir too (#318, follow-up to #312).
+
+#312 made deploy-time config sync carry the template tree to the server.
+`bootstrap._upload_config` still uploaded exactly one file, so a freshly
+bootstrapped host had a `fraises.yaml` whose `template_dir` pointed at a
+directory that was not there.
+
+Bounded, not catastrophic: bootstrap renders its initial scaffold *locally*
+(where the path resolves), never renders server-side, and the first deploy
+self-heals it. The exposure is the window in between, where any server-side
+render silently produces built-ins.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from fraisier.bootstrap import ServerBootstrapper
+from fraisier.config import FraisierConfig
+
+
+def _make(
+    tmp_path, template_dir: str | None, *, create: bool = True, dry: bool = False
+):
+    if create and template_dir:
+        d = tmp_path / template_dir / "core"
+        d.mkdir(parents=True)
+        (d / "sudoers.j2").write_text("# CUSTOM\n")
+
+    cfg_path = tmp_path / "fraises.yaml"
+    cfg_path.write_text(f"""
+name: myapp
+scaffold:
+  deploy_user: fraisier
+{f"  template_dir: {template_dir}" if template_dir else ""}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+""")
+    runner = MagicMock()
+    runner.run.return_value = MagicMock(returncode=0)
+    boot = ServerBootstrapper(
+        config=FraisierConfig(cfg_path),
+        environment="production",
+        runner=runner,
+        fraises_yaml_path=cfg_path,
+        dry_run=dry,
+    )
+    return boot, runner
+
+
+def _all_args(runner) -> str:
+    parts = []
+    for call in runner.run.call_args_list:
+        parts.extend(str(a) for a in call.args[0])
+    for call in runner.upload.call_args_list:
+        parts.extend(str(a) for a in call.args)
+    for call in runner.upload_tree.call_args_list:
+        parts.extend(str(a) for a in call.args)
+    return " ".join(parts)
+
+
+class TestBootstrapUploadsTemplateDir:
+    def test_template_tree_is_uploaded(self, tmp_path):
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates")
+
+        step = boot._upload_config()
+
+        assert step.success is True
+        assert "scaffold-templates" in _all_args(runner), (
+            f"template dir never uploaded: {_all_args(runner)}"
+        )
+
+    def test_destination_is_under_the_server_config_dir(self, tmp_path):
+        """A relative template_dir resolves against /opt/fraisier on the server."""
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates")
+
+        boot._upload_config()
+
+        assert "/opt/fraisier/scripts/scaffold-templates" in _all_args(runner)
+
+    def test_config_upload_still_happens(self, tmp_path):
+        """The template sync must be additive, never replace the config upload."""
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates")
+
+        boot._upload_config()
+
+        assert runner.upload.call_args_list[0].args[1] == "/opt/fraisier/fraises.yaml"
+
+    def test_stale_templates_are_cleared_first(self, tmp_path):
+        """A template deleted upstream must not survive and shadow a built-in."""
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates")
+
+        boot._upload_config()
+
+        assert "rm -rf /opt/fraisier/scripts/scaffold-templates" in _all_args(runner)
+
+
+class TestBootstrapTemplateDirEdgeCases:
+    def test_no_upload_when_not_configured(self, tmp_path):
+        boot, runner = _make(tmp_path, None)
+
+        boot._upload_config()
+
+        assert "scaffold-templates" not in _all_args(runner)
+
+    def test_absolute_template_dir_is_not_uploaded(self, tmp_path):
+        """An absolute path names a location the operator manages on the server."""
+        boot, runner = _make(tmp_path, str(tmp_path / "abs-templates"))
+
+        boot._upload_config()
+
+        assert "abs-templates" not in _all_args(runner)
+
+    def test_missing_directory_does_not_fail_bootstrap(self, tmp_path):
+        """Configured but absent locally: warn, do not abort provisioning."""
+        boot, _runner = _make(tmp_path, "scripts/scaffold-templates", create=False)
+
+        step = boot._upload_config()
+
+        assert step.success is True
+
+    def test_dry_run_uploads_nothing(self, tmp_path):
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates", dry=True)
+
+        step = boot._upload_config()
+
+        assert step.success is True
+        runner.upload.assert_not_called()
+        runner.upload_tree.assert_not_called()
+        runner.run.assert_not_called()
+
+    def test_dry_run_plan_mentions_the_template_dir(self, tmp_path):
+        """--dry-run is the review surface; a silent extra upload defeats it."""
+        boot, _ = _make(tmp_path, "scripts/scaffold-templates", dry=True)
+
+        step = boot._upload_config()
+
+        assert "scaffold-templates" in (step.command or "")
+
+    def test_upload_failure_is_not_fatal(self, tmp_path):
+        """Best-effort, matching the deploy path: log loudly, keep provisioning."""
+        boot, runner = _make(tmp_path, "scripts/scaffold-templates")
+        runner.upload_tree.side_effect = subprocess.CalledProcessError(1, "scp")
+
+        step = boot._upload_config()
+
+        assert step.success is True

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.53.0"
+version = "0.53.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #318.

Follow-up to #312, found by checking whether that fix covered every path into the server's config directory. It did not: the deploy path carried `scaffold.template_dir`, `bootstrap` did not.

`bootstrap._upload_config` uploaded exactly one file, so a freshly bootstrapped host had a `fraises.yaml` whose relative `template_dir` pointed at a directory nothing had created — the same single-file omission #312 fixed, at provisioning time instead. Same shape as #284: bootstrap and the deploy path disagreeing about what lands in `/opt/fraisier`.

## This is narrower than it sounds — three things bound it

Worth stating plainly so the fix is not over-read as a data-loss bug:

1. **Bootstrap renders its initial scaffold locally.** `_upload_scaffold_files` builds `ScaffoldRenderer(self.config)` from the *operator's* `fraises.yaml`, where a relative `template_dir` resolves correctly — so the uploaded tree already carried the customisations. The server started out right.
2. **Bootstrap never renders server-side.** Its only remote invocation against `/opt/fraisier/fraises.yaml` is `validate-setup` (`bootstrap.py:410`); `install.sh` installs from the already-rendered state dir. Nothing overwrote the correct tree.
3. **The first deploy self-heals it.** `deployers/api.py:194` syncs — including the template tree since #312 — *before* `_detect_config_changes` and `_regenerate_scaffold`.

**The actual exposure** was the window between bootstrap and the first deploy: a hand-run `fraisier scaffold` on the box, or `scaffold-install` after editing the server config, would silently render built-ins. Since v0.53.0 the renderer warns and names the resolved path, which is currently the only thing standing between this and a repeat of #312.

## Changes

- `_upload_config` uploads the template tree after the config, **replacing it wholesale** so a template deleted upstream cannot survive on the server and keep shadowing a built-in.
- **Absolute `template_dir` is skipped** — it names a location the operator manages on the server; uploading over it would be surprising.
- **`--dry-run` names the template upload in its plan.** A silent extra upload would defeat the review surface that makes `--dry-run` worth having.
- **Best-effort with a loud log**, matching the deploy path — provisioning that would otherwise succeed must not fail over templates.
- `bootstrap.py` gains the module logger it never had (my warning calls raised `NameError` until I noticed the tests failing for that reason rather than the intended one).

## Verification

- 4491 passed, 7 skipped (+10 collected, all new)
- 4 of the 10 confirmed failing before the fix; the other 6 pin edge cases that pass trivially today and would not otherwise be checked — absolute path skipped, nothing uploaded when unconfigured, dry-run writes nothing, upload failure non-fatal
- `ruff check .` clean; `ruff format --check .` clean on 444 files; `ty check` clean

## What this does not fix

- **The upload is best-effort**, so a host can still end up on built-in templates; the v0.53.0 render-time warning is what surfaces that.
- **`fraisier setup` is unaffected.** It renders and installs locally and never populates `/opt/fraisier`, so it has no template directory to carry — worth knowing before someone reads this as a general provisioning fix.

Patch, not minor: a fix with no new user-facing surface. Version bump rolled in per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)