### PR TITLE
fix(cli): friendly message instead of traceback when /run/fraisier is unreadable (#326)

### DIFF
--- a/fraisier/cli/_deploy.py
+++ b/fraisier/cli/_deploy.py
@@ -354,13 +354,14 @@ def deployment_status(
 
     # Try to read status for each environment
     status_found = False
+    permission_denied = False
     for env in environments:
         status_path = Path("/run/fraisier") / f"{project_name}-{env}.last_deployment"
 
-        if not status_path.exists():
-            continue
-
         try:
+            if not status_path.exists():
+                continue
+
             data = json.loads(status_path.read_text())
             status_found = True
 
@@ -374,9 +375,23 @@ def deployment_status(
                 # Human-readable output
                 _display_deployment_status(data, env)
 
+        except PermissionError:
+            permission_denied = True
+            continue
         except (json.JSONDecodeError, OSError) as e:
             console.print(f"[red]Error reading status for {env}:[/red] {e}")
             continue
+
+    if not status_found and permission_denied:
+        console.print("[yellow]Permission denied reading deployment status[/yellow]")
+        console.print(
+            f"[dim]/run/fraisier/{project_name}-*.last_deployment is readable "
+            "only by the deploy user.[/dim]"
+        )
+        console.print(
+            "[dim]Re-run as the deploy user (or with sudo) to see the status.[/dim]"
+        )
+        raise SystemExit(1)
 
     if not status_found:
         console.print("[yellow]No deployment status found[/yellow]")

--- a/fraisier/cli/_diagnose.py
+++ b/fraisier/cli/_diagnose.py
@@ -284,14 +284,21 @@ def _diagnose_socket_connectivity(socket_path: Path) -> dict:
 def _diagnose_deployment_status(status_path: Path) -> dict:
     """Analyze recent deployment status."""
     result: dict[str, object] = {
-        "status_file_exists": status_path.exists(),
+        "status_file_exists": False,
         "status": None,
         "deployed_version": None,
         "deployed_at": None,
         "error": None,
     }
 
-    if not status_path.exists():
+    try:
+        exists = status_path.exists()
+    except OSError as e:
+        result["error"] = f"Cannot stat status file: {e}"
+        return result
+
+    result["status_file_exists"] = exists
+    if not exists:
         return result
 
     try:

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -312,6 +312,24 @@ class TestDeploymentStatusCommand:
         result = runner.invoke(main, ["--config", cfg, "deployment-status", "my_api"])
         assert result.exit_code == 0
 
+    @patch("fraisier.cli._deploy.Path")
+    def test_permission_denied_gives_hint_not_traceback(
+        self, mock_path_cls: MagicMock, runner: CliRunner, cfg: str
+    ) -> None:
+        # /run/fraisier is only readable by the deploy user; Path.exists()
+        # propagates PermissionError for everyone else (#326)
+        mock_status_path = MagicMock()
+        mock_status_path.exists.side_effect = PermissionError(13, "Permission denied")
+        mock_run_dir = MagicMock()
+        mock_run_dir.__truediv__.return_value = mock_status_path
+        mock_path_cls.return_value = mock_run_dir
+
+        result = runner.invoke(main, ["--config", cfg, "deployment-status", "my_api"])
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "Permission denied" in result.output
+        assert "deploy user" in result.output
+
 
 # ── validate-setup ────────────────────────────────────────────────────────────
 # Note: systemd/socket helper functions (_check_socket_directory, _check_socket_file,


### PR DESCRIPTION
Fixes #326.

`Path.exists()` propagates `EACCES`, so `deployment-status` — the very command `trigger-deploy`'s timeout hint recommends running — tracebacked for any caller that is not the deploy user (repro on printoptim.dev, 0.55.0, Python 3.11).

- `deployment-status`: catch `PermissionError` per environment; if nothing was readable, print a "re-run as the deploy user (or with sudo)" hint and exit 1 instead of a stack trace.
- `_diagnose_deployment_status`: guard the same unguarded `exists()` and record the stat failure in the diagnostic result.
- Regression test: mocked `PermissionError` on `exists()` → exit 1, hint text, no traceback.

Verification: `pytest tests/test_cli_coverage.py tests/test_validate_setup.py` (59 passed), `ruff check` + `ty check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)