### PR TITLE
release: v0.56.0 — the webhook unit installed on a host is the one rendered for it (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,167 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-08-03
+
+Closes #325. **The webhook unit installed on a machine was not the one
+rendered for it.** Reported from production (printoptim.io, 2026-08-03): a
+prod-only host running the unit built for the dev host, so
+`ProtectSystem=strict` denied every write to the production bare repo and
+`git fetch` aborted with exit 255.
+
+### What broke
+
+The per-server filter was never wrong. `_build_context(config, server)`
+produced exactly the right path set. What was broken is that nothing
+guaranteed the file carrying that set was the file that got installed.
+
+The deploy path regenerates the tree with `fraisier scaffold --output-dir
+<state_dir>` and **no `--server`**, which takes the auto-per-server branch and
+writes only slugged `fraisier-{project}-webhook-{slug}.service` files. All
+three installers — the generated `install.sh`, `ServerSetup._plan_webhook_service`
+and `ScaffoldRenderer.get_install_mapping` — asked for the *unslugged*
+`fraisier-{project}-webhook.service`, a name that render never produced.
+`install.sh` guarded its copy with `if [ -f ]`, so the step was **silently
+skipped**, or silently copied whatever unslugged file survived in the state
+dir from an earlier, differently-filtered render — content frozen from
+whichever server context last wrote it.
+
+Two more routes reached the same failure, both fixed here:
+
+- `_collect_unique_servers` read only the global `environments:` section while
+  the installer's host gating read the per-fraise configs too. A config
+  declaring `server:` only under `fraises.*` looked server-less to the
+  renderer — one unit carrying **every** host's trees, the #62
+  least-privilege leak by a second route.
+- An environment declaring no `server:` in a multi-server config matched no
+  logical server, so its `git_repo`/`app_path` were rendered into **no** unit
+  at all.
+
+### Why nothing caught it
+
+Every operator-side check passes: the paths exist, are owned correctly and are
+writable from a login shell. Only a write attempted from *inside* the unit's
+sandbox reveals it, and nothing ever attempted one. `fraisier doctor`'s #317
+check compared `ReadWritePaths=` against dump directories only.
+
+### The new contract
+
+> When any environment declares a `server:`, the scaffold tree contains
+> **only** slugged `fraisier-{project}-webhook-{slug}.service` files, and the
+> installer resolves the slug from the machine hostname. When no environment
+> declares a `server:`, the tree contains the single unslugged file. There is
+> no fallback from the first mode to the second.
+
+The **destination** unit name is unchanged — only the source filename inside
+the scaffold tree carries the host. No unit rename, no `systemctl
+disable`/`enable` dance, no `[Install]` change. `install.sh` and the units
+ship from the same render by the same version, so there is no version skew.
+
+### Fixed
+
+- **The webhook unit is addressed by host and selected at install time**
+  (`scaffold/renderer.py`, `templates/core/install.sh.j2`, #325). `install.sh`
+  bakes `_FRAISIER_MACHINE_WEBHOOK` alongside the `machine_env_map` it already
+  had, and copies the unit matching `hostname -s`. The `if [ -f ]` guard is
+  gone along with the comment asserting that "the bootstrap renderer is always
+  called with `--server`" — the false premise the whole bug rested on.
+- **One resolver for "which environments are local"** (`config/loader.py`).
+  `FraisierConfig.iter_environment_servers()` is the single walk over both
+  declaration sites; `declared_servers()`, `get_environments_for_server()` and
+  therefore `get_machine_environment_map()` all derive from it.
+- **`ServerSetup` no longer drops its server** (`setup.py`). It built
+  `ScaffoldRenderer(config)` with no filter while `_resolve_allowed_environments`
+  auto-detected the host for the plan, so the plan and the tree could disagree.
+- **`get_install_mapping` and `_plan_webhook_service` resolve the same source
+  as `install.sh`** via one shared `local_webhook_source`, so `scaffold-diff`
+  stops reporting a phantom missing file.
+- **Stale webhook units are swept from the tree** on an unfiltered render —
+  both a slugged unit for a server dropped from the config and the legacy
+  unslugged file. A `--server` render deliberately sweeps nothing: it holds
+  one host's share of the truth.
+- **A failed regeneration reports stderr** (`deployers/base.py`). It reported
+  stdout only, which after this change would show the operator the successful
+  part of a refused render and no reason.
+
+### A render now refuses rather than narrowing
+
+Three conditions abort the render instead of emitting a smaller unit. A
+non-zero scaffold exit already becomes a `DeploymentError`, so a deploy that
+cannot render a correct unit stops *before* the install step.
+
+- `--server` naming a server no environment declares. This previously rendered
+  a unit with the fraisier state directories and no application paths —
+  installable, and then broken on every deploy.
+- An environment that declares no `server:` while others do. Rejected rather
+  than treated as hosted everywhere: "everywhere" re-creates the #62 leak by
+  default and makes the permissive reading of a half-migrated config the
+  safe-looking one. The error names the environment and the servers available.
+- A rendered `ProtectSystem=strict` unit missing a `git_repo`/`app_path` of an
+  environment its host runs. Checked against the rendered text, so it holds
+  however the filtering was reached.
+
+### Added
+
+- **Deploy-start sandbox probe** (`deployers/api.py`). The deploy already runs
+  inside the sandbox, so it creates and unlinks a file in each of this
+  environment's `git_repo` and `app_path` before the first git operation — a
+  real write, not `os.access`, which answers a different question. The
+  reported failure surfaced as `git fetch` exit 255; it now surfaces as a
+  diagnosis naming the path, the unit and the remedy.
+- **`doctor` check `webhook_hosted_trees_writable`** — the #317 check's shape
+  widened from dump directories to every hosted environment's trees. Reads the
+  **installed** unit, so it catches the upgrade-without-re-scaffold case and
+  hand-written units. A `warn`, matching #317: a hard failure would break hosts
+  limping along on a hand-edited unit that works.
+- **`fraisier doctor --probe-sandbox`** — opt-in active probe that spawns a
+  transient `ProtectSystem=strict` unit over the *rendered* `ReadWritePaths=`
+  and writes into each path, for checking a host before installing. Needs
+  root; skipped cleanly without it.
+
+### Conditional design decision
+
+`_regenerate_scaffold` still renders **unfiltered**, deliberately: the tree is
+host-independent and selection happens at install, so one tree stays valid for
+every machine, which is what the state dir is for.
+
+That is safe **only** under two invariants, and not otherwise. **(M)** mode is
+a function of the config alone — `--server` narrows which slugs a render
+emits, never the mode — so an unfiltered regen of a multi-server config emits
+every slug and no host-agnostic unit. **(N)** the installer never falls back
+to an unslugged leftover. Together, the all-paths unit that would re-create
+the #62 leak is never written *and* never installed. **If (M) or (N) is ever
+relaxed, `_regenerate_scaffold` must start passing `--server` in the same
+commit.** `TestModeIsAFunctionOfTheConfigAlone` is the tripwire.
+
+### Two deliberate test-contract changes
+
+Both in `TestWebhookServerFiltering`, both carrying the rationale in their
+docstrings so a later reader does not take the diff for a regression:
+
+- `test_webhook_includes_only_local_server_paths` now reads the **slugged**
+  file. It used to assert that a `--server` render writes the host-agnostic
+  name with host-filtered content — that pairing is the bug. The filter it
+  pins is unchanged and still correct; only the filename moved.
+- `test_webhook_server_with_no_matching_environments` is replaced by
+  `..._is_an_error`. The old assertion — that an unknown `--server` renders a
+  pathless unit silently, with exit 0 — *was* the behaviour it pinned.
+
+### Notes for operators
+
+- **Re-scaffold and re-install on every machine**: `fraisier scaffold && sudo
+  fraisier scaffold-install --yes`. Until you do, the installed unit is
+  whatever is there now.
+- **Add `server:` to every environment** if any environment has one. A render
+  refuses otherwise, naming what to add.
+- **A `prod-paths.conf` drop-in added as a workaround can be removed** after
+  upgrading and re-scaffolding. Leaving it is harmless — a drop-in's
+  `ReadWritePaths=` adds to the unit's list rather than replacing it.
+- **`fraisier setup` on a machine registered under no logical server** skips
+  the webhook install with a warning instead of copying a file that no render
+  wrote. Pass `--server` there.
+- Nothing changes for a genuinely single-server config: the tree still holds
+  one unslugged unit.
+
 ## [0.55.0] - 2026-08-01
 
 Closes #321. **Automatic rollback has never run in fraisier's own deployment

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -709,24 +709,85 @@ environments:
     server: prod.myserver.com
 ```
 
-Then on each server, run scaffold and setup filtered to that server:
+Then on each server, run scaffold and setup:
 
 ```bash
 # On staging.myserver.com
-fraisier scaffold --server staging.myserver.com
+fraisier scaffold
 sudo fraisier scaffold-install --yes
-sudo fraisier setup --server staging.myserver.com
+sudo fraisier setup
 
 # On prod.myserver.com
-fraisier scaffold --server prod.myserver.com
+fraisier scaffold
 sudo fraisier scaffold-install --yes
-sudo fraisier setup --server prod.myserver.com
+sudo fraisier setup
 ```
 
-The `--server` filter ensures that:
+`--server` is optional and narrows the render to one logical server. It is
+not needed for correctness: the generated tree is valid for every machine,
+because the webhook unit is addressed by host in its filename and the
+installer picks this machine's.
+
+Naming an unknown server is an error, not a narrower render. A typo'd
+`--server` used to produce a unit with the fraisier state directories and no
+application paths — installable, and then broken on every deploy.
+
+### How the webhook unit reaches the right host
+
+The webhook service runs `ProtectSystem=strict`: the entire filesystem is
+read-only inside its sandbox except the paths listed in `ReadWritePaths=`.
+Every bare repo and application directory a host deploys must appear there,
+or `git fetch` fails with `Read-only file system` (exit 255) even though the
+same path is writable from a login shell.
+
+The rule, in one line:
+
+> When any environment declares a `server:`, the scaffold tree contains
+> **only** `fraisier-{project}-webhook-{slug}.service` files — one per logical
+> server — and `install.sh` copies the one matching `hostname -s` to
+> `/etc/systemd/system/fraisier-{project}-webhook.service`. When no
+> environment declares a `server:`, the tree contains the single unslugged
+> file.
+
+Consequences worth knowing:
+
+- **The installed unit's name never changes.** Only the source filename in
+  the scaffold tree carries the host. Nothing is renamed, enabled or disabled
+  on the machine.
+- **There is no fallback.** A leftover `fraisier-{project}-webhook.service`
+  in a multi-server tree is never installed, and a machine whose slugged unit
+  is missing is a hard error rather than a skipped step.
+- **Every environment must declare a `server:`** once any of them does. An
+  environment with no server belongs to no machine, so its trees reach no
+  unit's allowlist; the render refuses rather than dropping it silently.
+
+To check a host before installing:
+
+```bash
+fraisier doctor --check webhook_hosted_trees_writable   # reads the installed unit
+sudo fraisier doctor --probe-sandbox                    # actually writes, under strict
+```
+
+The `--server` filter (when you do use it) ensures that:
 - Systemd units are only generated for environments assigned to that server
-- The webhook service's `ReadWritePaths` only includes paths that exist locally
+- The webhook service's `ReadWritePaths` only includes that server's paths
 - Sudoers entries only reference local service names
+
+### Carrying a custom webhook unit
+
+If you maintain your own `fraisier-{project}-webhook.service` — a drop-in
+under `/etc/systemd/system/fraisier-{project}-webhook.service.d/`, or a
+hand-edited unit — you own the `ReadWritePaths=` list, and no template fix
+reaches it. Keep every `git_repo` and `app_path` of every environment that
+host deploys in the list, plus any `database.pre_migrate_dump.output_dir`.
+`fraisier doctor` reads the *installed* unit precisely so it can still tell
+you when one is missing.
+
+Operators who added a `prod-paths.conf` drop-in as a workaround for a webhook
+unit carrying the wrong host's paths can remove it after upgrading and
+re-running `fraisier scaffold && sudo fraisier scaffold-install --yes`.
+Leaving it in place is harmless — a drop-in's `ReadWritePaths=` adds to the
+unit's list rather than replacing it.
 
 ### Branch mapping for multiple environments
 

--- a/fraisier/cli/doctor.py
+++ b/fraisier/cli/doctor.py
@@ -89,9 +89,22 @@ def render_json(results: list[CheckResult]) -> dict[str, Any]:
     is_flag=True,
     help="Skip checks that hit the network or external binaries",
 )
+@click.option(
+    "--probe-sandbox",
+    is_flag=True,
+    help=(
+        "Also run the active sandbox write probe: spawns a transient "
+        "ProtectSystem=strict unit over the rendered ReadWritePaths= and "
+        "writes into each one. Needs root; skipped cleanly without it."
+    ),
+)
 @click.pass_context
 def doctor_cmd(
-    ctx: click.Context, fmt: str, only: tuple[str, ...], skip_network: bool
+    ctx: click.Context,
+    fmt: str,
+    only: tuple[str, ...],
+    skip_network: bool,
+    probe_sandbox: bool,
 ) -> None:
     """Run host-wide health checks and report fraisier install state.
 
@@ -101,6 +114,7 @@ def doctor_cmd(
         fraisier doctor --format json | jq '.summary'
         fraisier doctor --check python_version --check fraisier_version
         fraisier doctor --skip-network --format json
+        sudo fraisier doctor --probe-sandbox   # before scaffold-install
     """
     config = ctx.obj.get("config") if ctx.obj else None
 
@@ -108,6 +122,7 @@ def doctor_cmd(
         config,
         only=list(only) if only else None,
         skip_network=skip_network,
+        probe_sandbox=probe_sandbox,
     )
 
     if fmt == "json":

--- a/fraisier/config/loader.py
+++ b/fraisier/config/loader.py
@@ -28,7 +28,7 @@ import os
 import re
 import subprocess
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -651,6 +651,69 @@ class FraisierConfig:
             return []
         return list(fraise.get("environments", {}).keys())
 
+    def iter_environment_servers(self) -> Iterator[tuple[str, str | None]]:
+        """Yield ``(env_name, declared_server)`` over every declaration site.
+
+        ``server:`` may be written in the global ``environments:`` section or
+        under ``fraises.<name>.environments.<env>``, and a config may use
+        either or both. This is the single walk over both sites; every
+        consumer that needs to know where an environment lives — the
+        renderer's server set, :meth:`get_environments_for_server`, and
+        through it :meth:`get_machine_environment_map`, which bakes
+        install.sh's host gating — derives from it.
+
+        Keeping them on one walk is the point: while the renderer read only
+        the global section and the installer read both, a config declaring
+        ``server:`` only per-fraise looked server-less to the renderer (one
+        webhook unit carrying every host's trees) and correctly filtered to
+        the installer — the #62 least-privilege leak reached by a second
+        route, and one of the three routes into #325.
+
+        The same environment name may be yielded more than once, with a
+        different (or absent) server each time; callers decide how to fold.
+        """
+        for env_name, env_config in self.environments.items():
+            if isinstance(env_config, dict):
+                yield env_name, env_config.get("server")
+
+        for fraise in self.fraises.values():
+            for env_name, env_config in (fraise.get("environments") or {}).items():
+                if isinstance(env_config, dict):
+                    yield env_name, env_config.get("server")
+
+    def declared_servers(self) -> list[str]:
+        """Unique logical servers named by any environment, in declaration order.
+
+        Empty when no environment declares a ``server:`` — which is exactly
+        the condition for single-host mode in the scaffold renderer. Note this
+        is a property of the *config*, never of a ``--server`` filter.
+        """
+        seen: dict[str, None] = {}
+        for _, server in self.iter_environment_servers():
+            if server:
+                seen[str(server)] = None
+        return list(seen)
+
+    def environments_without_a_server(self) -> list[str]:
+        """Environment names used by a fraise that name no logical server.
+
+        Only meaningful alongside :meth:`declared_servers`: in a multi-host
+        config such an environment resolves to *no* host, so its ``git_repo``
+        and ``app_path`` reach no webhook unit's ``ReadWritePaths=`` and every
+        deploy of it fails on a read-only filesystem. Ordered by first
+        appearance so the resulting diagnostic is stable.
+        """
+        hosted: set[str] = set()
+        candidates: dict[str, None] = {}
+        for env_name, server in self.iter_environment_servers():
+            if server:
+                hosted.add(env_name)
+        for fraise in self.fraises.values():
+            for env_name in fraise.get("environments") or {}:
+                if env_name not in hosted:
+                    candidates[env_name] = None
+        return list(candidates)
+
     def get_environments_for_server(self, server: str) -> list[str]:
         """Return environment names whose ``server`` field matches *server*.
 
@@ -659,18 +722,9 @@ class FraisierConfig:
         Returns an empty list when no environment declares that server.
         """
         matched: dict[str, None] = {}
-
-        # Check global environments section
-        for env_name, env_config in self.environments.items():
-            if env_config.get("server") == server:
+        for env_name, declared in self.iter_environment_servers():
+            if declared == server:
                 matched[env_name] = None
-
-        # Check per-fraise environment configs
-        for fraise in self.fraises.values():
-            for env_name, env_config in fraise.get("environments", {}).items():
-                if env_config.get("server") == server:
-                    matched[env_name] = None
-
         return list(matched)
 
     def get_machine_environment_map(self) -> dict[str, list[str]]:

--- a/fraisier/deployers/api.py
+++ b/fraisier/deployers/api.py
@@ -81,6 +81,75 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
         self._version_json_existed = False
         self._version_json_snapshot: bytes | None = None
 
+    def _validate_sandbox_writes(self) -> None:
+        """Prove this deploy can write to the trees it is about to change (#325).
+
+        The deploy already runs *inside* the systemd sandbox, so this needs no
+        ``systemd-run``: creating and unlinking one file in each of this
+        environment's ``git_repo`` and ``app_path`` answers exactly the
+        question ``ProtectSystem=strict`` decides.
+
+        A real write, deliberately, not ``os.access``. ``access(2)`` consults
+        the file mode and the caller's ids; whether the mount namespace this
+        process is in made the path read-only is a different question, and
+        ``access`` answers the wrong one confidently.
+
+        This is the only check that catches the class generically. The webhook
+        unit installed on a host used to be one rendered for a *different*
+        host, so ``ReadWritePaths=`` listed the other machine's trees and
+        ``git fetch`` failed with exit 255 several steps later, with nothing
+        to connect the exit code to the sandbox. It also covers what no
+        template fix can reach: a hand-written or hand-edited unit.
+
+        Paths that do not exist are skipped — a missing tree is a different
+        diagnosis, made by the checks that own it.
+
+        Raises:
+            DeploymentError: naming the path, the unit and the remedy.
+        """
+        candidates = [
+            (label, value)
+            for label, value in (
+                ("git_repo", self.git_repo),
+                ("app_path", self.app_path),
+            )
+            if value
+        ]
+
+        blocked: list[str] = []
+        for label, value in candidates:
+            path = Path(value)
+            if not path.is_dir():
+                continue
+            probe = path / f".fraisier-write-probe-{os.getpid()}"
+            try:
+                probe.touch()
+            except OSError as exc:
+                blocked.append(f"{label}={path} ({exc.strerror or exc})")
+            else:
+                probe.unlink(missing_ok=True)
+
+        if not blocked:
+            return
+
+        project = getattr(self.config_object, "project_name", None)
+        unit = f"fraisier-{project}-webhook.service" if project else "the webhook unit"
+        raise DeploymentError(
+            f"Cannot write to {', '.join(blocked)} from inside this deploy's "
+            f"systemd sandbox. The unit running this deploy ({unit}, or the "
+            f"deploy socket's unit) is ProtectSystem=strict and does not list "
+            f"these paths in ReadWritePaths=, so every write below them fails "
+            f"read-only — git fetch would abort with exit 255 a few steps from "
+            f"here. Re-run `fraisier scaffold` and "
+            f"`sudo fraisier scaffold-install --yes` on this machine to install "
+            f"the unit rendered for it.",
+            context={
+                "fraise": self.fraise_name,
+                "environment": self.environment,
+                "paths": [p for _, p in candidates],
+            },
+        )
+
     def _validate_wrapper_scripts(self) -> None:
         """Validate that required wrapper scripts exist and are executable.
 
@@ -438,6 +507,10 @@ class APIDeployer(GitDeployMixin, BaseDeployer):
 
         # Validate wrapper scripts before deployment starts
         self._validate_wrapper_scripts()
+
+        # Prove the sandbox can write where this deploy is about to (#325),
+        # before the first step that would fail on it with a bare exit code.
+        self._validate_sandbox_writes()
 
         try:
             with deployment_timeout(timeout):

--- a/fraisier/deployers/base.py
+++ b/fraisier/deployers/base.py
@@ -498,6 +498,26 @@ class BaseDeployer(ABC):
         Runs 'fraisier scaffold' on the server to generate updated
         systemd units, nginx configs, sudoers rules, etc.
 
+        Deliberately **unfiltered** — no ``--server``. The webhook unit is
+        addressed by host in its filename and selected at install time
+        (#325), so one tree is valid for every machine, which is what the
+        state dir is for.
+
+        That is safe only under two invariants, and not otherwise:
+
+        * **(M)** mode is a function of the config alone, so an unfiltered
+          regen of a multi-host config emits every slug and no host-agnostic
+          unit — the all-paths file that would re-create the #62
+          least-privilege leak is never written;
+        * **(N)** the installer never falls back to an unslugged leftover, so
+          such a file is never installed either.
+
+        In the genuine single-host case an unfiltered render's "every
+        environment" *is* that host's environments, so there is nothing to
+        leak. **If (M) or (N) is ever relaxed, this call must start passing
+        ``--server`` in the same commit.**
+        ``TestModeIsAFunctionOfTheConfigAlone`` is the tripwire.
+
         Args:
             config_path: Path to fraises.yaml to use for generation
 
@@ -529,8 +549,19 @@ class BaseDeployer(ABC):
         )
 
         if result.returncode != 0:
+            # stderr carries the reason. A render now refuses rather than
+            # silently narrowing (#325) — unknown --server, an environment
+            # that resolves to no host, a unit missing a hosted environment's
+            # trees — and those diagnostics go to stderr while stdout holds
+            # only the part of the render that succeeded. Reporting stdout
+            # alone left the operator with the good news and no cause.
+            detail = "\n".join(
+                part.strip()
+                for part in (getattr(result, "stderr", "") or "", result.stdout or "")
+                if part and part.strip()
+            )
             raise DeploymentError(
-                f"Failed to regenerate scaffold files: {result.stdout}"
+                f"Failed to regenerate scaffold files: {detail or '(no output)'}"
             )
 
         logger.info("✓ Scaffold files regenerated")

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -21,6 +21,7 @@ Security
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -53,16 +54,24 @@ CheckFn = Callable[["FraisierConfig | None"], CheckResult]
 class _CheckEntry:
     fn: CheckFn
     network: bool
+    privileged: bool = False
 
 
 DOCTOR_CHECKS: dict[str, _CheckEntry] = {}
 
 
-def register_check(name: str, *, network: bool = False) -> Callable[[CheckFn], CheckFn]:
-    """Decorator: register a doctor check by name."""
+def register_check(
+    name: str, *, network: bool = False, privileged: bool = False
+) -> Callable[[CheckFn], CheckFn]:
+    """Decorator: register a doctor check by name.
+
+    ``privileged`` marks a check that needs root and mutates nothing but
+    still costs real work (spawning a transient systemd unit). Those are
+    opt-in: a default ``fraisier doctor`` reports them as ``skip``.
+    """
 
     def deco(fn: CheckFn) -> CheckFn:
-        DOCTOR_CHECKS[name] = _CheckEntry(fn=fn, network=network)
+        DOCTOR_CHECKS[name] = _CheckEntry(fn=fn, network=network, privileged=privileged)
         return fn
 
     return deco
@@ -339,6 +348,230 @@ def _enabled_dump_dirs(config: FraisierConfig | None) -> list[str]:
     return dirs
 
 
+def _resolve_local_server(config: FraisierConfig) -> str | None:
+    """Which logical server this machine is. Seam for tests."""
+    from fraisier.scaffold.renderer import resolve_local_server
+
+    return resolve_local_server(config)
+
+
+def _strict_readwritepaths(unit_path: Path) -> list[str] | None:
+    """``ReadWritePaths=`` of an installed ``ProtectSystem=strict`` unit.
+
+    Returns None when the unit is not installed (a dev machine has none, and
+    that is not a finding) and an empty list when it is installed but not
+    strict — in which case the allowlist does not gate writes at all.
+    """
+    try:
+        unit = unit_path.read_text()
+    except OSError:
+        return None
+    if "ProtectSystem=strict" not in unit:
+        return []
+    return [
+        ln.split("=", 1)[1].strip()
+        for ln in unit.splitlines()
+        if ln.startswith("ReadWritePaths=")
+    ]
+
+
+def _not_covered(paths: list[str], allowed: list[str]) -> list[str]:
+    """Those of *paths* that no entry in *allowed* contains.
+
+    Prefix containment on whole components: ``ReadWritePaths=/var/www`` does
+    grant ``/var/www/api``, and ``/var/wwwroot`` is not a match for
+    ``/var/www``.
+    """
+    return [
+        p
+        for p in paths
+        if not any(p == a or p.startswith(a.rstrip("/") + "/") for a in allowed)
+    ]
+
+
+def _hosted_trees(config: FraisierConfig, server: str) -> list[str]:
+    """Every ``git_repo``/``app_path`` of an environment *server* hosts."""
+    hosted = set(config.get_environments_for_server(server))
+    trees: list[str] = []
+    for fraise in (getattr(config, "fraises", None) or {}).values():
+        if not isinstance(fraise, dict):
+            continue
+        for env_name, env_config in (fraise.get("environments") or {}).items():
+            if env_name not in hosted or not isinstance(env_config, dict):
+                continue
+            for key in ("git_repo", "app_path"):
+                value = env_config.get(key)
+                if value and str(value) not in trees:
+                    trees.append(str(value))
+    return trees
+
+
+@register_check("webhook_hosted_trees_writable")
+def _check_webhook_hosted_trees_writable(config: FraisierConfig | None) -> CheckResult:
+    """This host's webhook unit must allow writes to the trees it hosts (#325).
+
+    Same shape and same reasoning as the #317 dump-dir check, widened from
+    dump directories to the ``git_repo``/``app_path`` of every environment
+    this machine hosts. Reads the **installed** unit rather than the rendered
+    one, so it also catches the upgrade-without-re-scaffold case — the
+    likeliest way to still be broken after the template fix — and a
+    hand-written unit no template fix can reach.
+
+    Only the *missing* direction is a finding here. An extra path is the #62
+    least-privilege leak, which the render-time invariant owns; flagging it
+    here would report every host that legitimately shares a tree.
+
+    Warn rather than fail, matching #317: a hard failure would break hosts
+    limping along on a hand-edited unit that works.
+    """
+    name = "webhook_hosted_trees_writable"
+    project = getattr(config, "project_name", None) if config is not None else None
+    if config is None or not project:
+        return CheckResult(name, "skip", "no project_name in config")
+
+    server = _resolve_local_server(config)
+    if server is None:
+        return CheckResult(
+            name, "skip", "cannot tell which logical server this machine is"
+        )
+
+    trees = _hosted_trees(config, server)
+    if not trees:
+        return CheckResult(name, "skip", f"no git_repo/app_path hosted on {server}")
+
+    unit_path = _installed_webhook_unit(project)
+    allowed = _strict_readwritepaths(unit_path)
+    if allowed is None:
+        return CheckResult(name, "skip", f"{unit_path} not installed")
+    if not allowed:
+        return CheckResult(name, "pass", "webhook unit is not ProtectSystem=strict")
+
+    missing = _not_covered(trees, allowed)
+    if missing:
+        return CheckResult(
+            name,
+            "warn",
+            f"{unit_path} is ProtectSystem=strict but does not allow writes to "
+            f"{', '.join(missing)} — this machine hosts those environments, so "
+            f"their deploys fail read-only (git fetch exits 255). The installed "
+            f"unit is most likely the one rendered for another host",
+            fix_hint=(
+                "run `fraisier scaffold && sudo fraisier scaffold-install --yes` "
+                "on this machine to install the unit rendered for it"
+            ),
+        )
+    return CheckResult(
+        name, "pass", f"{len(trees)} hosted tree(s) writable from the sandbox"
+    )
+
+
+def _sandbox_probe_command(paths: list[str]) -> list[str]:
+    """Build the transient-unit command that writes into *paths* under strict.
+
+    ``systemd-run`` with the same two directives the webhook unit carries, so
+    the probe fails exactly where a deploy would. Property names are joined to
+    their values (``-pKey=value``) because the shell-less argv form takes one
+    token per property.
+    """
+    script = "; ".join(
+        f'p={path!r}; : > "$p/.fraisier-probe" || {{ echo "$p: not writable" >&2; '
+        f'exit 1; }}; rm -f "$p/.fraisier-probe"'
+        for path in paths
+    )
+    return [
+        "systemd-run",
+        "--pipe",
+        "--wait",
+        "--quiet",
+        "--collect",
+        "-pProtectSystem=strict",
+        f"-pReadWritePaths={' '.join(paths)}",
+        "/bin/sh",
+        "-c",
+        script,
+    ]
+
+
+def _run_sandbox_probe(paths: list[str]) -> tuple[int, str]:
+    """Execute the probe. Seam for tests — the real call needs root + systemd."""
+    result = subprocess.run(
+        _sandbox_probe_command(paths),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    return result.returncode, (result.stderr or result.stdout or "").strip()
+
+
+def _rendered_webhook_readwritepaths(config: FraisierConfig, server: str) -> list[str]:
+    """``ReadWritePaths=`` of the unit *this render* produces for *server*."""
+    import tempfile
+
+    from fraisier.scaffold.renderer import ScaffoldRenderer, webhook_source_for_server
+
+    with tempfile.TemporaryDirectory() as tmp:
+        renderer = ScaffoldRenderer(config, server=server)
+        renderer.output_dir = Path(tmp)
+        renderer.render()
+        unit = Path(tmp) / webhook_source_for_server(config, server)
+        return [
+            ln.split("=", 1)[1].strip()
+            for ln in unit.read_text().splitlines()
+            if ln.startswith("ReadWritePaths=")
+        ]
+
+
+@register_check("sandbox_write_probe", privileged=True)
+def _check_sandbox_write_probe(config: FraisierConfig | None) -> CheckResult:
+    """Actually write into the rendered unit's sandbox (#325), opt-in.
+
+    Every other check reads a path list and reasons about it. This one runs a
+    real write under a real ``ProtectSystem=strict`` transient unit built from
+    the **rendered** allowlist, so an operator can find the gap before
+    ``scaffold-install`` rather than on the next deploy.
+
+    Opt-in via ``fraisier doctor --probe-sandbox`` and skipped without root:
+    ``systemd-run`` needs privileges, and a check that fails for lack of them
+    is noise rather than signal.
+    """
+    name = "sandbox_write_probe"
+    if config is None:
+        return CheckResult(name, "skip", "no fraises.yaml")
+    if os.geteuid() != 0:
+        return CheckResult(name, "skip", "needs root to spawn a transient unit")
+
+    server = _resolve_local_server(config)
+    if server is None:
+        return CheckResult(
+            name, "skip", "cannot tell which logical server this machine is"
+        )
+
+    try:
+        paths = _rendered_webhook_readwritepaths(config, server)
+    except Exception as exc:
+        return CheckResult(name, "fail", f"could not render the unit: {exc}")
+    if not paths:
+        return CheckResult(name, "skip", "rendered unit lists no ReadWritePaths")
+
+    if shutil.which("systemd-run") is None:
+        return CheckResult(name, "skip", "systemd-run not available")
+
+    code, output = _run_sandbox_probe(paths)
+    if code != 0:
+        return CheckResult(
+            name,
+            "fail",
+            f"a write inside the rendered sandbox failed: {output or f'exit {code}'}",
+            fix_hint=(
+                "the path exists and is writable from a login shell but not from "
+                "inside ProtectSystem=strict — check the ReadWritePaths= list and "
+                "the mount it sits on"
+            ),
+        )
+    return CheckResult(name, "pass", f"wrote into {len(paths)} sandboxed path(s)")
+
+
 @register_check("pre_migrate_dump_writable")
 def _check_pre_migrate_dump_writable(config: FraisierConfig | None) -> CheckResult:
     """The dump gate must be able to write from inside the unit's sandbox (#317).
@@ -367,24 +600,13 @@ def _check_pre_migrate_dump_writable(config: FraisierConfig | None) -> CheckResu
         return CheckResult(name, "skip", "no project_name in config")
 
     unit_path = _installed_webhook_unit(project)
-    try:
-        unit = unit_path.read_text()
-    except OSError:
+    allowed = _strict_readwritepaths(unit_path)
+    if allowed is None:
         return CheckResult(name, "skip", f"{unit_path} not installed")
-
-    if "ProtectSystem=strict" not in unit:
+    if not allowed:
         return CheckResult(name, "pass", "webhook unit is not ProtectSystem=strict")
 
-    allowed = {
-        ln.split("=", 1)[1].strip()
-        for ln in unit.splitlines()
-        if ln.startswith("ReadWritePaths=")
-    }
-    missing = [
-        d
-        for d in dump_dirs
-        if not any(d == a or d.startswith(a.rstrip("/") + "/") for a in allowed)
-    ]
+    missing = _not_covered(dump_dirs, allowed)
     if missing:
         return CheckResult(
             name,
@@ -412,6 +634,7 @@ def run_all(
     *,
     only: list[str] | None = None,
     skip_network: bool = False,
+    probe_sandbox: bool = False,
 ) -> list[CheckResult]:
     """Execute every registered check (or a filtered subset) and return results.
 
@@ -420,6 +643,9 @@ def run_all(
         only: When non-empty, run only these check names.
         skip_network: When True, mark network-flagged checks as ``skip``
             instead of running them.
+        probe_sandbox: When True, also run privileged checks — today the
+            active sandbox write probe, which spawns a transient systemd unit
+            and therefore stays out of a default pass.
 
     Returns:
         Results in registration order. Each check is independent — one
@@ -431,6 +657,9 @@ def run_all(
             continue
         if skip_network and entry.network:
             results.append(CheckResult(name, "skip", "skipped (--skip-network)"))
+            continue
+        if entry.privileged and not probe_sandbox:
+            results.append(CheckResult(name, "skip", "skipped (needs --probe-sandbox)"))
             continue
         try:
             results.append(entry.fn(config))

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -10,6 +10,7 @@ to the configured output_dir.
 import logging
 import re
 import shutil
+import socket
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -474,6 +475,7 @@ def _build_context(config: FraisierConfig, server: str | None = None) -> dict[st
 
     # Build machine_env_map: filter to only that server's machines when --server given
     full_machine_env_map = config.get_machine_environment_map()
+    full_machine_webhook_map = webhook_machine_map(config)
     if server is not None:
         # Get machines for the specified server
         machines_for_server = config.servers.get(server, [])
@@ -482,8 +484,14 @@ def _build_context(config: FraisierConfig, server: str | None = None) -> dict[st
             for m in machines_for_server
             if m in full_machine_env_map
         }
+        machine_webhook_map = {
+            m: full_machine_webhook_map[m]
+            for m in machines_for_server
+            if m in full_machine_webhook_map
+        }
     else:
         machine_env_map = full_machine_env_map
+        machine_webhook_map = full_machine_webhook_map
 
     deploy_user = config.scaffold.deploy_user
     install_helper_sockets = _collect_install_helper_sockets(
@@ -522,6 +530,7 @@ def _build_context(config: FraisierConfig, server: str | None = None) -> dict[st
         "deploy_users": _collect_deploy_users(config, fraises_list),
         "sudoers_rules": _collect_deduplicated_sudoers_rules(config, fraises_list),
         "machine_env_map": machine_env_map,
+        "machine_webhook_map": machine_webhook_map,
         "install_helper_sockets": install_helper_sockets,
         "gateway_fraise": gateway_fraise,
         "has_per_env_nginx": has_per_env_nginx,
@@ -559,14 +568,15 @@ def _infer_project_name(config: FraisierConfig) -> str:
 
 
 def _collect_unique_servers(config: FraisierConfig) -> list[str]:
-    """Return unique server values from environments config, preserving order."""
-    seen: dict[str, None] = {}
-    for env_config in config.environments.values():
-        if isinstance(env_config, dict):
-            server = env_config.get("server")
-            if server:
-                seen[server] = None
-    return list(seen)
+    """Return the logical servers any environment declares, in declaration order.
+
+    Delegates to :meth:`FraisierConfig.declared_servers` rather than walking
+    the config itself: this function used to read only the global
+    ``environments:`` section while the installer's host gating read the
+    per-fraise configs too, so the two disagreed for any config that declared
+    ``server:`` only under ``fraises.*`` (#325, claim 4).
+    """
+    return config.declared_servers()
 
 
 def _server_slug(server: str) -> str:
@@ -576,6 +586,147 @@ def _server_slug(server: str) -> str:
     """
     slug = re.sub(r"[^a-zA-Z0-9]+", "-", server).lower().strip("-")
     return slug
+
+
+def webhook_unit_name(project_name: str, server_slug: str | None = None) -> str:
+    """The one place a webhook unit filename is built.
+
+    With a slug this is a *source* filename inside the scaffold tree, one per
+    logical server. Without one it is either the single-host source or — on
+    every host, in every mode — the **destination** under
+    ``/etc/systemd/system/``. The destination name never carries the host:
+    only the source does, so the fix needs no unit rename, no
+    ``systemctl disable``/``enable`` dance and no ``[Install]`` change.
+
+    Nothing else may build this string. Three call sites each built their own
+    copy of the unslugged name and all three asked for a file the deploy-path
+    render never wrote (#325).
+    """
+    if server_slug:
+        return f"fraisier-{project_name}-webhook-{server_slug}.service"
+    return f"fraisier-{project_name}-webhook.service"
+
+
+def _unknown_server_message(server: str, known: list[str]) -> str:
+    """Diagnostic for a ``--server`` value no environment declares."""
+    if known:
+        return (
+            f"No environment declares server {server!r}. Known servers: "
+            f"{', '.join(known)}. Rendering it anyway would emit a webhook "
+            f"unit with no application paths, which installs cleanly and then "
+            f"fails every deploy on a read-only filesystem."
+        )
+    return (
+        f"--server {server!r} was given but no environment declares a "
+        f"'server:' field, so there is nothing to filter by. Remove --server, "
+        f"or add 'server: {server}' to the environments hosted there."
+    )
+
+
+def webhook_machine_map(config: FraisierConfig) -> dict[str, str]:
+    """Map each machine hostname to the webhook unit filename it installs.
+
+    The inversion of ``servers:``. Empty in single-host mode — no environment
+    declares a ``server:``, so no slugged unit exists and there is nothing to
+    select between.
+
+    ``validate_servers`` already rejects a machine listed under two logical
+    servers, so the inversion is unambiguous; this does not re-validate it.
+    """
+    if not config.declared_servers():
+        return {}
+    project = config.project_name
+    return {
+        machine: webhook_unit_name(project, _server_slug(logical))
+        for logical, machines in config.servers.items()
+        for machine in machines
+    }
+
+
+def webhook_source_for_server(config: FraisierConfig, server: str) -> str:
+    """Return the webhook unit filename rendered for logical *server*."""
+    known = config.declared_servers()
+    if server not in known:
+        raise ValidationError(_unknown_server_message(server, known))
+    return webhook_unit_name(config.project_name, _server_slug(server))
+
+
+def _is_under_any(path: str, allowed: list[str]) -> bool:
+    """Return True when *path* is one of *allowed* or nested inside one.
+
+    Prefix containment on path components, matching the comparison the #317
+    doctor check uses — ``ReadWritePaths=/var/www`` does grant
+    ``/var/www/api``, and ``/var/wwwroot`` is not a match for ``/var/www``.
+    """
+    return any(path == a or path.startswith(a.rstrip("/") + "/") for a in allowed)
+
+
+def _local_hostnames() -> list[str]:
+    """Candidate names for this machine, longest-lived first, deduplicated."""
+    names = [socket.gethostname(), socket.getfqdn()]
+    names += [n.split(".", 1)[0] for n in names if n]
+    return list(dict.fromkeys(n for n in names if n))
+
+
+def resolve_local_server(config: FraisierConfig) -> str | None:
+    """Return the logical server this machine belongs to, or None.
+
+    Resolution order mirrors the generated ``install.sh``: the machine
+    hostname is looked up in the inversion of ``servers:`` first, then — for
+    configs that name their logical servers after the machines they run on and
+    carry no ``servers:`` section — against the declared server names
+    directly, the way ``ServerSetup`` has always read them.
+
+    None means "cannot tell", never "everywhere": callers decide whether that
+    is fatal (installing) or merely unfiltered (rendering).
+    """
+    known = config.declared_servers()
+    if not known:
+        return None
+
+    machine_to_server = {
+        machine: logical
+        for logical, machines in config.servers.items()
+        for machine in machines
+    }
+    hostnames = _local_hostnames()
+    for candidate in hostnames:
+        if candidate in machine_to_server:
+            return machine_to_server[candidate]
+    for candidate in hostnames:
+        if candidate in known:
+            return candidate
+    return None
+
+
+def local_webhook_source(config: FraisierConfig, server: str | None = None) -> str:
+    """Return the webhook unit filename *this machine* must install.
+
+    One resolver for every installer. The generated ``install.sh`` selects
+    from the same map keyed on ``hostname -s``; ``get_install_mapping`` and
+    ``ServerSetup._plan_webhook_service`` call this. They therefore cannot
+    pick different files for the same box, which is what let ``scaffold-diff``
+    report a phantom missing unit while the shell installer silently skipped
+    the copy (#325).
+
+    Raises rather than guessing. In multi-host mode there is no safe default:
+    installing another host's unit is precisely the failure being closed, and
+    reaching for the unslugged name is invariant (N)'s forbidden fallback.
+    """
+    if not config.declared_servers():
+        return webhook_unit_name(config.project_name)
+
+    resolved = server if server is not None else resolve_local_server(config)
+    if resolved is None:
+        raise ValidationError(
+            f"Cannot tell which webhook unit this machine installs: none of "
+            f"{', '.join(_local_hostnames())} is registered under 'servers:' "
+            f"({', '.join(sorted(webhook_machine_map(config))) or 'no machines listed'}"
+            f") or named as a logical server "
+            f"({', '.join(config.declared_servers())}). Add this machine under "
+            f"'servers:', or pass --server explicitly."
+        )
+    return webhook_source_for_server(config, resolved)
 
 
 class ScaffoldRenderer:
@@ -660,9 +811,15 @@ class ScaffoldRenderer:
                         f"/etc/systemd/system/{svc}.service"
                     )
 
-        # Webhook service unit (installed as generic name regardless of server slug)
-        webhook_svc = f"fraisier-{project_name}-webhook.service"
-        mapping[webhook_svc] = Path(f"/etc/systemd/system/{webhook_svc}")
+        # Webhook service unit: the source carries the host, the destination
+        # never does. Resolved through the same helper install.sh selects with,
+        # so scaffold-diff compares the file this box actually installs instead
+        # of reporting a phantom missing one (#325).
+        webhook_src = self._local_webhook_source()
+        if webhook_src is not None:
+            mapping[webhook_src] = Path(
+                f"/etc/systemd/system/{webhook_unit_name(project_name)}"
+            )
 
         # Systemctl helper service + socket
         if self.context["allowed_services"]:
@@ -704,6 +861,20 @@ class ScaffoldRenderer:
         mapping["sudoers"] = Path(f"/etc/sudoers.d/{project_name}")
 
         return mapping
+
+    def _local_webhook_source(self) -> str | None:
+        """The webhook unit this box installs, or None when it cannot be told.
+
+        ``scaffold-diff`` is a diagnostic that also runs off-server, where no
+        local hostname matches any machine in ``servers:``. Omitting the entry
+        there is deliberate: a diff cannot say whether the installed unit is
+        the right one, and naming an arbitrary host's unit would answer a
+        question nobody asked. Reporting nothing beats reporting a phantom.
+        """
+        try:
+            return local_webhook_source(self.config, self.server)
+        except ValidationError:
+            return None
 
     def _validate_names(self) -> None:
         """Validate fraise and environment names before rendering.
@@ -787,6 +958,7 @@ class ScaffoldRenderer:
         # Remove stale deploy socket/service files left by previous scaffold runs
         if not dry_run:
             self._remove_stale_deploy_units(rendered_files)
+            self._remove_stale_webhook_units(rendered_files)
 
         # Per-fraise service templates (systemd or rc.d based on service_manager)
         service_manager = self.config._config.get("service_manager", "systemd")
@@ -853,17 +1025,6 @@ class ScaffoldRenderer:
                 if db_cfg.get("strategy") == "restore_migrate":
                     return True
         return False
-
-    def _webhook_service_name(self, server_slug: str | None = None) -> str:
-        """Return the output filename for a webhook service unit.
-
-        With no slug: ``fraisier-{project}-webhook.service`` (single-server).
-        With a slug: ``fraisier-{project}-webhook-{slug}.service`` (per-server).
-        """
-        project = self.context["project_name"]
-        if server_slug:
-            return f"fraisier-{project}-webhook-{server_slug}.service"
-        return f"fraisier-{project}-webhook.service"
 
     def _render_install_helper_units(self, dry_run: bool) -> list[str]:
         """Render install-helper .socket and .service units for each fraise+env."""
@@ -966,28 +1127,60 @@ class ScaffoldRenderer:
         return [service_out, socket_out]
 
     def _render_webhook_services(self, dry_run: bool) -> list[str]:
-        """Render webhook service unit(s) with project-specific naming.
+        """Render the webhook service unit(s), addressed by host.
 
-        Behaviour:
-        - ``--server`` given → one file, context already filtered by server
-        - No ``--server``, no ``environments.server`` config → one file, all paths
-        - No ``--server``, ``environments.server`` configured → one file per server,
-          each with only that server's paths
+        The rule, stated once:
+
+            When any environment declares a ``server:``, the tree contains
+            **only** slugged ``fraisier-{project}-webhook-{slug}.service``
+            files and the installer resolves the slug from the machine
+            hostname. When no environment declares a ``server:``, the tree
+            contains the single unslugged file. There is no fallback from the
+            first mode to the second.
+
+        Mode is a function of the config alone (invariant **M**). ``--server``
+        narrows *which* slugged units this render emits; it never flips the
+        mode, so a multi-host config can never produce the host-agnostic
+        filename whose content depends on whoever rendered it last — the
+        property that produced #325.
+
+        Raises:
+            ValidationError: ``--server`` names a server no environment
+                declares. Rendering it anyway yields a valid-looking unit with
+                no application paths (the old behaviour), which installs
+                cleanly and then fails every deploy.
+            ValueError: an environment resolves to no host, or a rendered unit
+                omits a tree of an environment its host runs (invariant **C**).
         """
         servers = _collect_unique_servers(self.config)
 
-        if self.server is not None or not servers:
-            # Single file: either explicit server filter or no server config
-            out_name = self._webhook_service_name()
+        if not servers:
+            if self.server is not None:
+                raise ValidationError(_unknown_server_message(self.server, servers))
+            # Single-host mode: "every environment" and "this host's
+            # environments" are the same set, so there is nothing to leak.
+            out_name = webhook_unit_name(self.context["project_name"])
             if not dry_run:
                 self._render_template("core/fraisier-webhook.service.j2", out_name)
+                self._assert_hosted_trees_are_writable(
+                    None, (self.output_dir / out_name).read_text()
+                )
             return [out_name]
 
-        # Auto per-server: one file per unique server
+        self._assert_every_environment_has_a_host(servers)
+
+        if self.server is not None:
+            if self.server not in servers:
+                raise ValidationError(_unknown_server_message(self.server, servers))
+            targets = [self.server]
+        else:
+            targets = servers
+
         rendered: list[str] = []
-        for server in servers:
-            slug = _server_slug(server)
-            out_name = self._webhook_service_name(slug)
+        for server in targets:
+            out_name = webhook_unit_name(
+                self.context["project_name"], _server_slug(server)
+            )
             if not dry_run:
                 server_context = _build_context(self.config, server)
                 try:
@@ -996,8 +1189,79 @@ class ScaffoldRenderer:
                 except jinja2.TemplateNotFound:
                     content = "# Placeholder: fraisier-webhook.service.j2\n"
                 self._write_output(out_name, content)
+                self._assert_hosted_trees_are_writable(server, content)
             rendered.append(out_name)
         return rendered
+
+    def _assert_every_environment_has_a_host(self, servers: list[str]) -> None:
+        """Invariant (C), first half: no environment may resolve to zero hosts.
+
+        ``get_environments_for_server`` matches on exact equality, so in a
+        multi-host config an environment that declares no ``server:`` belongs
+        to no logical server and its ``git_repo``/``app_path`` are rendered
+        into **no** webhook unit at all — the #325 failure reached from a
+        config that reads like a partial migration rather than a mistake.
+
+        Rejected rather than treated as hosted everywhere: "everywhere"
+        re-creates the #62 least-privilege leak by default and makes the
+        permissive reading of a half-migrated config the safe-looking one.
+        """
+        orphans = self.config.environments_without_a_server()
+        if not orphans:
+            return
+        raise ValueError(
+            f"Environment(s) {', '.join(orphans)} declare no 'server:' while "
+            f"{', '.join(servers)} do. In a multi-server config an environment "
+            f"with no server belongs to no machine, so its git_repo and "
+            f"app_path reach no webhook unit's ReadWritePaths= and every "
+            f"deploy of it fails on a read-only filesystem. Add "
+            f"'server: <one of {', '.join(servers)}>' to each."
+        )
+
+    def _assert_hosted_trees_are_writable(
+        self, server: str | None, content: str
+    ) -> None:
+        """Invariant (C), second half: a host's unit carries all its own trees.
+
+        Checked against the *rendered text*, at the point of rendering, so it
+        holds independently of how the filtering was reached — a template
+        regression, a context bug or a new filtering route all trip it. The
+        mirror of #62 (too many paths) is this one's opposite direction (too
+        few); one check catches both failures of the same invariant.
+        """
+        if "ProtectSystem=strict" not in content:
+            return
+
+        allowed = [
+            ln.split("=", 1)[1].strip()
+            for ln in content.splitlines()
+            if ln.startswith("ReadWritePaths=")
+        ]
+        hosted = (
+            set(self.config.get_environments_for_server(server))
+            if server is not None
+            else None
+        )
+
+        missing: list[str] = []
+        for fraise in self.context["fraises"]:
+            for env_name, env_config in fraise.get("environments", {}).items():
+                if hosted is not None and env_name not in hosted:
+                    continue
+                for key in ("git_repo", "app_path"):
+                    path = env_config.get(key)
+                    if path and not _is_under_any(str(path), allowed):
+                        missing.append(f"{fraise['name']}/{env_name} {key}={path}")
+
+        if missing:
+            where = f"server {server!r}" if server else "this host"
+            raise ValueError(
+                f"The webhook unit rendered for {where} is ProtectSystem=strict "
+                f"but does not allow writes to: {', '.join(missing)}. Those "
+                f"environments are hosted there, so every deploy of them would "
+                f"fail on a read-only filesystem. Rendered ReadWritePaths: "
+                f"{', '.join(allowed) or '(none)'}."
+            )
 
     def _render_deploy_socket_services(self, dry_run: bool) -> list[str]:
         """Render socket-activated deploy units for each fraise-environment combo."""
@@ -1354,6 +1618,36 @@ class ScaffoldRenderer:
             if (name.startswith("fraisier-") and name.endswith(".socket")) or (
                 name.startswith("fraisier-") and name.endswith("@.service")
             ):
+                path.unlink()
+
+    def _remove_stale_webhook_units(self, rendered_files: list[str]) -> None:
+        """Delete webhook units in the tree that no host can install (#325).
+
+        A file that nothing writes and nothing deletes is the substrate of the
+        bug: the installer used to reach for exactly such a leftover, whose
+        content was frozen from whatever server context last wrote it. Both
+        directions are swept here — a slugged unit for a server dropped from
+        the config, and the legacy unslugged unit that multi-host mode no
+        longer produces.
+
+        Only on an unfiltered render. A ``--server`` render holds one host's
+        share of the truth; letting it delete the units it was not asked to
+        produce would leave the shared state tree valid for one machine and
+        broken for the rest, which is the failure mode this whole change
+        exists to remove.
+        """
+        if self.server is not None or not self.output_dir.exists():
+            return
+
+        prefix = f"fraisier-{self.context['project_name']}-webhook"
+        rendered_set = set(rendered_files)
+        for path in self.output_dir.iterdir():
+            if not path.is_file():
+                continue
+            name = path.name
+            if not name.startswith(prefix) or not name.endswith(".service"):
+                continue
+            if name not in rendered_set:
                 path.unlink()
 
     def _write_output(self, rel_path: str, content: str) -> None:

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -82,6 +82,23 @@ if [[ -z "$_FRAISIER_CURRENT_ENVS" ]]; then
 fi
 
 _env_active() { [[ " $_FRAISIER_CURRENT_ENVS " == *" $1 "* ]]; }
+
+# Webhook unit selection (#325). The unit is addressed by host: the scaffold
+# tree carries one fraisier-{project}-webhook-{slug}.service per logical
+# server, and this machine installs its own. There is deliberately no fallback
+# to a host-agnostic name — a leftover from a differently-filtered render is
+# exactly what shipped another host's ReadWritePaths= into production.
+declare -A _FRAISIER_MACHINE_WEBHOOK
+{% for machine, unit in machine_webhook_map.items() %}
+_FRAISIER_MACHINE_WEBHOOK["{{ machine }}"]="{{ unit }}"
+{% endfor %}
+_FRAISIER_WEBHOOK_UNIT="${_FRAISIER_MACHINE_WEBHOOK["$_FRAISIER_CURRENT_HOST"]:-}"
+if [[ -z "$_FRAISIER_WEBHOOK_UNIT" ]]; then
+    echo "Error: no webhook unit was rendered for this machine ('$_FRAISIER_CURRENT_HOST')." >&2
+    echo "  Machines with a unit: {{ machine_webhook_map.keys() | list | join(', ') }}" >&2
+    echo "  Add this machine under 'servers:' and re-run 'fraisier scaffold'." >&2
+    exit 1
+fi
 {% else %}
 # servers: section is required
 echo "Error: 'servers:' section is required in fraises.yaml." >&2
@@ -308,29 +325,42 @@ _run sudo apt-get install -y -qq --no-install-recommends \
     certbot \
     python3-certbot-nginx
 
-# Install webhook service unit
-# The bootstrap renderer is always called with --server, so the webhook file has
-# the generic name (no server slug) but content filtered for this server.
+# Install webhook service unit for THIS machine (#325).
+#
+# The source filename carries the host, the destination never does — so there
+# is no unit rename, no [Install] change and no enable/disable dance.
+#
+# No `[ -f ]` guard, on purpose. That guard is what turned a missing source
+# into a silent skip: the deploy path regenerates the tree without --server,
+# which emits only slugged units, so the host-agnostic name this block used to
+# ask for was never written and whatever stale file survived got installed
+# instead. A missing source now means the render did not produce this
+# machine's unit, and there is nothing safe to install in its place.
 {% set webhook_service = 'fraisier-' ~ project_name ~ '-webhook.service' %}
-WEBHOOK_SRC="${SCAFFOLD_DIR}/{{ webhook_service }}"
+WEBHOOK_SRC="${SCAFFOLD_DIR}/${_FRAISIER_WEBHOOK_UNIT}"
 WEBHOOK_DST="/etc/systemd/system/{{ webhook_service }}"
-if [ -f "${WEBHOOK_SRC}" ]; then
-    echo "  Installing webhook service"
-    _run sudo cp "${WEBHOOK_SRC}" "${WEBHOOK_DST}"
-    _run sudo systemctl daemon-reload
-    _run sudo systemctl restart {{ webhook_service }} || true
-    # Restart deploy sockets so their socket files are recreated under /run/fraisier/.
-    # The webhook service owns RuntimeDirectory=fraisier; even with
-    # RuntimeDirectoryPreserve=restart, a first-time install wipes the dir.
+if [ ! -f "${WEBHOOK_SRC}" ]; then
+    echo "Error: webhook unit '${_FRAISIER_WEBHOOK_UNIT}' is missing from ${SCAFFOLD_DIR}." >&2
+    echo "  This machine has no unit to install, and installing another host's" >&2
+    echo "  would grant it the wrong ReadWritePaths=." >&2
+    echo "  Re-run 'fraisier scaffold' against the full fraises.yaml." >&2
+    exit 1
+fi
+echo "  Installing webhook service"
+_run sudo cp "${WEBHOOK_SRC}" "${WEBHOOK_DST}"
+_run sudo systemctl daemon-reload
+_run sudo systemctl restart {{ webhook_service }} || true
+# Restart deploy sockets so their socket files are recreated under /run/fraisier/.
+# The webhook service owns RuntimeDirectory=fraisier; even with
+# RuntimeDirectoryPreserve=restart, a first-time install wipes the dir.
 {% for fraise in local_fraises %}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% set socket_unit = deploy_socket_name(env_config, env_name, fraise.name) %}
-    if _env_active "{{ env_name }}"; then
-        _run sudo systemctl restart {{ socket_unit }} || true
-    fi
-{% endfor %}
-{% endfor %}
+if _env_active "{{ env_name }}"; then
+    _run sudo systemctl restart {{ socket_unit }} || true
 fi
+{% endfor %}
+{% endfor %}
 
 # Install systemctl helper service and socket (replaces old systemctl wrapper)
 HELPER_SERVICE_SRC="${SCAFFOLD_DIR}/systemd/fraisier-{{ project_name }}-systemctl-helper.service"

--- a/fraisier/setup.py
+++ b/fraisier/setup.py
@@ -6,6 +6,7 @@ generates webhook env files, installs nginx vhosts, and validates.
 
 from __future__ import annotations
 
+import functools
 import logging
 import secrets
 import shlex
@@ -51,7 +52,28 @@ class ServerSetup:
         self.runner = runner
         self.environment = environment
         self.server = server
-        self._renderer = ScaffoldRenderer(config)
+
+    @functools.cached_property
+    def _renderer(self) -> ScaffoldRenderer:
+        """The renderer, filtered for the server this run provisions (#325).
+
+        Built lazily and once. Eager construction would run hostname
+        resolution at ``__init__`` time, before a caller can patch it, and
+        before ``--server`` has been weighed.
+
+        The filter used to be dropped here: ``_resolve_allowed_environments``
+        auto-detects the host for the *plan*, while the *tree* was rendered
+        unfiltered — so the plan and the tree could disagree about which
+        environments are local. ``resolve_local_server`` returning None (this
+        box is in no server) still renders unfiltered, which is safe under
+        invariant (M): a multi-host config emits one slugged unit per server
+        and no host-agnostic file, so there is nothing to leak and nothing to
+        go stale.
+        """
+        from fraisier.scaffold.renderer import resolve_local_server
+
+        server = self.server or resolve_local_server(self.config)
+        return ScaffoldRenderer(self.config, server=server)
 
     def plan(self) -> list[SetupAction]:
         """Build the full ordered list of actions without side effects."""
@@ -408,15 +430,41 @@ class ServerSetup:
         return actions
 
     def _plan_webhook_service(self) -> list[SetupAction]:
+        """Install the webhook unit rendered for *this* machine (#325).
+
+        Source and destination differ by design: the source filename carries
+        the host so a render cannot leave a host-agnostic file behind to go
+        stale, the destination never does so no unit is renamed on the box.
+        Resolved through ``local_webhook_source``, the same helper the
+        generated ``install.sh`` selects with, so the two installers cannot
+        disagree about which file this machine gets.
+        """
+        from fraisier.errors import ValidationError
+        from fraisier.scaffold.renderer import local_webhook_source, webhook_unit_name
+
         output_dir = self.config.scaffold.output_dir
         project = self.config.project_name
-        svc_name = f"fraisier-{project}-webhook.service"
-        src = f"{output_dir}/{svc_name}"
-        dst = f"/etc/systemd/system/{svc_name}"
+        dst_name = webhook_unit_name(project)
+        try:
+            src_name = local_webhook_source(self.config, self.server)
+        except ValidationError as exc:
+            # Nothing safe to plan: in a multi-server config every candidate
+            # unit carries a different host's ReadWritePaths=, and copying the
+            # wrong one is the failure this resolver exists to prevent. Warn
+            # and skip, matching _resolve_allowed_environments' contract for
+            # the same "this box is in no server" condition, rather than
+            # planning a copy of a file no render wrote (#325).
+            logger.warning("Skipping webhook unit install: %s", exc)
+            return []
         return [
             SetupAction(
-                description=f"Install {svc_name}",
-                command=["sudo", "cp", src, dst],
+                description=f"Install {dst_name}",
+                command=[
+                    "sudo",
+                    "cp",
+                    f"{output_dir}/{src_name}",
+                    f"/etc/systemd/system/{dst_name}",
+                ],
                 category="systemd",
             )
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.55.0"
+version = "0.56.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_deployers.py
+++ b/tests/test_deployers.py
@@ -780,6 +780,40 @@ class TestAPIDeployer:
             state_dir,
         ]
 
+    def test_regenerate_scaffold_failure_reports_stderr(self, tmp_path):
+        """A render that refuses must say *why* in the journal (#325).
+
+        Since #325 a render aborts rather than silently narrowing: an unknown
+        ``--server``, an environment that resolves to no host, or a unit
+        missing a hosted environment's trees all raise. Those diagnostics land
+        on stderr, and this is the range where an operator meets them — the
+        webhook journal, one line under "deploy failed". Reporting stdout
+        alone left them with the *successful* part of the render and no
+        reason.
+        """
+        from fraisier.errors import DeploymentError
+
+        opt_config, _ = self._write_state_dir_config(tmp_path)
+
+        runner = MagicMock()
+        runner.run.return_value = MagicMock(
+            returncode=1,
+            stdout="Generated 3 files\n",
+            stderr="ValueError: Environment(s) production declare no 'server:'\n",
+        )
+        deployer = APIDeployer(
+            {"fraise_name": "api", "app_path": str(tmp_path / "var/www/api")},
+            runner=runner,
+        )
+
+        with (
+            patch.object(deployer, "_get_fraisier_executable", return_value="fraisier"),
+            pytest.raises(DeploymentError) as exc,
+        ):
+            deployer._regenerate_scaffold(config_path=opt_config)
+
+        assert "declare no 'server:'" in str(exc.value)
+
     def test_install_scaffold_fallback_reads_from_state_dir(self, tmp_path):
         """The subprocess-fallback install reads from the state tree (#283).
 

--- a/tests/test_install_sh_standalone.py
+++ b/tests/test_install_sh_standalone.py
@@ -121,10 +121,26 @@ class TestInstallShStandaloneMode:
         )
         return result
 
+    @staticmethod
+    def _scaffold_dir(rendered_install_sh, tmp_path, name: str):
+        """A scaffold dir holding this machine's webhook unit.
+
+        Since #325 the webhook copy has no ``[ -f ]`` guard: a source the
+        render did not produce for this host is a hard error rather than a
+        silent skip, in every mode. So a stand-in scaffold dir must carry the
+        unit, the way a real one does — an empty directory is not a scaffold
+        tree.
+        """
+        scaffold_dir = tmp_path / name
+        scaffold_dir.mkdir()
+        rendered = rendered_install_sh.parent
+        for unit in rendered.glob("fraisier-*-webhook*.service"):
+            (scaffold_dir / unit.name).write_text(unit.read_text())
+        return scaffold_dir
+
     def test_standalone_dry_run_exits_zero(self, rendered_install_sh, tmp_path):
         """--standalone --dry-run must succeed even when /opt/testapp doesn't exist."""
-        scaffold_dir = tmp_path / "scaffold"
-        scaffold_dir.mkdir()
+        scaffold_dir = self._scaffold_dir(rendered_install_sh, tmp_path, "scaffold")
         result = self._run_with_hostname(
             rendered_install_sh,
             "default-testrunner",
@@ -147,8 +163,7 @@ class TestInstallShStandaloneMode:
 
     def test_scaffold_dir_implies_standalone(self, rendered_install_sh, tmp_path):
         """--scaffold-dir alone (without --standalone) must also work."""
-        scaffold_dir = tmp_path / "sc"
-        scaffold_dir.mkdir()
+        scaffold_dir = self._scaffold_dir(rendered_install_sh, tmp_path, "sc")
         result = self._run_with_hostname(
             rendered_install_sh,
             "default-testrunner",

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,6 +1,9 @@
 """Infrastructure scaffold tests."""
 
+import pytest
+
 from fraisier.config import FraisierConfig
+from fraisier.errors import ValidationError
 
 
 class TestScaffoldConfigParsing:
@@ -3376,7 +3379,19 @@ class TestWebhookServerFiltering:
     """Webhook service filters ReadWritePaths by server (#62)."""
 
     def test_webhook_includes_only_local_server_paths(self, tmp_path):
-        """Webhook service only includes ReadWritePaths for environments on the host."""
+        """Webhook service only includes ReadWritePaths for environments on the host.
+
+        Deliberate contract change (#325): this used to read the *unslugged*
+        ``fraisier-myproj-webhook.service``, because a ``--server`` render
+        wrote the host-agnostic name with host-filtered content. That pairing
+        is the whole bug — the file's content depended on who rendered it
+        last, so the deploy path's unfiltered regeneration replaced it (or
+        failed to, leaving a stale one) and the installer copied whatever
+        survived. The filter it pins is unchanged and still correct; only the
+        filename moved, and it now reads the slugged file the host installs.
+        Invariant (M) — mode is a function of the config, never of
+        ``--server`` — is what makes the unslugged name unreachable here.
+        """
         from fraisier.scaffold.renderer import ScaffoldRenderer
 
         p = tmp_path / "fraises.yaml"
@@ -3405,9 +3420,12 @@ fraises:
         renderer = ScaffoldRenderer(config, server="server-1")
         renderer.render()
 
-        content = (tmp_path / "output" / "fraisier-myproj-webhook.service").read_text()
+        content = (
+            tmp_path / "output" / "fraisier-myproj-webhook-server-1.service"
+        ).read_text()
         assert "ReadWritePaths=/var/www/dev" in content
         assert "ReadWritePaths=/var/www/prod" not in content
+        assert not (tmp_path / "output" / "fraisier-myproj-webhook.service").exists()
 
     def test_webhook_without_server_generates_per_server_files(self, tmp_path):
         """Without --server and environments.server set, one file per server is made."""
@@ -3512,8 +3530,23 @@ fraises:
         assert "fraisier-myproj-webhook-server-2.service" in files
         assert "fraisier-myproj-webhook.service" not in files
 
-    def test_webhook_server_with_no_matching_environments(self, tmp_path):
-        """Webhook for a server with no environments only has default paths."""
+    def test_webhook_server_with_no_matching_environments_is_an_error(self, tmp_path):
+        """An unknown --server is rejected, naming it and the servers that exist.
+
+        Deliberate contract change (#325). The old assertion — that
+        ``--server server-3`` renders a unit with the fraisier state dirs and
+        no application paths, silently and with exit 0 — *was* the bug it
+        pinned. A typo'd or stale ``--server`` produced a valid-looking,
+        installable unit that then failed every deploy on
+        ``Read-only file system``, because ``ProtectSystem=strict`` denies
+        every path the render quietly dropped.
+
+        A regeneration must never silently narrow: a render that cannot
+        produce a correct unit has to abort before the install step rather
+        than emit a narrower one. ``_regenerate_scaffold`` already turns a
+        non-zero scaffold exit into a DeploymentError, so this aborts the
+        deploy at the right range.
+        """
         from fraisier.scaffold.renderer import ScaffoldRenderer
 
         p = tmp_path / "fraises.yaml"
@@ -3540,15 +3573,13 @@ fraises:
         )
         config = FraisierConfig(p)
         renderer = ScaffoldRenderer(config, server="server-3")  # Non-existent server
-        renderer.render()
 
-        content = (tmp_path / "output" / "fraisier-myproj-webhook.service").read_text()
-        # Should have the default paths but no app paths
-        assert "ReadWritePaths=/var/lib/fraisier" in content
-        assert "ReadWritePaths=/run/fraisier" in content
-        # No app paths for any environment
-        assert "ReadWritePaths=/var/www/dev" not in content
-        assert "ReadWritePaths=/var/www/prod" not in content
+        with pytest.raises(ValidationError) as exc:
+            renderer.render()
+
+        message = str(exc.value)
+        assert "server-3" in message
+        assert "server-1" in message and "server-2" in message
 
 
 class TestWebhookNaming:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -720,6 +720,11 @@ class TestCLI:
         assert "actions would be executed" in result.output
 
     def test_server_flag(self, tmp_path):
+        # `-c` rather than the get_config patch: the CLI group builds
+        # ctx.obj["config"] from its own load, so without it this ran against
+        # the repository's own fraises.yaml and --server named a server that
+        # config never declares. Harmless while an unknown --server rendered a
+        # silently-empty unit; a hard error since #325.
         config = _make_config(tmp_path, SERVER_AWARE_CONFIG)
         runner = CliRunner()
 
@@ -727,7 +732,15 @@ class TestCLI:
             from fraisier.cli.main import main
 
             result = runner.invoke(
-                main, ["setup", "--dry-run", "--server", "prod.example.io"]
+                main,
+                [
+                    "-c",
+                    str(config.config_path),
+                    "setup",
+                    "--dry-run",
+                    "--server",
+                    "prod.example.io",
+                ],
             )
 
         assert result.exit_code == 0

--- a/tests/test_webhook_unit_matches_host.py
+++ b/tests/test_webhook_unit_matches_host.py
@@ -1,0 +1,1157 @@
+"""The webhook unit installed on a host must be the one rendered for it (#325).
+
+The deploy path regenerates the scaffold tree with no ``--server``
+(``deployers/base.py``), so ``_render_webhook_services`` takes its
+auto-per-server branch and writes **only** slugged
+``fraisier-{project}-webhook-{slug}.service`` files. Every installer — the
+generated ``install.sh``, ``ServerSetup._plan_webhook_service`` and
+``ScaffoldRenderer.get_install_mapping`` — asks for the *unslugged*
+``fraisier-{project}-webhook.service``, a name that render never produced.
+``install.sh`` guarded the copy with ``if [ -f ]``, so the step was silently
+skipped, or silently copied whatever stale unslugged file survived in the
+state dir from an earlier, differently-filtered render.
+
+The reported symptom (printoptim.io, 2026-08-03) was a production-only host
+running the webhook unit built for the dev host: ``ProtectSystem=strict`` plus
+a ``ReadWritePaths=`` list holding the *other* machine's git/www trees, so
+``git fetch`` in the bare repo failed with exit 255 and production could not
+deploy. The per-server filter was never wrong; the file carrying its output
+was never the file that got installed.
+
+The fix puts the host in the *source* filename and selects at install time
+from the hostname map ``install.sh`` already bakes. The destination unit name
+is unchanged. Three invariants carry it, and each is pinned below:
+
+(M) Mode is a function of the config alone, never of ``--server``.
+(N) No fallback — a leftover unslugged unit is never installed.
+(C) Every environment resolves to exactly one host, and every hosted
+    environment's trees appear in that host's unit.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+# A printoptim-shaped config: two logical servers, development+staging sharing
+# one machine, production alone on the other. `server:` in the global
+# `environments:` section.
+_GLOBAL_SERVERS = """\
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {out}
+servers:
+  printoptim-dev:
+    machine_hostnames: [pdev]
+  printoptim-io:
+    machine_hostnames: [pio]
+environments:
+  development:
+    server: printoptim-dev
+  staging:
+    server: printoptim-dev
+  production:
+    server: printoptim-io
+fraises:
+  api:
+    type: api
+    environments:
+      development:
+        app_path: /var/www/api.dev
+        git_repo: /var/git/api.dev.git
+      staging:
+        app_path: /var/www/api.st
+        git_repo: /var/git/api.st.git
+      production:
+        app_path: /var/www/api.io
+        git_repo: /var/git/api.io.git
+"""
+
+# The same topology expressed only under `fraises.*.environments.*`, with no
+# global `environments:` section at all. `get_environments_for_server` reads
+# both sources; `_collect_unique_servers` used to read only the global one, so
+# this shape resolved to "no servers configured" and rendered a single unit
+# carrying every host's trees — the #62 least-privilege leak by a second route.
+_PER_FRAISE_SERVERS = """\
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {out}
+servers:
+  printoptim-dev:
+    machine_hostnames: [pdev]
+  printoptim-io:
+    machine_hostnames: [pio]
+fraises:
+  api:
+    type: api
+    environments:
+      development:
+        server: printoptim-dev
+        app_path: /var/www/api.dev
+        git_repo: /var/git/api.dev.git
+      staging:
+        server: printoptim-dev
+        app_path: /var/www/api.st
+        git_repo: /var/git/api.st.git
+      production:
+        server: printoptim-io
+        app_path: /var/www/api.io
+        git_repo: /var/git/api.io.git
+"""
+
+# One environment declares a server, the other does not — the shape a partial
+# migration leaves behind. `get_environments_for_server` matches on exact
+# equality, so `production` belongs to no logical server and its trees land in
+# no webhook unit at all.
+_PARTIAL_SERVERS = """\
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {out}
+servers:
+  printoptim-dev:
+    machine_hostnames: [pdev]
+  printoptim-io:
+    machine_hostnames: [pio]
+environments:
+  development:
+    server: printoptim-dev
+fraises:
+  api:
+    type: api
+    environments:
+      development:
+        app_path: /var/www/api.dev
+        git_repo: /var/git/api.dev.git
+      production:
+        app_path: /var/www/api.io
+        git_repo: /var/git/api.io.git
+"""
+
+# Both declaration sites at once: the global section names the server, the
+# per-fraise config repeats it. Whichever site a config uses, the answer to
+# "which logical servers exist" must be the same.
+_BOTH_SITES = """\
+name: myproj
+scaffold:
+  deploy_user: fraisier
+  output_dir: {out}
+servers:
+  printoptim-dev:
+    machine_hostnames: [pdev]
+  printoptim-io:
+    machine_hostnames: [pio]
+environments:
+  development:
+    server: printoptim-dev
+  staging:
+    server: printoptim-dev
+  production:
+    server: printoptim-io
+fraises:
+  api:
+    type: api
+    environments:
+      development:
+        server: printoptim-dev
+        app_path: /var/www/api.dev
+        git_repo: /var/git/api.dev.git
+      staging:
+        server: printoptim-dev
+        app_path: /var/www/api.st
+        git_repo: /var/git/api.st.git
+      production:
+        server: printoptim-io
+        app_path: /var/www/api.io
+        git_repo: /var/git/api.io.git
+"""
+
+_DEV_TREES = ("/var/git/api.dev.git", "/var/www/api.dev")
+_STAGING_TREES = ("/var/git/api.st.git", "/var/www/api.st")
+_PROD_TREES = ("/var/git/api.io.git", "/var/www/api.io")
+
+
+class _NullRunner:
+    """ServerSetup only needs a runner to exist while planning."""
+
+    def run(self, *args, **kwargs):  # pragma: no cover - never invoked
+        raise AssertionError("plan() must not execute commands")
+
+
+def _render(tmp_path, yaml_text: str, *, server: str | None = None):
+    """Render *yaml_text* into ``tmp_path/out`` and return (config, out_dir)."""
+    cfg_path = tmp_path / "fraises.yaml"
+    out = tmp_path / "out"
+    cfg_path.write_text(yaml_text.format(out=out))
+    config = FraisierConfig(cfg_path)
+    ScaffoldRenderer(config, server=server).render()
+    return config, out
+
+
+def _rw_paths(text: str) -> list[str]:
+    return [
+        ln.split("=", 1)[1].strip()
+        for ln in text.splitlines()
+        if ln.startswith("ReadWritePaths=")
+    ]
+
+
+def _run_install_sh(out_dir, hostname: str, *extra_args) -> subprocess.CompletedProcess:
+    """Run the generated ``install.sh`` with ``hostname -s`` stubbed to *hostname*."""
+    bin_dir = out_dir.parent / f"bin-{hostname}"
+    bin_dir.mkdir(exist_ok=True)
+    fake = bin_dir / "hostname"
+    fake.write_text(f"#!/bin/bash\necho {hostname}\n")
+    fake.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    install_sh = out_dir / "install.sh"
+    install_sh.chmod(0o755)
+    return subprocess.run(
+        ["bash", str(install_sh), "--standalone", "--dry-run", *extra_args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _installed_webhook_source(
+    result: subprocess.CompletedProcess, project: str = "myproj"
+) -> Path | None:
+    """Return the source path install.sh would copy to the webhook unit slot.
+
+    Parses the ``[would run] sudo cp <src> <dst>`` line whose destination is
+    ``/etc/systemd/system/fraisier-{project}-webhook.service``. Returns None
+    when the copy never happens — which is the #325 silent skip.
+    """
+    dst = f"/etc/systemd/system/fraisier-{project}-webhook.service"
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if parts[-1:] == [dst] and "cp" in parts:
+            return Path(parts[-2])
+    return None
+
+
+class TestOneResolverForWhichEnvironmentsAreLocal:
+    """Claim 4 — two functions must not disagree about where a server is declared.
+
+    ``_collect_unique_servers`` read only the global ``environments:`` section
+    while ``get_environments_for_server`` — and therefore
+    ``get_machine_environment_map``, which bakes install.sh's host gating —
+    read the per-fraise configs as well. A config declaring ``server:`` only
+    under ``fraises.*`` looked server-less to the renderer (one unit, every
+    host's trees) and correctly filtered to the installer.
+    """
+
+    @pytest.mark.parametrize(
+        "yaml_text",
+        [_GLOBAL_SERVERS, _PER_FRAISE_SERVERS, _BOTH_SITES],
+        ids=["global", "per-fraise", "both"],
+    )
+    def test_server_set_is_identical_across_declaration_sites(
+        self, tmp_path, yaml_text
+    ):
+        from fraisier.scaffold.renderer import _collect_unique_servers
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(yaml_text.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        assert set(_collect_unique_servers(config)) == {
+            "printoptim-dev",
+            "printoptim-io",
+        }
+
+    @pytest.mark.parametrize(
+        "yaml_text",
+        [_GLOBAL_SERVERS, _PER_FRAISE_SERVERS, _BOTH_SITES],
+        ids=["global", "per-fraise", "both"],
+    )
+    def test_renderer_and_installer_agree_on_the_environment_split(
+        self, tmp_path, yaml_text
+    ):
+        """The two resolvers must partition environments the same way."""
+        from fraisier.scaffold.renderer import _collect_unique_servers
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(yaml_text.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        split = {
+            server: set(config.get_environments_for_server(server))
+            for server in _collect_unique_servers(config)
+        }
+        assert split == {
+            "printoptim-dev": {"development", "staging"},
+            "printoptim-io": {"production"},
+        }
+
+
+class TestTheUnitAHostInstallsIsTheUnitRenderedForIt:
+    """RED 1.1 to 1.3 - end-to-end from hostname to the installed unit's contents.
+
+    The assertion runs through the generated ``install.sh`` on purpose: the
+    per-server *filter* was already correct, so any test that reads a slugged
+    file directly passes even with the bug present. Only asking the installer
+    which file it picks reproduces #325.
+    """
+
+    def test_prod_machine_gets_only_production_trees(self, tmp_path):
+        """RED 1.1 — pio hosts production alone, and installs exactly that."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+
+        result = _run_install_sh(out, "pio")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        src = _installed_webhook_source(result)
+        assert src is not None, (
+            "install.sh installed no webhook unit at all — the deploy-path "
+            f"render writes only slugged files. stdout: {result.stdout}"
+        )
+
+        paths = _rw_paths((out / src.name).read_text())
+        for tree in _PROD_TREES:
+            assert tree in paths, f"production tree {tree} missing from {paths}"
+        for tree in _DEV_TREES + _STAGING_TREES:
+            assert tree not in paths, f"foreign tree {tree} present in {paths}"
+
+    def test_dev_machine_gets_development_and_staging_trees(self, tmp_path):
+        """RED 1.2 — the mirror, so the fix cannot be 'always emit everything'."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+
+        result = _run_install_sh(out, "pdev")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        src = _installed_webhook_source(result)
+        assert src is not None, f"no webhook unit installed. stdout: {result.stdout}"
+
+        paths = _rw_paths((out / src.name).read_text())
+        for tree in _DEV_TREES + _STAGING_TREES:
+            assert tree in paths, f"hosted tree {tree} missing from {paths}"
+        for tree in _PROD_TREES:
+            assert tree not in paths, f"foreign tree {tree} present in {paths}"
+
+    def test_per_fraise_server_declaration_still_filters(self, tmp_path):
+        """RED 1.3 — `server:` under fraises.* only, the #62 leak's second route."""
+        _, out = _render(tmp_path, _PER_FRAISE_SERVERS)
+
+        result = _run_install_sh(out, "pio")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        src = _installed_webhook_source(result)
+        assert src is not None, f"no webhook unit installed. stdout: {result.stdout}"
+
+        paths = _rw_paths((out / src.name).read_text())
+        for tree in _PROD_TREES:
+            assert tree in paths, f"production tree {tree} missing from {paths}"
+        for tree in _DEV_TREES + _STAGING_TREES:
+            assert tree not in paths, (
+                f"foreign tree {tree} present in {paths} — `server:` declared "
+                "only per-fraise must filter exactly like the global section"
+            )
+
+
+class TestInstallShSelectsTheWebhookUnitByHostname:
+    """RED 1.4 — the selection itself, at the shell level."""
+
+    def test_each_machine_selects_its_own_slugged_source(self, tmp_path):
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+
+        for machine, slug in (("pdev", "printoptim-dev"), ("pio", "printoptim-io")):
+            result = _run_install_sh(out, machine)
+            assert result.returncode == 0, f"{machine}: stderr={result.stderr}"
+            src = _installed_webhook_source(result)
+            assert src is not None, f"{machine}: no webhook unit installed"
+            assert src.name == f"fraisier-myproj-webhook-{slug}.service", (
+                f"{machine} selected {src!r}"
+            )
+
+    def test_destination_unit_name_is_unchanged(self, tmp_path):
+        """Only the source filename gains the host — no unit rename on the box."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+
+        result = _run_install_sh(out, "pio")
+        assert "/etc/systemd/system/fraisier-myproj-webhook.service" in result.stdout, (
+            result.stdout
+        )
+
+
+class TestNoFallbackToAnUnsluggedLeftover:
+    """RED 1.5 — invariant (N). A stale unslugged unit is never installed."""
+
+    def test_stale_unslugged_unit_is_ignored(self, tmp_path):
+        """The exact #325 mechanism: a leftover shadows the host's real unit."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        stale = out / "fraisier-myproj-webhook.service"
+        stale.write_text(
+            "[Service]\n"
+            "ProtectSystem=strict\n"
+            "ReadWritePaths=/var/git/api.dev.git\n"
+            "ReadWritePaths=/var/www/api.dev\n"
+        )
+
+        result = _run_install_sh(out, "pio")
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        src = _installed_webhook_source(result)
+        assert src is not None, "no webhook unit installed"
+        assert src.name == "fraisier-myproj-webhook-printoptim-io.service", (
+            f"installed the stale unslugged leftover instead: {src}"
+        )
+
+    def test_missing_slugged_unit_is_a_hard_error(self, tmp_path):
+        """A known machine whose unit is absent must fail, never skip."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        (out / "fraisier-myproj-webhook-printoptim-io.service").unlink()
+
+        result = _run_install_sh(out, "pio")
+        assert result.returncode != 0, (
+            "install.sh continued past a missing webhook unit — that silent "
+            f"skip is #325. stdout: {result.stdout}"
+        )
+        assert "webhook" in result.stderr.lower(), result.stderr
+
+    def test_missing_slugged_unit_does_not_reach_for_the_unslugged_one(self, tmp_path):
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        (out / "fraisier-myproj-webhook-printoptim-io.service").unlink()
+        (out / "fraisier-myproj-webhook.service").write_text("[Service]\n")
+
+        result = _run_install_sh(out, "pio")
+        src = _installed_webhook_source(result)
+        assert src is None, f"fell back to {src!r}"
+
+
+class TestModeIsAFunctionOfTheConfigAlone:
+    """Invariant (M) — ``--server`` narrows the render, it never flips the mode.
+
+    A tree is in multi-host mode iff *any* environment declares a ``server:``.
+    ``--server`` selects which slugged units a render emits; it can never make
+    a multi-host config produce an unslugged unit, and it can never make a
+    single-host config produce a slugged one.
+
+    This is the test that licenses Phase 5's decision to leave
+    ``_regenerate_scaffold`` unfiltered. That decision is conditional, not
+    free: an unfiltered regen of a multi-host config is safe only because it
+    emits every slug and no unslugged unit (M), and because the installer
+    refuses to install an unslugged leftover (N). **If (M) or (N) is ever
+    relaxed, ``_regenerate_scaffold`` must start passing ``--server`` in the
+    same commit** — this class is the tripwire.
+    """
+
+    def test_multi_host_config_never_emits_an_unslugged_unit(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        files = ScaffoldRenderer(config).render(dry_run=True)
+
+        assert "fraisier-myproj-webhook.service" not in files
+        assert "fraisier-myproj-webhook-printoptim-dev.service" in files
+        assert "fraisier-myproj-webhook-printoptim-io.service" in files
+
+    def test_server_filter_narrows_which_slugs_not_the_mode(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        files = ScaffoldRenderer(config, server="printoptim-io").render(dry_run=True)
+
+        assert "fraisier-myproj-webhook-printoptim-io.service" in files
+        assert "fraisier-myproj-webhook-printoptim-dev.service" not in files
+        assert "fraisier-myproj-webhook.service" not in files, (
+            "a --server render wrote the host-agnostic name — that file is what "
+            "goes stale and then gets installed on the wrong box (#325)"
+        )
+
+    def test_single_host_config_emits_only_the_unslugged_unit(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(
+            _GLOBAL_SERVERS.format(out=tmp_path / "out")
+            .replace("    server: printoptim-dev\n", "")
+            .replace("    server: printoptim-io\n", "")
+        )
+        config = FraisierConfig(cfg_path)
+
+        files = ScaffoldRenderer(config).render(dry_run=True)
+
+        assert "fraisier-myproj-webhook.service" in files
+        assert not [f for f in files if f.startswith("fraisier-myproj-webhook-")]
+
+    def test_the_two_renders_agree_on_the_mode(self, tmp_path):
+        """The same config never yields slugged units in one render and an
+        unslugged one in another."""
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        unfiltered = ScaffoldRenderer(config).render(dry_run=True)
+        filtered = ScaffoldRenderer(config, server="printoptim-dev").render(
+            dry_run=True
+        )
+
+        def slugged(files):
+            return {f for f in files if f.startswith("fraisier-myproj-webhook")}
+
+        assert all("-webhook-" in f for f in slugged(unfiltered))
+        assert all("-webhook-" in f for f in slugged(filtered))
+        assert slugged(filtered) <= slugged(unfiltered)
+
+
+class TestTheMachineToUnitMapReachesTheContext:
+    """Cycle 3.2 — the inversion of ``servers:`` install.sh selects from.
+
+    ``validate_servers`` already rejects a machine listed under two logical
+    servers, so the inversion is unambiguous and needs no second check here.
+    """
+
+    def test_every_machine_in_servers_has_an_entry(self, tmp_path):
+        from fraisier.scaffold.renderer import _build_context
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        assert _build_context(config)["machine_webhook_map"] == {
+            "pdev": "fraisier-myproj-webhook-printoptim-dev.service",
+            "pio": "fraisier-myproj-webhook-printoptim-io.service",
+        }
+
+    def test_single_host_mode_has_no_map(self, tmp_path):
+        """No slugged units exist, so there is nothing to select between."""
+        from fraisier.scaffold.renderer import _build_context
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(
+            _GLOBAL_SERVERS.format(out=tmp_path / "out")
+            .replace("    server: printoptim-dev\n", "")
+            .replace("    server: printoptim-io\n", "")
+        )
+        config = FraisierConfig(cfg_path)
+
+        assert _build_context(config)["machine_webhook_map"] == {}
+
+
+class TestServerSetupDoesNotDropItsServer:
+    """``ServerSetup`` built its renderer with no server and dropped the filter.
+
+    ``_resolve_allowed_environments`` auto-detects the host for its own
+    actions, so the plan knew which environments were local while the tree it
+    rendered did not. The two must not be able to disagree.
+    """
+
+    def test_explicit_server_reaches_the_renderer(self, tmp_path):
+        from fraisier.setup import ServerSetup
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        setup = ServerSetup(config, _NullRunner(), server="printoptim-io")
+
+        assert setup._renderer.server == "printoptim-io"
+
+    def test_the_plan_installs_the_unit_the_render_wrote(self, tmp_path):
+        from fraisier.setup import ServerSetup
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        setup = ServerSetup(config, _NullRunner(), server="printoptim-io")
+        rendered = setup._renderer.render()
+        (action,) = setup._plan_webhook_service()
+        source = Path(action.command[-2])
+
+        assert source.name in rendered, (
+            f"the plan copies {source.name} but the render wrote {rendered}"
+        )
+        assert source.name == "fraisier-myproj-webhook-printoptim-io.service"
+        assert (
+            action.command[-1] == "/etc/systemd/system/fraisier-myproj-webhook.service"
+        )
+
+
+class TestStaleWebhookUnitsAreSweptFromTheTree:
+    """The next render removes units no host can install.
+
+    A file nothing writes and nothing deletes is the substrate of #325: the
+    installer used to reach for exactly such a leftover. The sweep runs only
+    on an unfiltered render — a ``--server`` render knows one host's share of
+    the truth and must not delete units it was never asked to produce.
+    """
+
+    def test_unit_for_a_removed_server_is_deleted(self, tmp_path):
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        orphan = out / "fraisier-myproj-webhook-printoptim-old.service"
+        orphan.write_text("[Service]\n")
+
+        _render(tmp_path, _GLOBAL_SERVERS)
+
+        assert not orphan.exists()
+
+    def test_legacy_unslugged_unit_is_deleted_in_multi_host_mode(self, tmp_path):
+        """The stale file #325 installed. Nothing in this mode may write it."""
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        legacy = out / "fraisier-myproj-webhook.service"
+        legacy.write_text("[Service]\nReadWritePaths=/var/www/api.dev\n")
+
+        _render(tmp_path, _GLOBAL_SERVERS)
+
+        assert not legacy.exists()
+
+    def test_a_filtered_render_does_not_sweep_other_hosts_units(self, tmp_path):
+        _, out = _render(tmp_path, _GLOBAL_SERVERS)
+        other = out / "fraisier-myproj-webhook-printoptim-dev.service"
+        assert other.exists()
+
+        _render(tmp_path, _GLOBAL_SERVERS, server="printoptim-io")
+
+        assert other.exists(), (
+            "a --server render deleted another host's unit — the state dir "
+            "must stay valid for every machine"
+        )
+
+    def test_slugged_leftovers_are_deleted_in_single_host_mode(self, tmp_path):
+        single_host = _GLOBAL_SERVERS.replace(
+            "    server: printoptim-dev\n", ""
+        ).replace("    server: printoptim-io\n", "")
+        _, out = _render(tmp_path, single_host)
+        leftover = out / "fraisier-myproj-webhook-printoptim-dev.service"
+        leftover.write_text("[Service]\n")
+
+        _render(tmp_path, single_host)
+
+        assert not leftover.exists()
+        assert (out / "fraisier-myproj-webhook.service").exists()
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root ignores the mode bits this test relies on"
+)
+class TestDeployAbortsWhenItCannotWriteFromInsideTheSandbox:
+    """Defense in depth: prove the write, do not infer it.
+
+    The deploy already runs *inside* the unit's sandbox, so it needs no
+    ``systemd-run`` — a create-and-unlink in each tree answers the exact
+    question ``ProtectSystem=strict`` decides. This is the only check that
+    catches the failure class generically, including for a hand-written unit
+    no template fix can reach.
+
+    A real write, not ``os.access``: ``access(2)`` consults the file mode and
+    the caller's ids, which is a different question from "did the mount
+    namespace this process is in make that path read-only", and it answers
+    the wrong one confidently.
+
+    The reported failure surfaced in ``_git_pull`` as ``git fetch`` exit 255.
+    Landing one step earlier turns a raw exit code into a diagnosis.
+    """
+
+    @staticmethod
+    def _deployer(tmp_path):
+        from fraisier.deployers.api import APIDeployer
+
+        app = tmp_path / "app"
+        repo = tmp_path / "repo.git"
+        app.mkdir()
+        repo.mkdir()
+        return (
+            APIDeployer(
+                {
+                    "fraise_name": "api",
+                    "environment": "production",
+                    "app_path": str(app),
+                    "git_repo": str(repo),
+                }
+            ),
+            app,
+            repo,
+        )
+
+    def test_unwritable_git_repo_aborts_with_a_diagnosis(self, tmp_path):
+        from fraisier.errors import DeploymentError
+
+        deployer, _, repo = self._deployer(tmp_path)
+        repo.chmod(0o555)
+        try:
+            with pytest.raises(DeploymentError) as exc:
+                deployer._validate_sandbox_writes()
+        finally:
+            repo.chmod(0o755)
+
+        message = str(exc.value)
+        assert str(repo) in message
+        assert "ReadWritePaths" in message
+        assert "webhook" in message
+
+    def test_unwritable_app_path_aborts(self, tmp_path):
+        from fraisier.errors import DeploymentError
+
+        deployer, app, _ = self._deployer(tmp_path)
+        app.chmod(0o555)
+        try:
+            with pytest.raises(DeploymentError) as exc:
+                deployer._validate_sandbox_writes()
+        finally:
+            app.chmod(0o755)
+
+        assert str(app) in str(exc.value)
+
+    def test_writable_trees_pass_and_leave_nothing_behind(self, tmp_path):
+        deployer, app, repo = self._deployer(tmp_path)
+
+        deployer._validate_sandbox_writes()
+
+        assert list(app.iterdir()) == []
+        assert list(repo.iterdir()) == []
+
+    def test_missing_tree_is_not_this_check_s_business(self, tmp_path):
+        """A path that does not exist is a different diagnosis, made elsewhere."""
+        from fraisier.deployers.api import APIDeployer
+
+        deployer = APIDeployer(
+            {
+                "fraise_name": "api",
+                "app_path": str(tmp_path / "nope"),
+                "git_repo": str(tmp_path / "nope.git"),
+            }
+        )
+
+        deployer._validate_sandbox_writes()
+
+    def test_probe_runs_before_the_git_pull(self, tmp_path):
+        """Ordering is the point: a diagnosis instead of `git fetch` exit 255."""
+        import inspect
+
+        from fraisier.deployers.api import APIDeployer
+
+        body = inspect.getsource(APIDeployer.execute)
+        assert body.index("_validate_sandbox_writes") < body.index("_git_pull")
+        assert body.index("_validate_wrapper_scripts") < body.index(
+            "_validate_sandbox_writes"
+        )
+
+
+class TestDoctorReadsTheInstalledUnitAgainstTheHostedTrees:
+    """The #317 check's shape, widened from dump dirs to hosted env trees.
+
+    Reads the *installed* unit rather than the rendered one on purpose: that
+    is the upgrade-without-re-scaffold case, which is the likeliest way to
+    still be broken after a template fix, and it is also the only way to see a
+    hand-written unit.
+
+    Warn, not fail — matching #317. A hard failure here would break hosts
+    limping along on a hand-edited unit that works.
+    """
+
+    def _run(self, config):
+        from fraisier import doctor
+
+        return doctor.DOCTOR_CHECKS["webhook_hosted_trees_writable"].fn(config)
+
+    def _config(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        return FraisierConfig(cfg_path)
+
+    def _install(self, tmp_path, monkeypatch, body: str):
+        unit = tmp_path / "installed-webhook.service"
+        unit.write_text(body)
+        monkeypatch.setattr("fraisier.doctor._installed_webhook_unit", lambda _p: unit)
+        return unit
+
+    def _pretend_host_is(self, monkeypatch, machine: str):
+        monkeypatch.setattr(
+            "fraisier.doctor._resolve_local_server",
+            lambda _config: {"pdev": "printoptim-dev", "pio": "printoptim-io"}[machine],
+        )
+
+    def test_registered(self):
+        from fraisier import doctor
+
+        assert "webhook_hosted_trees_writable" in doctor.DOCTOR_CHECKS
+
+    def test_warns_when_a_hosted_tree_is_missing(self, tmp_path, monkeypatch):
+        """The exact production state: prod host, dev host's allowlist."""
+        self._pretend_host_is(monkeypatch, "pio")
+        self._install(
+            tmp_path,
+            monkeypatch,
+            "[Service]\nProtectSystem=strict\n"
+            "ReadWritePaths=/var/lib/fraisier\n"
+            "ReadWritePaths=/var/git/api.dev.git\n"
+            "ReadWritePaths=/var/www/api.dev\n",
+        )
+
+        result = self._run(self._config(tmp_path))
+
+        assert result.status == "warn"
+        assert "/var/git/api.io.git" in result.detail
+        assert result.fix_hint is not None and "scaffold" in result.fix_hint
+
+    def test_passes_when_every_hosted_tree_is_allowed(self, tmp_path, monkeypatch):
+        self._pretend_host_is(monkeypatch, "pio")
+        self._install(
+            tmp_path,
+            monkeypatch,
+            "[Service]\nProtectSystem=strict\n"
+            "ReadWritePaths=/var/lib/fraisier\n"
+            "ReadWritePaths=/var/git/api.io.git\n"
+            "ReadWritePaths=/var/www/api.io\n",
+        )
+
+        assert self._run(self._config(tmp_path)).status == "pass"
+
+    def test_a_foreign_tree_is_not_this_check_s_finding(self, tmp_path, monkeypatch):
+        """#62 is the other direction; this check owns the missing side only."""
+        self._pretend_host_is(monkeypatch, "pio")
+        self._install(
+            tmp_path,
+            monkeypatch,
+            "[Service]\nProtectSystem=strict\n"
+            "ReadWritePaths=/var/git/api.io.git\n"
+            "ReadWritePaths=/var/www/api.io\n"
+            "ReadWritePaths=/var/www/api.dev\n",
+        )
+
+        assert self._run(self._config(tmp_path)).status == "pass"
+
+    def test_skips_when_the_host_is_unresolvable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "fraisier.doctor._resolve_local_server", lambda _config: None
+        )
+        self._install(tmp_path, monkeypatch, "[Service]\nProtectSystem=strict\n")
+
+        assert self._run(self._config(tmp_path)).status == "skip"
+
+    def test_skips_when_the_unit_is_not_installed(self, tmp_path, monkeypatch):
+        self._pretend_host_is(monkeypatch, "pio")
+        monkeypatch.setattr(
+            "fraisier.doctor._installed_webhook_unit",
+            lambda _p: tmp_path / "nope.service",
+        )
+
+        assert self._run(self._config(tmp_path)).status == "skip"
+
+    def test_passes_when_the_sandbox_is_not_strict(self, tmp_path, monkeypatch):
+        self._pretend_host_is(monkeypatch, "pio")
+        self._install(
+            tmp_path, monkeypatch, "[Service]\nReadWritePaths=/opt/fraisier\n"
+        )
+
+        assert self._run(self._config(tmp_path)).status == "pass"
+
+    def test_skips_without_config(self):
+        assert self._run(None).status == "skip"
+
+
+class TestOptInActiveSandboxProbe:
+    """``fraisier doctor --probe-sandbox`` — check the unit *before* installing.
+
+    The passive checks read a path list and reason about it. This one runs a
+    real write under a real ``ProtectSystem=strict`` sandbox built from the
+    **rendered** unit's ``ReadWritePaths=``, so an operator can find out
+    before ``scaffold-install`` rather than on the next deploy.
+
+    Off by default and skipped without root: ``systemd-run`` needs
+    privileges, and a check that fails for lack of them is noise.
+    """
+
+    def _run(self, config):
+        from fraisier import doctor
+
+        return doctor.DOCTOR_CHECKS["sandbox_write_probe"].fn(config)
+
+    def _config(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "out"))
+        return FraisierConfig(cfg_path)
+
+    def test_registered_and_opt_in(self):
+        from fraisier import doctor
+
+        entry = doctor.DOCTOR_CHECKS["sandbox_write_probe"]
+        assert entry.privileged, "the probe must not run in a default doctor pass"
+
+    def test_default_doctor_run_skips_it(self, tmp_path):
+        from fraisier import doctor
+
+        results = {
+            r.name: r for r in doctor.run_all(self._config(tmp_path), skip_network=True)
+        }
+        assert results["sandbox_write_probe"].status == "skip"
+
+    def test_skips_without_root(self, tmp_path, monkeypatch):
+        from fraisier import doctor
+
+        monkeypatch.setattr("fraisier.doctor.os.geteuid", lambda: 1000)
+        result = doctor.run_all(
+            self._config(tmp_path), only=["sandbox_write_probe"], probe_sandbox=True
+        )[0]
+
+        assert result.status == "skip"
+        assert "root" in result.detail
+
+    def test_probes_the_rendered_paths_for_this_host(self, tmp_path, monkeypatch):
+        from fraisier import doctor
+
+        monkeypatch.setattr("fraisier.doctor.os.geteuid", lambda: 0)
+        monkeypatch.setattr(
+            "fraisier.doctor._resolve_local_server", lambda _config: "printoptim-io"
+        )
+        seen: list[list[str]] = []
+        monkeypatch.setattr(
+            "fraisier.doctor._run_sandbox_probe",
+            lambda paths: (seen.append(list(paths)), (0, ""))[1],
+        )
+
+        result = doctor.run_all(
+            self._config(tmp_path), only=["sandbox_write_probe"], probe_sandbox=True
+        )[0]
+
+        assert result.status == "pass"
+        assert seen and "/var/git/api.io.git" in seen[0]
+        assert "/var/git/api.dev.git" not in seen[0], (
+            "probed another host's trees — the probe must use the unit rendered "
+            "for this machine"
+        )
+
+    def test_a_failing_probe_is_reported_as_fail(self, tmp_path, monkeypatch):
+        from fraisier import doctor
+
+        monkeypatch.setattr("fraisier.doctor.os.geteuid", lambda: 0)
+        monkeypatch.setattr(
+            "fraisier.doctor._resolve_local_server", lambda _config: "printoptim-io"
+        )
+        monkeypatch.setattr(
+            "fraisier.doctor._run_sandbox_probe",
+            lambda _paths: (1, "/var/git/api.io.git: Read-only file system"),
+        )
+
+        result = doctor.run_all(
+            self._config(tmp_path), only=["sandbox_write_probe"], probe_sandbox=True
+        )[0]
+
+        assert result.status == "fail"
+        assert "Read-only file system" in result.detail
+
+    def test_probe_command_is_a_strict_sandbox_over_the_given_paths(self):
+        from fraisier.doctor import _sandbox_probe_command
+
+        argv = _sandbox_probe_command(["/var/git/api.io.git", "/var/www/api.io"])
+
+        assert argv[0] == "systemd-run"
+        assert "-pProtectSystem=strict" in argv
+        assert "-pReadWritePaths=/var/git/api.io.git /var/www/api.io" in argv
+
+
+class TestEveryEnvironmentResolvesToExactlyOneHost:
+    """RED 1.6 — invariant (C), claim 6.
+
+    An environment with no ``server:`` in a multi-host config belongs to no
+    logical server, so its trees are rendered into no webhook unit. That is
+    the #325 failure reached from a config that reads like a partial
+    migration rather than a mistake. Reject at render: treating it as hosted
+    *everywhere* would re-create the #62 leak by default and make the
+    permissive reading the safe-looking one.
+    """
+
+    def test_a_unit_missing_a_hosted_tree_fails_the_render(self, tmp_path):
+        """(C)'s other half, checked against the rendered text.
+
+        #62 is this invariant violated one way (a host's unit carries another
+        host's trees); #325 is the same invariant violated the other (a host's
+        unit is missing its own). Asserting on the rendered
+        ``ReadWritePaths=`` rather than on the context catches both, and
+        catches them however the filtering was reached — a template
+        regression included, which is what this stands in for.
+        """
+        templates = tmp_path / "templates" / "core"
+        templates.mkdir(parents=True)
+        (templates / "fraisier-webhook.service.j2").write_text(
+            "[Service]\n"
+            "ProtectSystem=strict\n"
+            "ReadWritePaths=/var/lib/fraisier\n"
+            "ReadWritePaths=/run/fraisier\n"
+        )
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(
+            _GLOBAL_SERVERS.format(out=tmp_path / "out").replace(
+                "  deploy_user: fraisier\n",
+                "  deploy_user: fraisier\n  template_dir: templates\n",
+            )
+        )
+        config = FraisierConfig(cfg_path)
+
+        with pytest.raises(ValueError) as exc:
+            ScaffoldRenderer(config).render()
+
+        message = str(exc.value)
+        assert "ReadWritePaths" in message
+        assert "/var/git/api" in message or "/var/www/api" in message
+
+    def test_environment_without_a_server_is_rejected(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_PARTIAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        with pytest.raises(ValueError) as exc:
+            ScaffoldRenderer(config).render()
+
+        message = str(exc.value)
+        assert "production" in message, message
+        assert "server" in message.lower(), message
+
+    def test_error_names_the_servers_it_could_be_assigned_to(self, tmp_path):
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_PARTIAL_SERVERS.format(out=tmp_path / "out"))
+        config = FraisierConfig(cfg_path)
+
+        with pytest.raises(ValueError) as exc:
+            ScaffoldRenderer(config).render()
+
+        assert "printoptim-dev" in str(exc.value), str(exc.value)
+
+
+class TestTheInvariantSweep:
+    """The whole contract, as a loop over the machine map.
+
+    Written as a sweep rather than per-host literals so that adding a machine
+    to a config cannot leave a hole in the test. Both directions of the same
+    invariant are asserted together, because #62 and #325 are that invariant
+    violated in opposite directions — too many paths, and too few.
+    """
+
+    @pytest.mark.parametrize(
+        "yaml_text",
+        [_GLOBAL_SERVERS, _PER_FRAISE_SERVERS, _BOTH_SITES],
+        ids=["global", "per-fraise", "both"],
+    )
+    def test_every_machine_installs_exactly_its_own_trees(self, tmp_path, yaml_text):
+        config, out = _render(tmp_path, yaml_text)
+
+        every_tree = {
+            str(env_config[key])
+            for fraise in config.fraises.values()
+            for env_config in fraise.get("environments", {}).values()
+            for key in ("git_repo", "app_path")
+            if env_config.get(key)
+        }
+
+        for machine in sorted(m for ms in config.servers.values() for m in ms):
+            result = _run_install_sh(out, machine)
+            assert result.returncode == 0, f"{machine}: {result.stderr}"
+            source = _installed_webhook_source(result)
+            assert source is not None, f"{machine}: no webhook unit installed"
+
+            allowed = set(_rw_paths((out / source.name).read_text()))
+            hosted_envs = {
+                env
+                for logical, machines in config.servers.items()
+                if machine in machines
+                for env in config.get_environments_for_server(logical)
+            }
+            mine = {
+                str(env_config[key])
+                for fraise in config.fraises.values()
+                for env_name, env_config in fraise.get("environments", {}).items()
+                if env_name in hosted_envs
+                for key in ("git_repo", "app_path")
+                if env_config.get(key)
+            }
+
+            assert mine <= allowed, f"{machine} is missing {sorted(mine - allowed)}"
+            foreign = (every_tree - mine) & allowed
+            assert not foreign, f"{machine} may write another host's {sorted(foreign)}"
+
+    def test_state_dirs_are_shared_by_every_machine(self, tmp_path):
+        """The three fraisier state dirs are identical on every host."""
+        config, out = _render(tmp_path, _GLOBAL_SERVERS)
+        shared = {"/opt/fraisier", "/var/lib/fraisier", "/run/fraisier"}
+
+        for machine in sorted(m for ms in config.servers.values() for m in ms):
+            source = _installed_webhook_source(_run_install_sh(out, machine))
+            assert source is not None
+            allowed = set(_rw_paths((out / source.name).read_text()))
+            assert shared <= allowed, f"{machine} lacks {sorted(shared - allowed)}"
+
+
+class TestTheActualDeployPathChain:
+    """The exact argv `_regenerate_scaffold` runs, then the install (#325).
+
+    Every other test in this file constructs the renderer directly. This one
+    drives the real CLI with the real deploy-path arguments — ``-c <cfg>
+    scaffold --output-dir <state_dir>``, **no ``--server``** — because that is
+    the mode that produced the incident. The bootstrap path, which does pass
+    ``--server``, was never the broken one.
+
+    Kept separate and named for the caller so that a future change to
+    `_regenerate_scaffold`'s argv (notably: starting to pass ``--server``,
+    which invariants (M) and (N) currently make unnecessary) has to come past
+    a test that spells the old argv out.
+    """
+
+    def _regenerate_as_the_deployer_does(self, tmp_path):
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        cfg_path = tmp_path / "fraises.yaml"
+        cfg_path.write_text(_GLOBAL_SERVERS.format(out=tmp_path / "unused-output-dir"))
+        state_dir = tmp_path / "state" / "scaffold"
+
+        result = CliRunner().invoke(
+            main,
+            ["-c", str(cfg_path), "scaffold", "--output-dir", str(state_dir)],
+        )
+        assert result.exit_code == 0, result.output
+        return state_dir
+
+    def test_regeneration_then_install_lands_the_prod_unit_on_the_prod_host(
+        self, tmp_path
+    ):
+        state_dir = self._regenerate_as_the_deployer_does(tmp_path)
+
+        install = _run_install_sh(state_dir, "pio")
+        assert install.returncode == 0, install.stderr
+        source = _installed_webhook_source(install)
+        assert source is not None, (
+            "the deploy path regenerated and the installer took nothing — "
+            f"this is #325 verbatim. stdout: {install.stdout}"
+        )
+        assert source.name == "fraisier-myproj-webhook-printoptim-io.service"
+
+        paths = _rw_paths((state_dir / source.name).read_text())
+        for tree in _PROD_TREES:
+            assert tree in paths
+        for tree in _DEV_TREES + _STAGING_TREES:
+            assert tree not in paths
+
+    def test_the_same_regeneration_serves_the_dev_host(self, tmp_path):
+        """One tree, valid for every machine — what the state dir is for."""
+        state_dir = self._regenerate_as_the_deployer_does(tmp_path)
+
+        install = _run_install_sh(state_dir, "pdev")
+        assert install.returncode == 0, install.stderr
+        source = _installed_webhook_source(install)
+        assert source is not None
+        assert source.name == "fraisier-myproj-webhook-printoptim-dev.service"
+
+        paths = _rw_paths((state_dir / source.name).read_text())
+        for tree in _DEV_TREES + _STAGING_TREES:
+            assert tree in paths
+        for tree in _PROD_TREES:
+            assert tree not in paths
+
+    def test_the_regeneration_writes_no_host_agnostic_unit(self, tmp_path):
+        """Invariant (M) at the deploy path — the file that used to go stale."""
+        state_dir = self._regenerate_as_the_deployer_does(tmp_path)
+
+        assert not (state_dir / "fraisier-myproj-webhook.service").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.55.0"
+version = "0.56.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## The webhook unit installed on a host is now the one rendered for it

Closes #325. Rolls in the v0.56.0 bump.

The per-server filter was never wrong — `_build_context(config, server)`
produced exactly the right path set. What was broken is that nothing
guaranteed the file carrying that set was the file that got installed.

The deploy path regenerates with `fraisier -c <cfg> scaffold --output-dir
<state_dir>` and **no `--server`**, so the renderer took its auto-per-server
branch and wrote only slugged `fraisier-{project}-webhook-{slug}.service`
files. All three installers asked for the *unslugged*
`fraisier-{project}-webhook.service` — a name that render never produced.
`install.sh` guarded the copy with `if [ -f ]`, so the step was silently
skipped in a fresh tree, or silently copied whatever unslugged leftover
survived in the state dir from an earlier, differently-filtered render.

Reported from production (printoptim.io, 2026-08-03): a prod-only host running
the unit built for the dev host, so `ProtectSystem=strict` denied every write
to the production bare repo and `git fetch` aborted with exit 255.

Two further routes reached the same failure and are fixed here: a config
declaring `server:` only under `fraises.*` looked server-less to the renderer
(one unit carrying every host's trees — the #62 leak by a second route), and an
environment declaring no `server:` at all matched no logical server, so its
trees reached no unit.

### The new contract

> When any environment declares a `server:`, the tree contains **only** slugged
> `fraisier-{project}-webhook-{slug}.service` files, and the installer resolves
> the slug from the machine hostname. When no environment declares a `server:`,
> the tree contains the single unslugged file. There is no fallback from the
> first mode to the second.

The **destination** unit name is unchanged — only the source filename inside
the scaffold tree carries the host. No unit rename, no `systemctl
disable`/`enable`, no `[Install]` change. `install.sh` and the units ship from
the same render by the same version, so there is no version skew.

Full detail in the CHANGELOG entry; it carries the conditional design decision
and the two deliberate test-contract changes.

---

## ⚠️ Rollout — bumping the pin is NOT sufficient

**The fix lives in generated systemd units.** A pin bump plus webhook
self-upgrade ships the *package* and leaves the *unit* on disk untouched. Until
a scaffold regen + install runs on each host, the wrong unit stays installed
and production keeps failing exactly as before.

Sequence, in order:

1. Release fraisier v0.56.0.
2. Bump the fraisier pin in `printoptim_backend`.
3. Let the webhook self-upgrade (or upgrade it manually).
4. **Regenerate and install the scaffold on _each_ host** — this is the step
   that actually applies the fix:
   ```bash
   fraisier scaffold && sudo fraisier scaffold-install --yes
   ```
5. **Verify on printoptim.io before trusting it.** The installed base unit must
   carry the prod trees and *not* the dev/staging ones:
   ```bash
   grep ^ReadWritePaths= /etc/systemd/system/fraisier-printoptim-webhook.service
   # expect: /opt/fraisier /var/lib/fraisier /run/fraisier
   #         /var/git/api.io.git /var/www/api.io
   # expect ABSENT: /var/git/api.dev.git /var/www/api.dev /var/git/api.st.git /var/www/api.st

   fraisier doctor --check webhook_hosted_trees_writable
   ```
   Mirror the check on the dev host (dev + staging present, prod absent).
6. **Only then retire the `prod-paths.conf` drop-in.** Leaving it in place is
   harmless — a drop-in's `ReadWritePaths=` adds to the unit's list rather than
   replacing it — so remove it *after* step 5 passes, not before.

Two config preconditions this release enforces, both of which fail the render
loudly rather than silently narrowing:

- **Every environment must declare a `server:`** once any of them does.
- **`--server` must name a server some environment declares.** A typo now
  aborts instead of rendering a pathless unit.

If either trips during step 4, the deploy stops *before* the install step —
`_regenerate_scaffold` turns a non-zero scaffold exit into a `DeploymentError`,
and it now reports the render's stderr so the reason reaches the journal.

Also new for operators: `sudo fraisier doctor --probe-sandbox` spawns a
transient `ProtectSystem=strict` unit over the *rendered* allowlist and writes
into each path — a way to check a host *before* installing.

---

## Verification

- **4566 passed, 7 skipped** (+56 collected, all new). `ruff check` clean,
  repo-wide `ruff format --check .` clean (447 files), `ty check` exit 0.
- **Phase 1 established red before any source moved.** The headline failure was
  not the stale-copy story but something sharper: on a fresh tree the generated
  `install.sh` installed **no webhook unit at all**, because the copy asked for
  a file the deploy-path render never writes.
- **The deploy-path chain is pinned explicitly** (`TestTheActualDeployPathChain`):
  drives the real CLI with `_regenerate_scaffold`'s exact argv — `-c <cfg>
  scaffold --output-dir <state_dir>`, no `--server` — then runs the generated
  `install.sh` with `hostname` stubbed, and asserts the prod host lands the prod
  unit and the dev host lands the dev unit from that *same* regeneration. Two of
  its three assertions fail against the parent commit; the third (no
  host-agnostic unit is written) passes there too, which is the bug's shape
  rather than a gap — the old code also wrote only slugged files, it just had no
  installer that could find them.
- **Invariant sweep as a loop over the machine map**, not per-host literals, so
  adding a machine to a config cannot leave a hole: every machine's unit holds
  every tree it hosts (C) and no tree it does not (#62). Parametrised across all
  three `server:` declaration shapes.
- **Manual, outside the suite**: rendered a printoptim-shaped config in
  deploy-path mode (no `--server`) and ran the generated `install.sh` with
  `hostname` stubbed to `pio` then `pdev`. `ReadWritePaths=` disjoint on the env
  trees, identical on the three fraisier state dirs.

## Follow-up filed separately

`ServerSetup._resolve_allowed_environments` matches hostnames against *logical
server names* only and never reads `servers:.machine_hostnames`, so on a
printoptim-shaped box it falls through to "provision all environments" with a
warning. The webhook path no longer depends on it, but it still governs users,
directories, symlinks, app units and nginx vhosts — the same over-broad-fallback
class as #325, in a different pair of components. Deliberately out of scope
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
