### PR TITLE
release: v0.54.0 — the pre-migration dump gate can actually write (#317, #318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.53.1] - 2026-08-01
+## [0.54.0] - 2026-08-01
 
-Closes #318. Follow-up to #312: the deploy path carried `scaffold.template_dir`
-to the server, `bootstrap` did not.
+Closes #317 and #318. #317 is the important one: **the v0.52.0 pre-migration
+dump gate could never succeed on a standard install**, so every deploy with
+pending migrations failed closed.
+
+Absorbs v0.53.1, which was merged but never published.
 
 ### Fixed
 
+- **The dump gate's `output_dir` is now writable from the webhook unit's sandbox** (`core/fraisier-webhook.service.j2`, #317). The generated unit runs `ProtectSystem=strict` with a `ReadWritePaths=` list covering only the fraisier state dirs and the app/git trees. `database.pre_migrate_dump.output_dir` was never propagated into it, so `pg_dump` failed with `Read-only file system` and the gate — correctly — aborted the deploy. On any strict install, which is every scaffold-generated unit, the feature was a guaranteed deploy blocker on first use. Hit in production on printoptim.io, 2026-08-01.
 - **`fraisier bootstrap` now uploads `scaffold.template_dir`** (`bootstrap.py`, #318). `_upload_config` uploaded exactly one file, so a freshly bootstrapped host had a `fraises.yaml` whose relative `template_dir` pointed at a directory nothing had created — the same single-file omission #312 fixed on the deploy path, at provisioning time instead. It now uploads the tree alongside the config, replacing it wholesale so a template deleted upstream cannot survive and keep shadowing a built-in.
+
+### Added
+
+- **`doctor` check `pre_migrate_dump_writable`** (#317). Reads the **installed** webhook unit — not the freshly rendered one — and warns when it is `ProtectSystem=strict` but does not allow writes to a configured dump directory. That catches the upgrade-without-re-scaffold case, which is the likeliest way to still be broken after this fix. Advisory: `warn`, never `fail`.
 
 ### Notes for operators
 
-- **Nothing was corrupted by this, and a bootstrap-then-deploy host was never affected.** Bootstrap renders its initial scaffold *locally*, where a relative `template_dir` resolves correctly, so the uploaded tree already carried your customisations; bootstrap never renders server-side; and the first deploy's config sync created the directory. The exposure was the window in between, where a hand-run `fraisier scaffold` on the box would silently render built-ins. Since v0.53.0 that case warns.
-- **`--dry-run` now names the template upload** in its plan, so the review surface still shows everything that will be written.
-- An **absolute** `template_dir` is still never uploaded — it names a location you manage on the server yourself.
+- **Re-run `fraisier scaffold && sudo fraisier scaffold-install --yes`.** The fix is in a generated unit; upgrading the package alone changes nothing. `fraisier doctor` will tell you if you have not.
+- **Nothing was silently wrong.** The gate did its job — migrations were not applied, the service was not restarted, the database was untouched. The failure mode was a blocked deploy, not a corrupted one.
+- **The config key is `output_dir`**, not `dir`. The issue text says `dir`; the code has always read `output_dir` (`strategies/_core.py`).
+- **`fraisier bootstrap` now uploads `scaffold.template_dir`** (#318) — see the note below, carried from the unpublished v0.53.1.
+- **`--dry-run` names the template upload** in its plan, and an absolute `template_dir` is still never uploaded.
 
 ### Known limitations
 
-- **The upload is best-effort**, matching the deploy path: a failure is logged loudly but does not abort provisioning that would otherwise succeed. A host can still end up on built-in templates, and the render-time warning added in v0.53.0 is what surfaces that.
-- **`fraisier setup` is unaffected and unchanged.** It renders and installs locally and does not populate `/opt/fraisier`, so it has no template directory to carry.
+- **Only the webhook unit's sandbox was widened.** If you run the deploy through a different unit, or carry a hand-written one, it needs the same `ReadWritePaths=` entry — the doctor check reads the generated unit's path, so a custom unit is not inspected.
+- **The doctor check does not attempt a real write.** It compares the configured directory against the unit's allowlist textually; it will not catch a directory that is allowlisted but unwritable for some other reason (ownership, full filesystem, read-only mount).
+- **The template-dir upload is best-effort** (#318): a failure is logged loudly but does not abort provisioning, so a host can still end up on built-in templates.
+- **`fraisier setup` is unaffected** by #318 — it renders and installs locally and never populates `/opt/fraisier`.
 
 ## [0.53.0] - 2026-07-31
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -34,6 +34,7 @@ passed.
 | `fraises_yaml_resolves` | every reachable `!envvar` resolves to a set var | no | export the missing variables or move them to `~/.config/fraisier/secrets.env` |
 | `secrets_env_readable` | `~/.config/fraisier/secrets.env` exists and is mode 0600 | no | `chmod 600 ~/.config/fraisier/secrets.env` |
 | `helper_sudoers` | `/etc/sudoers.d/<project>` exists and is mode 0440 | no | `fraisier scaffold-install` |
+| `pre_migrate_dump_writable` | the installed webhook unit allows writes to `pre_migrate_dump.output_dir` | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
 | `install_compile_bytecode` | a `uv sync` `install.command` passes `--compile-bytecode` | no | add `--compile-bytecode` to `install.command` — see [bytecode and startup time](deployment-guide.md#bytecode-and-startup-time) |
 
 `install_compile_bytecode` is **advisory** — it returns `warn`, never `fail`,

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -317,6 +317,91 @@ def _check_install_compile_bytecode(config: FraisierConfig | None) -> CheckResul
     return CheckResult(name, "pass", f"{checked} `uv sync` command(s) compile bytecode")
 
 
+def _installed_webhook_unit(project_name: str) -> Path:
+    """Where scaffold-install puts the webhook unit. Seam for tests."""
+    return Path("/etc/systemd/system") / f"fraisier-{project_name}-webhook.service"
+
+
+def _enabled_dump_dirs(config: FraisierConfig | None) -> list[str]:
+    """Every ``pre_migrate_dump.output_dir`` for a gate that is switched on."""
+    dirs: list[str] = []
+    fraises = getattr(config, "fraises", None) if config is not None else None
+    for fraise in (fraises or {}).values():
+        if not isinstance(fraise, dict):
+            continue
+        for env_config in (fraise.get("environments") or {}).values():
+            if not isinstance(env_config, dict):
+                continue
+            pmd = (env_config.get("database") or {}).get("pre_migrate_dump") or {}
+            out = pmd.get("output_dir")
+            if pmd.get("enabled") and out and out not in dirs:
+                dirs.append(out)
+    return dirs
+
+
+@register_check("pre_migrate_dump_writable")
+def _check_pre_migrate_dump_writable(config: FraisierConfig | None) -> CheckResult:
+    """The dump gate must be able to write from inside the unit's sandbox (#317).
+
+    The webhook unit runs ``ProtectSystem=strict``; a dump directory missing
+    from its ``ReadWritePaths=`` fails with ``Read-only file system`` and the
+    gate — correctly — aborts the deploy. Every deploy with pending migrations
+    then fails closed.
+
+    Nothing else catches it: the path is writable from a login shell, so
+    ownership and free-space checks all pass. Only a write attempted from
+    inside the sandbox reveals it, and the first signal was a failed
+    production deploy.
+
+    Reads the **installed** unit rather than the rendered one, so it also
+    catches the upgrade-without-re-scaffold case, which is the likeliest way to
+    still be broken after the template fix.
+    """
+    name = "pre_migrate_dump_writable"
+    dump_dirs = _enabled_dump_dirs(config)
+    if not dump_dirs:
+        return CheckResult(name, "skip", "no pre_migrate_dump gate enabled")
+
+    project = getattr(config, "project_name", None)
+    if not project:
+        return CheckResult(name, "skip", "no project_name in config")
+
+    unit_path = _installed_webhook_unit(project)
+    try:
+        unit = unit_path.read_text()
+    except OSError:
+        return CheckResult(name, "skip", f"{unit_path} not installed")
+
+    if "ProtectSystem=strict" not in unit:
+        return CheckResult(name, "pass", "webhook unit is not ProtectSystem=strict")
+
+    allowed = {
+        ln.split("=", 1)[1].strip()
+        for ln in unit.splitlines()
+        if ln.startswith("ReadWritePaths=")
+    }
+    missing = [
+        d
+        for d in dump_dirs
+        if not any(d == a or d.startswith(a.rstrip("/") + "/") for a in allowed)
+    ]
+    if missing:
+        return CheckResult(
+            name,
+            "warn",
+            f"{unit_path} is ProtectSystem=strict but does not allow writes to "
+            f"{', '.join(missing)} — the dump gate will fail closed and block "
+            f"every deploy with pending migrations",
+            fix_hint=(
+                "run `fraisier scaffold && sudo fraisier scaffold-install --yes` "
+                "to regenerate the unit with the dump directory allowed"
+            ),
+        )
+    return CheckResult(
+        name, "pass", f"{len(dump_dirs)} dump dir(s) writable from the sandbox"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public runner
 # ---------------------------------------------------------------------------

--- a/fraisier/scaffold/templates/core/fraisier-webhook.service.j2
+++ b/fraisier/scaffold/templates/core/fraisier-webhook.service.j2
@@ -70,6 +70,20 @@ RuntimeDirectoryPreserve=restart
 ReadWritePaths={{ mp.path }}
 {% endif %}
 {% endfor %}
+{# The pre-migration dump gate (#313) writes here from inside this sandbox.
+   Without the entry every deploy with pending migrations fails closed on
+   `Read-only file system`, and nothing before the deploy reveals it: the path
+   is writable from a login shell, so preflight and doctor both pass (#317). #}
+{% set _dump_dirs = [] %}
+{% for fraise in local_fraises %}
+{% for env_config in fraise.get('environments', {}).values() %}
+{% set _pmd = (env_config.get('database') or {}).get('pre_migrate_dump') or {} %}
+{% if _pmd.get('enabled') and _pmd.get('output_dir') and _pmd.get('output_dir') not in _dump_dirs %}
+{% set _ = _dump_dirs.append(_pmd.get('output_dir')) %}
+ReadWritePaths={{ _pmd.get('output_dir') }}
+{% endif %}
+{% endfor %}
+{% endfor %}
 
 [Install]
 WantedBy=multi-user.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.53.1"
+version = "0.54.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_pre_migrate_dump_sandbox.py
+++ b/tests/test_pre_migrate_dump_sandbox.py
@@ -1,0 +1,187 @@
+"""The dump gate's output_dir must reach the webhook unit's sandbox (#317).
+
+`database.pre_migrate_dump` (v0.52.0) makes the deploy take a verified pg_dump
+before applying migrations, and aborts if it cannot. The generated webhook unit
+runs `ProtectSystem=strict` with a `ReadWritePaths=` list that never included
+the dump directory — so on every strict install the dump failed with
+`Read-only file system` and **every deploy with pending migrations failed
+closed**.
+
+Invisible to preflight: the path is writable from a login shell, and only a
+write from inside the unit's sandbox reveals it. First signal was a failed
+production deploy (printoptim.io, 2026-08-01).
+
+Note the key is `output_dir`, not `dir` as the issue text says.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {output}
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+        git_repo: /var/git/api.git
+        database:
+          name: myapp_prod
+          strategy: migrate
+{dump}
+"""
+
+_DUMP_BLOCK = """          pre_migrate_dump:
+            enabled: true
+            output_dir: /var/backups/myproj/pre_migrate
+"""
+
+
+def _unit(tmp_path, dump: str) -> str:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(_YAML.format(output=str(tmp_path / "out"), dump=dump))
+    ScaffoldRenderer(FraisierConfig(p)).render()
+    return (tmp_path / "out" / "fraisier-myproj-webhook.service").read_text()
+
+
+def _rw_paths(text: str) -> list[str]:
+    return [
+        ln.split("=", 1)[1].strip()
+        for ln in text.splitlines()
+        if ln.startswith("ReadWritePaths=")
+    ]
+
+
+class TestDumpDirIsWritableFromTheSandbox:
+    def test_output_dir_appears_in_readwritepaths(self, tmp_path):
+        paths = _rw_paths(_unit(tmp_path, _DUMP_BLOCK))
+
+        assert "/var/backups/myproj/pre_migrate" in paths, (
+            f"dump dir not in the sandbox allowlist: {paths}"
+        )
+
+    def test_the_unit_is_still_strict(self, tmp_path):
+        """The fix must widen the allowlist, not disable the sandbox."""
+        text = _unit(tmp_path, _DUMP_BLOCK)
+
+        assert "ProtectSystem=strict" in text
+
+    def test_existing_paths_are_retained(self, tmp_path):
+        """Widening must not drop the state dirs or the app/git trees."""
+        paths = _rw_paths(_unit(tmp_path, _DUMP_BLOCK))
+
+        for expected in ("/opt/fraisier", "/var/lib/fraisier", "/run/fraisier"):
+            assert expected in paths
+
+    def test_nothing_added_when_the_gate_is_absent(self, tmp_path):
+        """No dump config, no extra sandbox hole."""
+        paths = _rw_paths(_unit(tmp_path, ""))
+
+        assert not any("backups" in p for p in paths)
+
+    def test_nothing_added_when_the_gate_is_disabled(self, tmp_path):
+        """enabled: false must not widen the sandbox either."""
+        disabled = _DUMP_BLOCK.replace("enabled: true", "enabled: false")
+        paths = _rw_paths(_unit(tmp_path, disabled))
+
+        assert not any("backups" in p for p in paths)
+
+    def test_no_duplicate_entries(self, tmp_path):
+        paths = _rw_paths(_unit(tmp_path, _DUMP_BLOCK))
+
+        assert len(paths) == len(set(paths)), f"duplicate ReadWritePaths: {paths}"
+
+
+class TestDoctorCatchesItBeforeADeployDoes:
+    """Re-scaffolding is what applies the fix; nothing told you that.
+
+    An operator who upgrades but does not re-run `scaffold-install` keeps the
+    old unit and keeps failing closed. This check reads the *installed* unit,
+    so it catches exactly that gap.
+    """
+
+    def _run(self, cfg):
+        from fraisier import doctor
+
+        return doctor.DOCTOR_CHECKS["pre_migrate_dump_writable"].fn(cfg)
+
+    def _cfg(self, tmp_path, enabled=True, output_dir="/var/backups/x"):
+        p = tmp_path / "fraises.yaml"
+        p.write_text(f"""
+name: myproj
+scaffold:
+  deploy_user: fraisier
+fraises:
+  my_api:
+    type: api
+    environments:
+      production:
+        app_path: /var/www/api
+        database:
+          name: db
+          strategy: migrate
+          pre_migrate_dump:
+            enabled: {str(enabled).lower()}
+            output_dir: {output_dir}
+""")
+        return FraisierConfig(p)
+
+    def test_registered(self):
+        from fraisier import doctor
+
+        assert "pre_migrate_dump_writable" in doctor.DOCTOR_CHECKS
+
+    def test_skips_when_gate_not_enabled(self, tmp_path):
+        assert self._run(self._cfg(tmp_path, enabled=False)).status == "skip"
+
+    def test_skips_without_config(self):
+        assert self._run(None).status == "skip"
+
+    def test_warns_when_installed_unit_omits_the_dir(self, tmp_path, monkeypatch):
+        unit = tmp_path / "webhook.service"
+        unit.write_text(
+            "[Service]\nProtectSystem=strict\nReadWritePaths=/opt/fraisier\n"
+        )
+        monkeypatch.setattr("fraisier.doctor._installed_webhook_unit", lambda _p: unit)
+
+        result = self._run(self._cfg(tmp_path))
+
+        assert result.status == "warn"
+        assert "/var/backups/x" in result.detail
+        assert result.fix_hint is not None
+        assert "scaffold" in result.fix_hint
+
+    def test_passes_when_installed_unit_lists_the_dir(self, tmp_path, monkeypatch):
+        unit = tmp_path / "webhook.service"
+        unit.write_text(
+            "[Service]\nProtectSystem=strict\n"
+            "ReadWritePaths=/opt/fraisier\nReadWritePaths=/var/backups/x\n"
+        )
+        monkeypatch.setattr("fraisier.doctor._installed_webhook_unit", lambda _p: unit)
+
+        assert self._run(self._cfg(tmp_path)).status == "pass"
+
+    def test_skips_when_the_unit_is_not_installed(self, tmp_path, monkeypatch):
+        """A dev machine has no unit — that is not a finding."""
+        monkeypatch.setattr(
+            "fraisier.doctor._installed_webhook_unit",
+            lambda _p: tmp_path / "nope.service",
+        )
+
+        assert self._run(self._cfg(tmp_path)).status == "skip"
+
+    def test_no_warning_when_sandbox_is_not_strict(self, tmp_path, monkeypatch):
+        """Without ProtectSystem=strict the allowlist does not gate writes."""
+        unit = tmp_path / "webhook.service"
+        unit.write_text("[Service]\nReadWritePaths=/opt/fraisier\n")
+        monkeypatch.setattr("fraisier.doctor._installed_webhook_unit", lambda _p: unit)
+
+        assert self._run(self._cfg(tmp_path)).status == "pass"

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.53.1"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #317, closes #318.

**#317 is a production deploy blocker**: the v0.52.0 `pre_migrate_dump` gate could never succeed on a standard install, so every deploy with pending migrations failed closed.

Absorbs v0.53.1 (#318), which was merged but never published — folded into one entry rather than leaving a version documented but never released.

## #317 — the gate could not write

The generated webhook unit runs `ProtectSystem=strict`, and its `ReadWritePaths=` loop filters the manifest through a hardcoded set: `app_path`, `git_repo`, `/opt/fraisier`, `/var/lib/fraisier`, `/run/fraisier`. Verified that `pre_migrate_dump` appears **nowhere** under `fraisier/scaffold/` or in `manifest.py` — the dump directory could never reach the allowlist. `pg_dump` hit `Read-only file system`, and the gate correctly aborted.

Rendered against the reporter's own config shape, the unit now carries the exact path from their error message:

```
ProtectSystem=strict
…
ReadWritePaths=/var/backups/printoptim/pre_migrate      ← new
```

Plus **`doctor` check `pre_migrate_dump_writable`**, which reads the *installed* unit rather than a freshly rendered one — so it catches upgrade-without-re-scaffold, the likeliest way to still be broken after this fix. Advisory (`warn`, never `fail`).

**One correction to the issue:** the config key is `output_dir`, not `dir` (`strategies/_core.py`). Only matters for anyone fixing this by grep — which is exactly how it would be fixed.

## The issue's second half does not reproduce — deliberately not fixed

Its side observation says a gate-failed host is left with new code and a new `version.json` while the old process runs. Driving a real deploy to gate failure:

```
status             : ROLLED_BACK
version.json now   : OLD          ← restored, not left advanced
git rollback called: True ('prev123',)
```

The failure handler already calls `_restore_previous_state()` (git-reverts the tree, restarts the service) then `_restore_version_json()`. That snapshot/restore was added by #257 for exactly this case, and version.json is generated before migrations **on purpose** — the rebuild strategy reads it to stamp the database — so re-ordering is not a free change.

I have [put the evidence and four narrowing questions back to the reporter](https://github.com/fraiseql/fraisier/issues/317#issuecomment-5151240533) rather than reorder deploy steps against a symptom I could not make happen. Same discipline the repo applied to #286.

## Verification

- 4504 passed, 7 skipped (+13 collected, all new)
- 4 confirmed failing before the fix; the rest pin edge cases that pass trivially today — gate disabled, gate absent, non-strict unit, unit not installed, no duplicate entries
- Rendered artifact inspected against the reporter's config, not just the template

## What this does not fix

- **Only the webhook unit's sandbox was widened.** A hand-written or different unit needs the same entry, and the doctor check inspects only the generated unit's path.
- **The doctor check does not attempt a real write.** It compares configured directory against allowlist textually — it will not catch an allowlisted directory that is unwritable for another reason (ownership, full disk, read-only mount).
- **The #318 template upload remains best-effort**, so a host can still end up on built-in templates.

Minor, not patch: adds a doctor check. Version bump rolled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)