### PR TITLE
fix(versioning): refresh uv.lock after version bumps (#328)

### DIFF
--- a/fraisier/cli/version.py
+++ b/fraisier/cli/version.py
@@ -140,7 +140,7 @@ def version_bump(
         fraisier version bump minor --dry-run
         fraisier version bump major --no-tag
     """
-    from fraisier.versioning import bump_version, parse_semver
+    from fraisier.versioning import bump_version, parse_semver, refresh_uv_lock
 
     path = Path(pyproject)
     old_version = _read_current_version(path)
@@ -164,6 +164,9 @@ def version_bump(
 
     result = bump_version(path, part)
     console.print(f"[green]Bumped:[/green] {old_version} -> {result.version}")
+    lock_warning = refresh_uv_lock(path.parent)
+    if lock_warning:
+        console.print(f"[yellow]Warning:[/yellow] {lock_warning}")
 
 
 @main.command(name="ship")
@@ -276,7 +279,7 @@ def ship(
         )
         raise SystemExit(1)
 
-    from fraisier.versioning import bump_version
+    from fraisier.versioning import bump_version, refresh_uv_lock
 
     pyproject_path = Path(pyproject)
     current_version = _read_current_version(pyproject_path)
@@ -375,6 +378,12 @@ def ship(
     def _apply_bump() -> None:
         bump_version(pyproject_path, bump_type)
         success(f"Version bumped: {current_version} -> {new}")
+        # Keep uv.lock's self-version in step so the release commit does not
+        # ship a lockfile that every later bare `uv run` rewrites (#328). The
+        # pipeline's `git add --update` stages the refreshed lockfile.
+        lock_warning = refresh_uv_lock(pyproject_path.parent)
+        if lock_warning:
+            console.print(f"[yellow]Warning:[/yellow] {lock_warning}")
 
     _ship_commit_push_deploy(
         new,

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -284,6 +284,11 @@ def bump_version(
     return VersionInfo(version=new_version)
 
 
+# Generous ceiling: a self-version re-lock is near-instant on a warm cache,
+# but a cold one may hit the network. Bounded so a ship cannot hang here.
+_UV_LOCK_TIMEOUT_SECONDS = 120
+
+
 def refresh_uv_lock(project_dir: Path) -> str | None:
     """Refresh ``uv.lock`` so its self-version matches ``pyproject.toml``.
 
@@ -294,6 +299,9 @@ def refresh_uv_lock(project_dir: Path) -> str | None:
     Returns ``None`` on success or when there is no ``uv.lock`` to refresh,
     else a human-readable warning. Never raises — a stale lockfile is
     exactly the pre-existing behaviour, so failure must not abort a ship.
+    Callers run this *after* ``bump_version`` has committed pyproject.toml,
+    so every failure mode here has to degrade to a warning: raising would
+    abort the ship on an already-applied bump, leaving a dirty tree.
     """
     import shutil
     import subprocess
@@ -309,13 +317,24 @@ def refresh_uv_lock(project_dir: Path) -> str | None:
             "lockfile self-version will lag pyproject.toml"
         )
 
-    result = subprocess.run(
-        [uv, "lock"],
-        cwd=project_dir,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [uv, "lock"],
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_UV_LOCK_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return (
+            f"'uv lock' timed out after {_UV_LOCK_TIMEOUT_SECONDS}s — "
+            "lockfile self-version will lag pyproject.toml"
+        )
+    except OSError as exc:
+        # ``which`` found a file; it does not prove the file can be exec'd.
+        return f"'uv lock' could not be run after version bump: {exc.strerror or exc}"
+
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip().splitlines()
         tail = detail[-1] if detail else "unknown error"

--- a/fraisier/versioning.py
+++ b/fraisier/versioning.py
@@ -284,6 +284,45 @@ def bump_version(
     return VersionInfo(version=new_version)
 
 
+def refresh_uv_lock(project_dir: Path) -> str | None:
+    """Refresh ``uv.lock`` so its self-version matches ``pyproject.toml``.
+
+    Called after a version bump: without this, uv-managed projects ship a
+    lockfile whose own package entry is one bump behind, and any later bare
+    ``uv run`` re-locks and dirties the working tree mid-command (#328).
+
+    Returns ``None`` on success or when there is no ``uv.lock`` to refresh,
+    else a human-readable warning. Never raises — a stale lockfile is
+    exactly the pre-existing behaviour, so failure must not abort a ship.
+    """
+    import shutil
+    import subprocess
+
+    lock_path = project_dir / "uv.lock"
+    if not lock_path.exists():
+        return None
+
+    uv = shutil.which("uv")
+    if uv is None:
+        return (
+            "uv.lock present but 'uv' not on PATH — "
+            "lockfile self-version will lag pyproject.toml"
+        )
+
+    result = subprocess.run(
+        [uv, "lock"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        tail = detail[-1] if detail else "unknown error"
+        return f"'uv lock' failed after version bump: {tail}"
+    return None
+
+
 _PYPROJECT_VERSION_RE = re.compile(r'^(version\s*=\s*")([^"]+)(")', re.MULTILINE)
 
 

--- a/tests/test_atomic_version.py
+++ b/tests/test_atomic_version.py
@@ -169,3 +169,58 @@ class TestRefreshUvLock:
             warning = refresh_uv_lock(tmp_path)
         assert warning is not None
         assert "resolver exploded" in warning
+
+    def test_lock_is_bounded_by_a_timeout(self, tmp_path):
+        """`uv lock` runs under a timeout so a ship cannot hang on it."""
+        from unittest.mock import MagicMock, patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            refresh_uv_lock(tmp_path)
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("timeout")
+
+    def test_timeout_warns_instead_of_raising(self, tmp_path):
+        """A hung `uv lock` degrades to a warning rather than aborting a ship."""
+        import subprocess as _subprocess
+        from unittest.mock import patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch(
+                "subprocess.run",
+                side_effect=_subprocess.TimeoutExpired(["uv", "lock"], 120),
+            ),
+        ):
+            warning = refresh_uv_lock(tmp_path)
+        assert warning is not None
+        assert "timed out" in warning
+
+    def test_exec_failure_warns_instead_of_raising(self, tmp_path):
+        """uv on PATH but unexecutable warns; the bump is already committed.
+
+        ``shutil.which`` only proves a file was found, not that it can be
+        exec'd. This runs after ``bump_version`` has written pyproject.toml,
+        so raising here would abort a ship on a half-applied bump.
+        """
+        from unittest.mock import patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("subprocess.run", side_effect=OSError(8, "Exec format error")),
+        ):
+            warning = refresh_uv_lock(tmp_path)
+        assert warning is not None
+        assert "Exec format error" in warning

--- a/tests/test_atomic_version.py
+++ b/tests/test_atomic_version.py
@@ -108,3 +108,64 @@ class TestAtomicBump:
         result = bump_version(pp, "patch")
         assert isinstance(result, VersionInfo)
         assert result.version == "3.1.5"
+
+
+class TestRefreshUvLock:
+    """refresh_uv_lock keeps uv.lock's self-version in step after a bump (#328)."""
+
+    def test_no_lockfile_is_a_noop(self, tmp_path):
+        """Without uv.lock there is nothing to refresh and no warning."""
+        from unittest.mock import patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        with patch("subprocess.run") as mock_run:
+            assert refresh_uv_lock(tmp_path) is None
+        mock_run.assert_not_called()
+
+    def test_runs_uv_lock_in_project_dir(self, tmp_path):
+        """With uv.lock present, `uv lock` runs in the project directory."""
+        from unittest.mock import MagicMock, patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            assert refresh_uv_lock(tmp_path) is None
+        args, kwargs = mock_run.call_args
+        assert args[0] == ["/usr/bin/uv", "lock"]
+        assert kwargs["cwd"] == tmp_path
+
+    def test_missing_uv_warns_instead_of_raising(self, tmp_path):
+        """uv absent from PATH degrades to a warning, not a crash."""
+        from unittest.mock import patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with patch("shutil.which", return_value=None):
+            warning = refresh_uv_lock(tmp_path)
+        assert warning is not None
+        assert "not on PATH" in warning
+
+    def test_failed_lock_warns_with_stderr_tail(self, tmp_path):
+        """A failing `uv lock` returns a warning carrying the error tail."""
+        from unittest.mock import MagicMock, patch
+
+        from fraisier.versioning import refresh_uv_lock
+
+        (tmp_path / "uv.lock").write_text("")
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr="boom\nresolver exploded", stdout=""
+            )
+            warning = refresh_uv_lock(tmp_path)
+        assert warning is not None
+        assert "resolver exploded" in warning


### PR DESCRIPTION
Fixes #328.

`fraisier ship`'s `_apply_bump` and `fraisier version bump` rewrite the version in `pyproject.toml` but never refresh `uv.lock`, so uv-managed projects ship every release with a lockfile whose own package entry is one bump behind. Any later bare `uv run` re-locks and rewrites `uv.lock` mid-command, and `fraisier sync` aborts on the dirty tree (hit twice on printoptim_backend on 2026-08-03 alone).

- New `versioning.refresh_uv_lock(project_dir)`: if a sibling `uv.lock` exists, run `uv lock` there. Warn-don't-fail on missing uv or lock failure — a stale lockfile is exactly the pre-existing behaviour, so it must not abort a ship.
- Wired into ship's `_apply_bump` (after the checks pass, alongside the pyproject write — the pipeline's `git add --update` stages the refreshed lockfile into the release commit) and into `version bump`.
- 4 unit tests: no-lockfile no-op, invocation cwd, missing-uv warning, failure warning with stderr tail.

Verification: `pytest` on all ship/version test files (218 passed), `ruff check` + `ruff format --check` + `ty check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)