### PR TITLE
release: v0.55.0 — automatic rollback stops being a no-op (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-08-01
+
+Closes #321. **Automatic rollback has never run in fraisier's own deployment
+model.** Reported by a beta tester from journal evidence — every successful
+webhook deploy logged `(None -> sha)` — and reproduced here.
+
+### Fixed
+
+- **`get_worktree_sha` now reads the SHA that is actually deployed** (`git/operations.py`, #321). It ran `git -C <worktree> rev-parse HEAD`, but the bare-repo + worktree layout leaves the worktree with **no `.git` directory** — which is exactly why `fetch_and_checkout` passes `--git-dir/--work-tree`. The call failed with `fatal: not a git repository`, was caught, and returned `None` on **every** deploy rather than only the first, as its docstring claimed.
+
+### ⚠️ What that meant
+
+`_previous_sha` is assigned from that function and nothing else. With it permanently `None`:
+
+- **`_restore_previous_state` returned immediately** — no git revert, no service restart. A failed deploy left the worktree and venv **ahead of the database**.
+- The database rollback never received a target.
+- `rollback()` and the deploy-timeout rollback path were no-ops.
+- `get_current_version()` had the same flaw, so deploy results always reported `old_version: null`.
+
+Status reporting was *honest* throughout — with nothing restored, v0.51.0's classifier correctly reported `FAILED` rather than `ROLLED_BACK` — which is why this never surfaced as a wrong-status bug. The safety net accurately reported doing nothing.
+
+### Notes for operators
+
+- **Rollback now actually happens on a failed deploy.** If you have been relying on manual recovery, expect the deploy to revert the worktree and restart the service on the previous commit by itself.
+- **`old_version` starts being populated** in deploy results, notifications and the status file, where it was previously always null.
+- Nothing to re-scaffold: this is package code, not a generated unit.
+
+### Known limitations
+
+- **A genuinely first deploy still has no previous SHA**, so there is still nothing to roll back to — correctly reported as `FAILED`.
+- **Fixed for the bare-repo + worktree model and the plain-clone fallback**; a layout that is neither still returns `None`.
+- **This does not change what rollback *does*** — only that it now runs. The database half remains governed by the strategy, and a git-only revert still reports `ROLLED_BACK` per v0.51.0.
+
 ## [0.54.0] - 2026-08-01
 
 Closes #317 and #318. #317 is the important one: **the v0.52.0 pre-migration

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -115,7 +115,9 @@ class GitDeployMixin:
         """Get currently deployed git commit from worktree."""
         if not self.app_path:
             return None
-        sha = get_worktree_sha(Path(self.app_path))
+        # Pass the bare repo: the worktree has no .git in fraisier's
+        # deploy model, so the in-worktree read always fails (#321).
+        sha = get_worktree_sha(Path(self.app_path), bare_repo=self.bare_repo)
         return sha[:8] if sha else None
 
     def get_latest_version(self) -> str | None:

--- a/fraisier/git/operations.py
+++ b/fraisier/git/operations.py
@@ -25,21 +25,47 @@ _SELFHEAL_ESCALATE_WITHIN_DEPLOYS = 3
 _SELFHEAL_STATE_FILE = "fraisier_selfheal_state.json"
 
 
-def get_worktree_sha(worktree: Path) -> str | None:
-    """Read the current HEAD SHA from a worktree.
+def get_worktree_sha(worktree: Path, bare_repo: Path | None = None) -> str | None:
+    """Read the SHA currently deployed into *worktree*.
 
-    Returns None if the worktree has no git state (first deploy).
+    Pass *bare_repo* for the bare-repo + worktree layout fraisier deploys into.
+    That worktree has **no ``.git`` directory**, so a plain
+    ``git -C <worktree> rev-parse HEAD`` fails with "not a git repository" and
+    silently reports None — on every deploy, not only the first. Since
+    ``_previous_sha`` is assigned from this and nothing else, that made every
+    rollback path a no-op (#321).
+
+    Reading the bare repo's HEAD is correct rather than approximate:
+    :func:`fetch_and_checkout` runs ``git --git-dir=<bare> reset --soft
+    <new_sha>`` after each checkout, so the bare repo's HEAD *is* the deployed
+    commit.
+
+    Returns None when there is genuinely no deployed commit — an empty bare
+    repo on a true first deploy — or when neither read succeeds.
     """
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
+    attempts: list[list[str]] = []
+    if bare_repo is not None:
+        attempts.append(
+            [
+                "git",
+                f"--git-dir={bare_repo}",
+                f"--work-tree={worktree}",
+                "rev-parse",
+                "HEAD",
+            ]
         )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError:
-        return None
+    # Fall back to the in-worktree read so a plain-clone layout still works.
+    attempts.append(["git", "-C", str(worktree), "rev-parse", "HEAD"])
+
+    for cmd in attempts:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        sha = result.stdout.strip()
+        if sha:
+            return sha
+    return None
 
 
 def get_commit_timestamp(git_dir: Path, sha: str) -> str | None:
@@ -86,7 +112,7 @@ def fetch_and_checkout(
     Returns (old_sha, new_sha). old_sha is None on first deploy.
     The old_sha can be used for rollback.
     """
-    old_sha = get_worktree_sha(worktree)
+    old_sha = get_worktree_sha(worktree, bare_repo=bare_repo)
 
     # Fetch latest from origin
     subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.54.0"
+version = "0.55.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_worktree_sha_bare_model.py
+++ b/tests/test_worktree_sha_bare_model.py
@@ -1,0 +1,116 @@
+"""`get_worktree_sha` must work in fraisier's own deploy model (#321).
+
+The bare-repo + worktree layout leaves the worktree with **no `.git`
+directory** — which is why `fetch_and_checkout` passes `--git-dir/--work-tree`.
+`get_worktree_sha` did not, so `git -C <worktree> rev-parse HEAD` raised
+`fatal: not a git repository`, was caught, and returned None on *every* deploy
+rather than only the first.
+
+`_previous_sha` is assigned from it and nothing else, so every rollback path —
+git revert, service restart, database rollback target — was a permanent no-op.
+A failed deploy left the worktree and venv ahead of the database.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from fraisier.git.operations import fetch_and_checkout, get_worktree_sha
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def bare_and_worktree(tmp_path):
+    """A bare mirror + worktree, exactly the shape fraisier deploys into."""
+    src = tmp_path / "src"
+    src.mkdir()
+    _git("init", "-q", ".", cwd=src)
+    _git("config", "user.email", "t@e.st", cwd=src)
+    _git("config", "user.name", "t", cwd=src)
+    (src / "f.txt").write_text("v1\n")
+    _git("add", "-A", cwd=src)
+    _git("commit", "-qm", "one", cwd=src)
+
+    bare = tmp_path / "bare.git"
+    _git("clone", "-q", "--bare", str(src), str(bare))
+    # A plain --bare clone has no refs/remotes/origin/*, so `origin/<branch>`
+    # would not resolve. Production bare repos do resolve it (fetch_and_checkout
+    # rev-parses it), so give the fixture the same refspec.
+    _git(
+        f"--git-dir={bare}",
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/*:refs/remotes/origin/*",
+    )
+    _git(f"--git-dir={bare}", "fetch", "-q", "origin")
+    branch = _git("-C", str(src), "rev-parse", "--abbrev-ref", "HEAD")
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _git(f"--git-dir={bare}", f"--work-tree={worktree}", "checkout", "-f", "HEAD")
+    return bare, worktree, src, branch
+
+
+class TestBareRepoWorktree:
+    def test_worktree_really_has_no_dot_git(self, bare_and_worktree):
+        """The premise — if this changes, the whole bug class changes."""
+        _bare, worktree, _src, _branch = bare_and_worktree
+
+        assert not (worktree / ".git").exists()
+
+    def test_sha_is_readable_with_the_bare_repo(self, bare_and_worktree):
+        bare, worktree, _src, _branch = bare_and_worktree
+        expected = _git(f"--git-dir={bare}", "rev-parse", "HEAD")
+
+        assert get_worktree_sha(worktree, bare_repo=bare) == expected
+
+    def test_previous_sha_survives_a_second_deploy(self, bare_and_worktree):
+        """The actual regression: deploy twice, old_sha must be the first commit."""
+        bare, worktree, src, branch = bare_and_worktree
+        first = _git(f"--git-dir={bare}", "rev-parse", "HEAD")
+
+        (src / "f.txt").write_text("v2\n")
+        _git("add", "-A", cwd=src)
+        _git("commit", "-qm", "two", cwd=src)
+
+        old_sha, new_sha = fetch_and_checkout(bare, worktree, branch)
+
+        assert old_sha == first, "old_sha lost — rollback would have no target"
+        assert new_sha != first
+
+
+class TestStillCorrectElsewhere:
+    def test_plain_clone_worktree_still_works(self, tmp_path):
+        """A worktree that does have .git must keep working without a bare repo."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git("init", "-q", ".", cwd=repo)
+        _git("config", "user.email", "t@e.st", cwd=repo)
+        _git("config", "user.name", "t", cwd=repo)
+        (repo / "f.txt").write_text("x\n")
+        _git("add", "-A", cwd=repo)
+        _git("commit", "-qm", "one", cwd=repo)
+
+        assert get_worktree_sha(repo) == _git("-C", str(repo), "rev-parse", "HEAD")
+
+    def test_genuinely_first_deploy_returns_none(self, tmp_path):
+        """An empty bare repo has no HEAD — that is a real None, keep it."""
+        bare = tmp_path / "empty.git"
+        _git("init", "-q", "--bare", str(bare))
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        assert get_worktree_sha(worktree, bare_repo=bare) is None
+
+    def test_nonexistent_paths_return_none_not_raise(self, tmp_path):
+        assert get_worktree_sha(tmp_path / "nope", bare_repo=tmp_path / "nah") is None

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.54.0"
+version = "0.55.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #321.

**Automatic rollback has never run in fraisier's own deployment model.** Found by a beta tester from journal evidence — every successful webhook deploy logged `(None -> sha)` — and reproduced here.

## The bug

`git/operations.py` read the deployed SHA with:

```python
git -C <worktree> rev-parse HEAD
```

But the bare-repo + worktree layout leaves the worktree with **no `.git` directory** — which is precisely why `fetch_and_checkout` passes `--git-dir/--work-tree` eighty lines further down in the same file. The call failed with `fatal: not a git repository`, was caught, and returned `None` on **every** deploy, not just the first as its docstring claimed.

Reproduced outside the test suite before writing any code:

```
$ git clone --bare src bare.git && mkdir worktree
$ git --work-tree=worktree --git-dir=bare.git checkout -f HEAD
$ test -e worktree/.git                          # NO

$ git -C worktree rev-parse HEAD                 # what the code did
fatal: not a git repository (or any parent up to mount point /)

$ git --git-dir=bare.git --work-tree=worktree rev-parse HEAD
4e62fc1d06d86ef36c2acf608aaba9ea7f560450
```

## Why it mattered, and why nobody saw it

`_previous_sha` is assigned from that function and nothing else. Permanently `None` meant:

- **`_restore_previous_state` returned immediately** — no git revert, no service restart. A failed deploy left the worktree and venv **ahead of the database**.
- The database rollback never received a target.
- `rollback()` and the deploy-timeout path were no-ops.
- `get_current_version()` shared the flaw, so results always reported `old_version: null`.

**Status reporting was honest throughout.** With nothing restored, v0.51.0's classifier correctly returned `FAILED` rather than `ROLLED_BACK` — so this never surfaced as a wrong-status bug. The safety net was accurately reporting that it had done nothing, and nobody read it that way. That is also why my own #296 probe of the version.json half came back clean: I set `_previous_sha` by hand in the harness, which is exactly the condition that never holds in production.

## The fix

`get_worktree_sha(worktree, bare_repo=None)` prefers `--git-dir`, falling back to the in-worktree read so a plain-clone layout still works.

Reading the bare repo's HEAD is **exact, not approximate**: `fetch_and_checkout` runs `git --git-dir=<bare> reset --soft <new_sha>` after each checkout, so that HEAD *is* the deployed commit. Reading it before the next fetch yields precisely the previous SHA.

## Verification

- 4510 passed, 7 skipped (+6 collected, all new)
- **4 of the 6 confirmed failing against the old code**, including the end-to-end one: deploy twice into a real bare repo + worktree, assert `old_sha` is the first commit
- One test pins the *premise* — that the worktree has no `.git` — so if that ever changes, the whole bug class is re-evaluated rather than silently assumed
- `ruff check .` clean; `ruff format --check .` clean on 446 files; `ty check` clean

## What this does not fix

- **A genuinely first deploy still has no previous SHA** — correctly reported as `FAILED`.
- **Fixed for bare+worktree and plain-clone**; a layout that is neither still returns `None`.
- **It does not change what rollback *does*** — only that it now runs. A git-only revert still reports `ROLLED_BACK` per v0.51.0, which will now start appearing where deploys previously reported `FAILED`.

## Operator note

Nothing to re-scaffold — this is package code, not a generated unit. But expect behaviour change: failed deploys will now revert the worktree and restart the service on the previous commit by themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)