### PR TITLE
fix(setup): resolve this host via machine_hostnames, and refuse when it cannot (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`fraisier setup` on an unrecognised machine no longer provisions every
+  environment** (#331). `_resolve_allowed_environments` matched the machine's
+  hostname against *logical server names* only, never against
+  `servers:.machine_hostnames` — the map that exists precisely because a
+  logical server is not a machine hostname. A config shaped like
+
+  ```yaml
+  servers:
+    printoptim-io:
+      machine_hostnames: [pio]
+  environments:
+    production: {server: printoptim-io}
+  ```
+
+  matched nothing on `pio`, and no match returned `None`, which the caller
+  reads as *provision everything*. Resolution now routes through
+  `resolve_local_server` — the sole host authority since v0.56.0 — which
+  consults `machine_hostnames` first.
+
+  **Breaking for multi-host configs:** an unresolvable host is now an error,
+  not a warning-then-widen. `setup` creates users, chowns application trees and
+  installs and **enables** systemd units and nginx vhosts; doing that for every
+  environment from a box that cannot identify itself is a refusal to answer
+  combined with maximum action, and a live candidate for how a production-only
+  host acquires development units — the #325 failure shape one level up. There
+  is no deprecation cycle because the warning already existed, already fired,
+  and #331 exists *because nobody acted on it*.
+
+  The error names this machine, lists the hosts the config knows with their
+  registered machines and environments, and prints all three exits copy-paste
+  ready: a `servers:` registration snippet, `--server <host>`, and a new
+  `--all-environments` flag for "everything, deliberately".
+
+  Unaffected: configs where **no** environment declares a `server:`. That is
+  single-host, and provisions everything as before — a separate branch, not a
+  fallback, because there "everything" and "this host's" are the same set.
+
+  Also: `--server` naming a server no environment declares is now an error
+  instead of silently widening to every environment.
+
 ## [0.56.0] - 2026-08-03
 
 Closes #325. **The webhook unit installed on a machine was not the one

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -543,19 +543,43 @@ fraisier setup [OPTIONS]
 | `--dry-run` | Show what would be provisioned without making changes |
 | `--environment ENV` | Provision only this environment |
 | `--server HOSTNAME` | Provision only environments assigned to this server |
+| `--all-environments` | Provision every environment, including ones hosted elsewhere |
 | `--yes`, `-y` | Skip confirmation prompt |
+
+`--environment`, `--server` and `--all-environments` are mutually exclusive.
+
+**Which environments get provisioned**
+
+With no selector, `setup` works out which host this machine is and provisions
+only that host's environments. It matches the machine's hostnames against
+`servers:.machine_hostnames` first, then against logical server names.
+
+- **No environment declares a `server:`** — single-host config. Every
+  environment is provisioned, because "everything" and "this host's" are the
+  same set.
+- **The machine resolves to a declared host** — only that host's environments.
+- **The machine resolves to nothing** — `setup` stops with an error naming this
+  machine and the hosts the config knows (v0.57.0, #331). It does not fall back
+  to provisioning everything: setup creates users, chowns trees and *enables*
+  systemd units and nginx vhosts, so acting on every environment from a box
+  that cannot identify itself is how a production host acquires development
+  units. Register the machine under `servers:`, name the host with `--server`,
+  or pass `--all-environments` to say "everything, deliberately".
 
 **Examples:**
 
 ```bash
-# Provision everything defined in fraises.yaml
+# Provision this host's environments (auto-detected)
 sudo fraisier setup
 
 # Provision only production
 sudo fraisier setup --environment production
 
-# Provision only environments on this host
+# Provision only environments on a named host
 sudo fraisier setup --server prod.myserver.com
+
+# Provision every environment regardless of host
+sudo fraisier setup --all-environments
 
 # Preview without changes
 fraisier setup --dry-run

--- a/fraisier/cli/setup.py
+++ b/fraisier/cli/setup.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import click
 from rich.table import Table
 
+from fraisier.errors import ValidationError
+
 from ._helpers import console, require_config
 from .main import main
 
@@ -17,6 +19,11 @@ from .main import main
     "-s",
     help="Only setup environments assigned to this server hostname",
 )
+@click.option(
+    "--all-environments",
+    is_flag=True,
+    help="Provision every environment, even ones hosted on other machines",
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
 @click.pass_context
 def setup(
@@ -24,6 +31,7 @@ def setup(
     dry_run: bool,
     environment: str | None,
     server: str | None,
+    all_environments: bool,
     yes: bool,
 ) -> None:
     """Provision server infrastructure from fraises.yaml.
@@ -31,30 +39,61 @@ def setup(
     Creates directories, symlinks bare repos, installs systemd services,
     generates webhook env files, installs nginx vhosts, and validates.
 
-    When neither --environment nor --server is given, auto-detects the
-    current hostname and provisions only the matching environments.
-    If the hostname doesn't match any ``environments.*.server`` entry,
-    all environments are provisioned (backwards-compatible).
+    When neither --environment nor --server is given, auto-detects which host
+    this machine is — via ``servers:.machine_hostnames`` first, then logical
+    server names — and provisions only that host's environments. A machine
+    that matches no declared host is an error naming the alternatives (#331);
+    pass --all-environments to provision everything deliberately. Configs
+    where no environment declares a ``server:`` are single-host and provision
+    everything, as before.
 
     \b
     Examples:
-        fraisier setup                    # auto-detect server from hostname
+        fraisier setup                    # auto-detect host, provision its envs
         fraisier setup --dry-run          # preview only
         fraisier setup --environment dev  # single environment
         fraisier setup --server host.io   # all envs on that server
+        fraisier setup --all-environments # every env, regardless of host
         fraisier setup --yes              # skip confirmation
     """
-    if environment and server:
-        raise click.UsageError("--environment and --server are mutually exclusive.")
+    exclusive = [
+        name
+        for name, given in (
+            ("--environment", bool(environment)),
+            ("--server", bool(server)),
+            ("--all-environments", all_environments),
+        )
+        if given
+    ]
+    if len(exclusive) > 1:
+        raise click.UsageError(f"{' and '.join(exclusive)} are mutually exclusive.")
 
     from fraisier.runners import LocalRunner
     from fraisier.setup import ServerSetup
 
     config = require_config(ctx)
     runner = LocalRunner()
-    server_setup = ServerSetup(config, runner, environment=environment, server=server)
+    server_setup = ServerSetup(
+        config,
+        runner,
+        environment=environment,
+        server=server,
+        all_environments=all_environments,
+    )
 
-    actions = server_setup.plan()
+    # The host-identity refusal (#331) is a message written for the operator
+    # reading it on the box; a traceback would bury it and lose the exits it
+    # spells out.
+    try:
+        actions = server_setup.plan()
+    except ValidationError as exc:
+        # markup=False on the body: it carries a YAML snippet whose
+        # `machine_hostnames: [thishost]` would otherwise be parsed as a Rich
+        # style tag and rendered as nothing, silently gutting the fix the
+        # message exists to hand over.
+        console.print("[red]Cannot determine what to provision[/red]\n")
+        console.print(str(exc), markup=False, highlight=False)
+        raise SystemExit(1) from None
 
     if not actions:
         console.print("[yellow]Nothing to do.[/yellow]")

--- a/fraisier/scaffold/renderer.py
+++ b/fraisier/scaffold/renderer.py
@@ -661,7 +661,7 @@ def _is_under_any(path: str, allowed: list[str]) -> bool:
     return any(path == a or path.startswith(a.rstrip("/") + "/") for a in allowed)
 
 
-def _local_hostnames() -> list[str]:
+def local_hostnames() -> list[str]:
     """Candidate names for this machine, longest-lived first, deduplicated."""
     names = [socket.gethostname(), socket.getfqdn()]
     names += [n.split(".", 1)[0] for n in names if n]
@@ -689,7 +689,7 @@ def resolve_local_server(config: FraisierConfig) -> str | None:
         for logical, machines in config.servers.items()
         for machine in machines
     }
-    hostnames = _local_hostnames()
+    hostnames = local_hostnames()
     for candidate in hostnames:
         if candidate in machine_to_server:
             return machine_to_server[candidate]
@@ -720,7 +720,7 @@ def local_webhook_source(config: FraisierConfig, server: str | None = None) -> s
     if resolved is None:
         raise ValidationError(
             f"Cannot tell which webhook unit this machine installs: none of "
-            f"{', '.join(_local_hostnames())} is registered under 'servers:' "
+            f"{', '.join(local_hostnames())} is registered under 'servers:' "
             f"({', '.join(sorted(webhook_machine_map(config))) or 'no machines listed'}"
             f") or named as a logical server "
             f"({', '.join(config.declared_servers())}). Add this machine under "

--- a/fraisier/setup.py
+++ b/fraisier/setup.py
@@ -10,14 +10,15 @@ import functools
 import logging
 import secrets
 import shlex
-import socket
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fraisier.config import FraisierConfig, NginxEnvConfig
-from fraisier.scaffold.renderer import ScaffoldRenderer
+from fraisier.errors import ValidationError
+from fraisier.scaffold import renderer as scaffold_renderer
+from fraisier.scaffold.renderer import ScaffoldRenderer, resolve_local_server
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,75 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from fraisier.runners import CommandRunner
+
+
+def _unknown_setup_server_message(server: str, known: list[str]) -> str:
+    """Diagnostic for a server value no environment is assigned to."""
+    if known:
+        return (
+            f"No environment declares server {server!r}, so there is nothing "
+            f"to provision for it. Known servers: {', '.join(known)}."
+        )
+    return (
+        f"Server {server!r} was selected but no environment declares a "
+        f"'server:' field, so there is nothing to filter by. Drop the filter, "
+        f"or add 'server: {server}' to the environments hosted there."
+    )
+
+
+def _unidentified_host_message(config: FraisierConfig, known: list[str]) -> str:
+    """Explain an unresolvable host and lay out every way forward.
+
+    Fail-closed replaces a warning that fired for years without being acted
+    on (#331), so the error has to carry what the warning left the operator to
+    work out: who this machine is, who the config knows, and the exact edits
+    or flags that resolve it. Everything here is copy-paste ready — an error
+    that answers its own support question is cheaper than one silent wrong
+    install.
+    """
+    # Read through the module, not a bound name: the host authority has one
+    # interception point and both resolution and this diagnostic must see the
+    # same answer, or the error would name hostnames that were never tried.
+    hostnames = scaffold_renderer.local_hostnames()
+    machines = config.servers
+    lines = [
+        f"This machine ({', '.join(repr(h) for h in hostnames)}) matches no "
+        f"host declared in fraises.yaml, so 'fraisier setup' cannot tell which "
+        f"environments belong to it.",
+        "",
+        "It will not guess. Setup creates users, chowns application trees, and "
+        "installs and enables systemd units and nginx vhosts — running all of "
+        "that for every environment is how a production host acquires "
+        "development units.",
+        "",
+        "Known hosts:",
+    ]
+    for server in known:
+        registered = ", ".join(machines.get(server, [])) or "(none registered)"
+        envs = ", ".join(config.get_environments_for_server(server))
+        lines.append(f"  {server} — machines: {registered} — environments: {envs}")
+
+    primary = hostnames[0] if hostnames else "this-machine"
+    example = known[0]
+    lines += [
+        "",
+        "Resolve it one of three ways:",
+        "",
+        "  1. Register this machine — in fraises.yaml, under the host it is:",
+        "",
+        "       servers:",
+        f"         {example}:   # <- replace with the host this machine is",
+        f"           machine_hostnames: [{primary}]",
+        "",
+        "  2. Name the host explicitly, for a one-off run:",
+        "",
+        f"       fraisier setup --server {example}",
+        "",
+        "  3. Provision every environment on this box, deliberately:",
+        "",
+        "       fraisier setup --all-environments",
+    ]
+    return "\n".join(lines)
 
 
 @dataclass
@@ -47,11 +117,13 @@ class ServerSetup:
         *,
         environment: str | None = None,
         server: str | None = None,
+        all_environments: bool = False,
     ) -> None:
         self.config = config
         self.runner = runner
         self.environment = environment
         self.server = server
+        self.all_environments = all_environments
 
     @functools.cached_property
     def _renderer(self) -> ScaffoldRenderer:
@@ -608,31 +680,53 @@ class ServerSetup:
 
         Resolution order:
         1. Explicit ``--environment`` → single environment.
-        2. Explicit ``--server`` → environments whose ``server`` field matches.
-        3. Auto-detect via hostname/FQDN → environments whose ``server`` matches.
-        4. No match → ``None`` (provision everything, backwards-compatible).
+        2. Explicit ``--all-environments`` → ``None``, deliberately unfiltered.
+        3. Explicit ``--server`` → environments whose ``server`` field matches;
+           a value no environment declares is an error, not a widening.
+        4. No environment declares a ``server:`` at all → ``None``. This is the
+           genuine single-host case, and a *branch* rather than a fallback:
+           "every environment" and "this host's environments" are the same set.
+        5. Auto-detect via :func:`resolve_local_server` — the sole host
+           authority since v0.56.0, which consults ``servers:.machine_hostnames``
+           before logical server names.
+        6. Still unresolved → :class:`ValidationError`.
+
+        Step 6 used to be ``None``, meaning *provision everything* (#331).
+        ``setup`` creates users, chowns application trees, and installs and
+        **enables** systemd units and nginx vhosts, so answering "which machine
+        am I?" with "cannot tell" and then acting on every environment is a
+        refusal to answer combined with maximum action — and a live candidate
+        for how a production-only host acquires development units, which is the
+        #325 failure shape one level up. The old warning existed, fired, and
+        was not acted on; a louder warning would have been a fourth instance.
         """
         if self.environment:
             return {self.environment}
 
+        if self.all_environments:
+            return None
+
+        known = self.config.declared_servers()
+
         if self.server:
             envs = self.config.get_environments_for_server(self.server)
-            return set(envs) if envs else None
+            if not envs:
+                raise ValidationError(_unknown_setup_server_message(self.server, known))
+            return set(envs)
 
-        # Auto-detect: try FQDN first, then short hostname.
-        hostnames = list(dict.fromkeys([socket.getfqdn(), socket.gethostname()]))
-        for hostname in hostnames:
-            envs = self.config.get_environments_for_server(hostname)
-            if envs:
-                return set(envs)
+        if not known:
+            return None
 
-        logger.warning(
-            "No server match for hostname(s) %s — provisioning all environments. "
-            "Use --server or --environment to filter, or set 'server' in your "
-            "environments config.",
-            hostnames,
-        )
-        return None
+        local = resolve_local_server(self.config)
+        if local is None:
+            raise ValidationError(_unidentified_host_message(self.config, known))
+
+        envs = self.config.get_environments_for_server(local)
+        if not envs:
+            # ``servers:`` registers this machine under a logical server that
+            # no environment is assigned to — resolvable, but to nothing.
+            raise ValidationError(_unknown_setup_server_message(local, known))
+        return set(envs)
 
     def _iter_fraise_environments(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,41 @@ def _reset_config_singleton():
 
 
 @pytest.fixture(autouse=True)
+def _unpoison_cli_get_config():
+    """Undo a mock leaked into ``fraisier.cli.main`` by import-under-patch.
+
+    ``fraisier/cli/main.py`` binds ``get_config`` with a ``from`` import at
+    module scope. A test that does::
+
+        with patch("fraisier.config.get_config", return_value=cfg):
+            from fraisier.cli.main import main
+
+    binds the *mock* into ``fraisier.cli.main`` if that import is the first
+    one in the session — and ``patch`` cannot undo it, because the name it
+    restores lives in ``fraisier.config``. Every later CLI test then runs
+    against whichever config that first test happened to build, ignoring even
+    an explicit ``-c``.
+
+    That made CLI results depend on collection order, invisibly: until #331
+    an unresolvable host provisioned everything, so a test reading the wrong
+    config still exited 0 and still passed.
+    """
+    yield
+
+    import sys
+
+    from fraisier.config import get_config as real_get_config
+
+    # Via sys.modules, not ``import fraisier.cli.main``: the package's
+    # ``from .main import main`` shadows the submodule with the click Group.
+    cli_main = sys.modules.get("fraisier.cli.main")
+    if cli_main is not None and getattr(cli_main, "get_config", None) is not (
+        real_get_config
+    ):
+        cli_main.get_config = real_get_config  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture(autouse=True)
 def _isolated_db(tmp_path, monkeypatch):
     """Ensure every test gets a fresh, isolated SQLite database.
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from fraisier.config import FraisierConfig
+from fraisier.errors import ValidationError
 from fraisier.setup import ServerSetup, SetupAction
 
 SERVER_AWARE_CONFIG = """\
@@ -682,13 +685,18 @@ class TestWebhookTemplate:
 
 class TestCLI:
     def test_dry_run_exits_cleanly(self, tmp_path):
+        # `-c`, not the get_config patch: fraisier/cli/main.py binds
+        # get_config with a `from` import, so patching fraisier.config leaves
+        # the CLI reading the repository's own fraises.yaml — a config this
+        # machine is not a declared host of, which #331 now refuses.
         config = _make_config(tmp_path, MINIMAL_CONFIG)
         runner = CliRunner()
 
-        with patch("fraisier.config.get_config", return_value=config):
-            from fraisier.cli.main import main
+        from fraisier.cli.main import main
 
-            result = runner.invoke(main, ["setup", "--dry-run"])
+        result = runner.invoke(
+            main, ["-c", str(config.config_path), "setup", "--dry-run"]
+        )
 
         assert result.exit_code == 0
         assert "actions would be executed" in result.output
@@ -697,10 +705,11 @@ class TestCLI:
         config = _make_config(tmp_path, MINIMAL_CONFIG)
         runner = CliRunner()
 
-        with patch("fraisier.config.get_config", return_value=config):
-            from fraisier.cli.main import main
+        from fraisier.cli.main import main
 
-            result = runner.invoke(main, ["setup"], input="n\n")
+        result = runner.invoke(
+            main, ["-c", str(config.config_path), "setup"], input="n\n"
+        )
 
         assert result.exit_code == 0
         assert "Aborted" in result.output
@@ -788,20 +797,23 @@ class TestServerFiltering:
         assert any("my-api-dev" in d for d in descriptions)
         assert any("my-api-stg" in d for d in descriptions)
 
-    def test_unknown_server_provisions_all(self, tmp_path):
+    def test_unknown_server_is_refused(self, tmp_path):
+        """#331: an unmatched --server used to widen to every environment."""
         config = _make_config(tmp_path, SERVER_AWARE_CONFIG)
         setup = ServerSetup(config, FakeRunner(), server="unknown.host")
-        actions = setup._plan_app_services()
 
-        assert len(actions) == 3
+        with pytest.raises(ValidationError, match=re.escape("unknown.host")):
+            setup._plan_app_services()
 
     def test_auto_detect_hostname(self, tmp_path):
         config = _make_config(tmp_path, SERVER_AWARE_CONFIG)
         setup = ServerSetup(config, FakeRunner())
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="prod.example.io"),
-            patch("fraisier.setup.socket.gethostname", return_value="prod"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["prod", "prod.example.io"],
+            ),
         ):
             actions = setup._plan_app_services()
 
@@ -818,33 +830,39 @@ class TestServerFiltering:
         setup = ServerSetup(config, FakeRunner())
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="prod.example.io"),
-            patch("fraisier.setup.socket.gethostname", return_value="prod"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["prod", "prod.example.io"],
+            ),
         ):
             actions = setup._plan_app_services()
 
         assert len(actions) == 1
         assert "my-api.service" in actions[0].description
 
-    def test_auto_detect_no_match_provisions_all(self, tmp_path):
+    def test_auto_detect_no_match_is_refused(self, tmp_path):
+        """#331: 'cannot tell which host I am' must not mean 'provision all'."""
         config = _make_config(tmp_path, SERVER_AWARE_CONFIG)
         setup = ServerSetup(config, FakeRunner())
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="other.host"),
-            patch("fraisier.setup.socket.gethostname", return_value="other"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["other", "other.host"],
+            ),
+            pytest.raises(ValidationError, match="matches no host"),
         ):
-            actions = setup._plan_app_services()
-
-        assert len(actions) == 3
+            setup._plan_app_services()
 
     def test_no_global_environments_provisions_all(self, tmp_path):
         config = _make_config(tmp_path, MINIMAL_CONFIG)
         setup = ServerSetup(config, FakeRunner())
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="any.host"),
-            patch("fraisier.setup.socket.gethostname", return_value="any"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["any", "any.host"],
+            ),
         ):
             actions = setup._plan_app_services()
 
@@ -855,8 +873,10 @@ class TestServerFiltering:
         setup = ServerSetup(config, FakeRunner(), environment="staging")
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="prod.example.io"),
-            patch("fraisier.setup.socket.gethostname", return_value="prod"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["prod", "prod.example.io"],
+            ),
         ):
             actions = setup._plan_app_services()
 
@@ -868,10 +888,12 @@ class TestServerFiltering:
         all_setup = ServerSetup(config, FakeRunner(), server="dev.example.io")
         prod_setup = ServerSetup(config, FakeRunner(), server="prod.example.io")
 
-        # Patch hostname auto-detect to not interfere
+        # Pin host auto-detect so it cannot interfere with the --server filter
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="localhost"),
-            patch("fraisier.setup.socket.gethostname", return_value="localhost"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["localhost"],
+            ),
         ):
             dev_actions = all_setup.plan()
             prod_actions = prod_setup.plan()
@@ -902,20 +924,29 @@ fraises:
         assert len(actions) == 1
         assert "development" in actions[0].description
 
-    def test_auto_detect_no_match_logs_warning(self, tmp_path, caplog):
-        """Warning is logged when hostname auto-detect finds no match (#35)."""
+    def test_auto_detect_no_match_names_the_alternatives(self, tmp_path):
+        """The #35 warning became the #331 error, and carries the way out.
+
+        The warning this replaces fired for years and was acted on by nobody,
+        which is why #331 exists at all; a louder warning would have been a
+        fourth instance of the same non-response.
+        """
         config = _make_config(tmp_path, SERVER_AWARE_CONFIG)
         setup = ServerSetup(config, FakeRunner())
 
         with (
-            patch("fraisier.setup.socket.getfqdn", return_value="other.host"),
-            patch("fraisier.setup.socket.gethostname", return_value="other"),
-            caplog.at_level("WARNING", logger="fraisier.setup"),
+            patch(
+                "fraisier.scaffold.renderer.local_hostnames",
+                return_value=["other", "other.host"],
+            ),
+            pytest.raises(ValidationError) as exc,
         ):
-            actions = setup._plan_app_services()
+            setup._plan_app_services()
 
-        assert len(actions) == 3  # All provisioned
-        assert "No server match" in caplog.text
+        message = str(exc.value)
+        assert "dev.example.io" in message
+        assert "prod.example.io" in message
+        assert "--all-environments" in message
 
 
 class TestPlanUsers:

--- a/tests/test_setup_host_gating.py
+++ b/tests/test_setup_host_gating.py
@@ -1,0 +1,265 @@
+"""``fraisier setup`` provisions this host's environments, or refuses (#331).
+
+``_resolve_allowed_environments`` used to answer "which environments am I?"
+by matching the machine's hostname against *logical server names* only. A
+config that registers its machines under ``servers:.machine_hostnames`` — the
+map that exists precisely because a logical server is not a machine hostname —
+matched nothing, and no match meant ``None``, which the caller reads as
+*provision every environment*.
+
+That is not a benign default. ``setup`` creates users, chowns trees, installs
+and **enables** systemd units and nginx vhosts; doing all of it for every
+environment on a box that could not identify itself is a refusal to answer
+combined with maximum action. It is also a live candidate for how a prod-only
+host acquires dev and staging units — the #325 failure shape, one level up.
+
+So the resolution routes through ``resolve_local_server`` (the sole host
+authority since v0.56.0) and fails closed. The genuine single-host case is a
+separate branch, not a fallback: when no environment declares a ``server:``,
+"every environment" and "this host's environments" are the same set.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.errors import ValidationError
+from fraisier.setup import ServerSetup
+
+# The asymmetric multi-host shape: one host carries two environments, the
+# other carries one. Registered by machine hostname, the way #331 reports it.
+MACHINE_REGISTERED_CONFIG = """\
+name: tp
+fraises:
+  my_api:
+    type: api
+    description: Test API
+    environments:
+      development:
+        app_path: /var/www/my-api-dev
+        systemd_service: my-api-dev.service
+        git_repo: /var/git/my-api-dev.git
+      staging:
+        app_path: /var/www/my-api-stg
+        systemd_service: my-api-stg.service
+        git_repo: /var/git/my-api-stg.git
+      production:
+        app_path: /var/www/my-api
+        systemd_service: my-api.service
+        git_repo: /var/git/my-api.git
+
+servers:
+  dev.example.io:
+    machine_hostnames: [devbox]
+  prod.example.io:
+    machine_hostnames: [pio]
+
+environments:
+  development:
+    server: dev.example.io
+  staging:
+    server: dev.example.io
+  production:
+    server: prod.example.io
+"""
+
+SINGLE_HOST_CONFIG = """\
+name: tp
+fraises:
+  my_api:
+    type: api
+    description: Test API
+    environments:
+      development:
+        app_path: /var/www/my-api-dev
+        systemd_service: my-api-dev.service
+        git_repo: /var/git/my-api-dev.git
+      production:
+        app_path: /var/www/my-api
+        systemd_service: my-api.service
+        git_repo: /var/git/my-api.git
+"""
+
+
+def _make_config(tmp_path, yaml_content: str) -> FraisierConfig:
+    p = tmp_path / "fraises.yaml"
+    p.write_text(yaml_content)
+    return FraisierConfig(str(p))
+
+
+class _NullRunner:
+    """Never invoked — these tests only build plans."""
+
+    def run(self, *args, **kwargs):
+        raise AssertionError("planning must not execute commands")
+
+
+def _hostnames(*names: str):
+    """Patch the machine's identity as ``resolve_local_server`` reads it."""
+    return patch("fraisier.scaffold.renderer.local_hostnames", return_value=list(names))
+
+
+class TestMachineHostnameResolution:
+    """A machine registered in ``servers:`` resolves to its logical server."""
+
+    def test_machine_hostname_selects_only_its_environments(self, tmp_path):
+        """`pio` is registered under prod.example.io — production only."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("pio"):
+            assert setup._resolve_allowed_environments() == {"production"}
+
+    def test_asymmetric_host_gets_both_its_environments(self, tmp_path):
+        """The other side of the asymmetry: devbox carries two environments."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("devbox"):
+            assert setup._resolve_allowed_environments() == {"development", "staging"}
+
+    def test_logical_server_name_still_resolves(self, tmp_path):
+        """Configs naming servers after their machines keep working."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("prod.example.io"):
+            assert setup._resolve_allowed_environments() == {"production"}
+
+
+class TestFailsClosed:
+    """An unresolvable host is an error, never "provision everything"."""
+
+    def test_unregistered_machine_raises(self, tmp_path):
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("stranger"), pytest.raises(ValidationError):
+            setup._resolve_allowed_environments()
+
+    def test_error_answers_its_own_support_question(self, tmp_path):
+        """Names this machine, the known hosts, and both ways forward.
+
+        A loud error that is copy-paste actionable is cheaper than one silent
+        wrong install; this is the whole justification for skipping a
+        deprecation cycle, so it is pinned rather than left to prose.
+        """
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("stranger"), pytest.raises(ValidationError) as exc:
+            setup._resolve_allowed_environments()
+
+        message = str(exc.value)
+        assert "stranger" in message
+        assert "dev.example.io" in message
+        assert "prod.example.io" in message
+        assert "--all-environments" in message
+        assert "machine_hostnames" in message
+
+    def test_explicit_server_matching_nothing_raises(self, tmp_path):
+        """`--server bogus` used to silently widen to every environment."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner(), server="bogus")
+
+        with pytest.raises(ValidationError) as exc:
+            setup._resolve_allowed_environments()
+
+        assert "bogus" in str(exc.value)
+        assert "prod.example.io" in str(exc.value)
+
+
+class TestLegitimateWideningStillWorks:
+    """Fail-closed must not break the cases that genuinely mean "everything"."""
+
+    def test_single_host_config_provisions_everything(self, tmp_path):
+        """No environment declares a server: the two sets coincide."""
+        config = _make_config(tmp_path, SINGLE_HOST_CONFIG)
+        setup = ServerSetup(config, _NullRunner())
+
+        with _hostnames("anything-at-all"):
+            assert setup._resolve_allowed_environments() is None
+
+    def test_all_environments_flag_is_the_escape_hatch(self, tmp_path):
+        """Explicit intent to provision everything is honoured without a match."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner(), all_environments=True)
+
+        with _hostnames("stranger"):
+            assert setup._resolve_allowed_environments() is None
+
+    def test_explicit_environment_bypasses_host_resolution(self, tmp_path):
+        """--environment answers the question directly; identity is moot."""
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner(), environment="staging")
+
+        with _hostnames("stranger"):
+            assert setup._resolve_allowed_environments() == {"staging"}
+
+    def test_explicit_server_selects_its_environments(self, tmp_path):
+        config = _make_config(tmp_path, MACHINE_REGISTERED_CONFIG)
+        setup = ServerSetup(config, _NullRunner(), server="dev.example.io")
+
+        assert setup._resolve_allowed_environments() == {"development", "staging"}
+
+
+class TestCliSurfacesTheRefusal:
+    """The operator reads the message on the box, not a traceback."""
+
+    def test_unresolvable_host_exits_1_with_the_guidance(self, tmp_path):
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(MACHINE_REGISTERED_CONFIG)
+
+        with _hostnames("stranger"):
+            result = CliRunner().invoke(
+                main, ["--config", str(cfg), "setup", "--dry-run"]
+            )
+
+        assert result.exit_code == 1
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "--all-environments" in result.output
+        assert "Traceback" not in result.output
+
+    def test_registration_snippet_survives_rich_markup(self, tmp_path):
+        """`machine_hostnames: [thishost]` must reach the terminal intact.
+
+        Rich reads square brackets as style tags, so the one line an operator
+        is meant to copy renders as an empty list unless markup is disabled —
+        the message would look complete and be useless.
+        """
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(MACHINE_REGISTERED_CONFIG)
+
+        with _hostnames("stranger"):
+            result = CliRunner().invoke(
+                main, ["--config", str(cfg), "setup", "--dry-run"]
+            )
+
+        assert "machine_hostnames: [stranger]" in result.output
+
+    def test_mutually_exclusive_selectors_are_rejected(self, tmp_path):
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        cfg = tmp_path / "fraises.yaml"
+        cfg.write_text(MACHINE_REGISTERED_CONFIG)
+
+        result = CliRunner().invoke(
+            main,
+            ["--config", str(cfg), "setup", "--server", "x", "--all-environments"],
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output


### PR DESCRIPTION
Closes #331.

## The bug

`ServerSetup._resolve_allowed_environments` matched the machine's hostname against **logical server names** only, never against `servers:.machine_hostnames` — the map that exists precisely because a logical server is not a machine hostname:

```yaml
servers:
  printoptim-io:
    machine_hostnames: [pio]
environments:
  production: {server: printoptim-io}
```

On `pio`, both candidates miss, and no match returned `None` — which the caller reads as **provision everything**.

## The fix

Resolution routes through `resolve_local_server`, the sole host authority since v0.56.0, which consults `machine_hostnames` before logical names.

**Behaviour change for multi-host configs:** an unresolvable host is now an error, not warning-then-widen. `setup` creates users, chowns application trees, and installs and **enables** systemd units and nginx vhosts. Doing that for every environment from a box that cannot identify itself is a refusal to answer combined with maximum action — and a live candidate for how a prod-only host acquires dev+staging units, which is the #325 failure shape one level up.

No deprecation cycle: the warning already existed, already fired, and #331 exists *because nobody acted on it*. The effort went into the error instead:

```
This machine ('archbox') matches no host declared in fraises.yaml, so
'fraisier setup' cannot tell which environments belong to it.

It will not guess. Setup creates users, chowns application trees, and installs
and enables systemd units and nginx vhosts — running all of that for every
environment is how a production host acquires development units.

Known hosts:
  printoptim-dev — machines: pdev — environments: development, staging
  printoptim-io — machines: pio — environments: production

Resolve it one of three ways:

  1. Register this machine — in fraises.yaml, under the host it is:

       servers:
         printoptim-dev:   # <- replace with the host this machine is
           machine_hostnames: [archbox]

  2. Name the host explicitly, for a one-off run:

       fraisier setup --server printoptim-dev

  3. Provision every environment on this box, deliberately:

       fraisier setup --all-environments
```

## Not affected

Configs where **no** environment declares a `server:` still provision everything. That is single-host, and it is a separate branch rather than a fallback: there, "everything" and "this host's" are the same set.

## Also here

- `--server` naming a server no environment declares is an error instead of silently widening.
- The CLI prints the message with `markup=False` — Rich reads the snippet's `machine_hostnames: [host]` as a style tag and renders it **empty**, gutting the one line the operator is meant to copy. Pinned by a test.
- `conftest`: un-poison `fraisier.cli.main.get_config`. `main.py` binds it with a `from` import, so a test doing `from fraisier.cli.main import main` *inside* `patch("fraisier.config.get_config")` leaves a dead mock bound for the rest of the session — later CLI tests then read that test's config and ignore even an explicit `-c`. It was invisible until now precisely because an unresolvable host exited 0 anyway.

## Verification

- 4587 pass, 7 skipped; `ruff check` + `format` clean; `ty check` clean (zero floor held)
- Verified end-to-end against a real config through the real CLI: unregistered box refuses with the snippet intact, registering it under a host selects only that host's environments, `--all-environments` provisions all, `--server` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)