### PR TITLE
release: v0.62.0 — a skipped check you can see (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,112 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-08-08
+
+`fraisier ship` decided whether a `triggers:` check ran by diffing the **working
+tree**. A changeset that is already committed leaves a clean tree, so the
+changed-file list was empty and **every** triggered check was skipped — with no
+output at all, because the skipped checks were filtered out before the only code
+that prints.
+
+The reporter had 12 triggered checks and a changeset touching 6 files under
+`db/`. Four ran: exactly the four with no `triggers:` at all. Among the silent
+ones was the gate blocking a schema change with no migration — the check
+specifically protecting migrate-only production.
+
+Committing before `ship` is not exotic. `git add --update` stages only tracked
+files, so a changeset adding a new file must be committed by hand; and a check
+that inspects committed history only passes once the work is committed. Together
+there was no working-tree state in which such a check both ran and passed.
+
+This is v0.61.0's theme in the tooling rather than on a host. That release was
+about units that could not fail visibly; this is a check that could not be seen
+*not* to have run.
+
+### Fixed
+
+- **Triggered checks see committed changes** (#346). The changed set is now the
+  **union** of `merge-base(HEAD, base)..HEAD` and the working-tree diff — not a
+  replacement, because checks deliberately run *before* `git add --update`, so
+  uncommitted work must keep counting. Untracked files stay out: `ship` already
+  fails outright on untracked files under `db/migrations/`, so the dangerous case
+  is covered without letting a scratch file run unrelated checks.
+
+- **"I could not tell" no longer means "nothing changed".** `_get_changed_files`
+  returned `[]` both when git failed and when nothing had changed, and `[]` was
+  read as *skip*. So a failed git invocation silently disabled every gate. The
+  changed set is three-valued now, and an undetermined one runs **every**
+  triggered check. Same rule as `db restore`'s lock ("a lock that cannot be
+  evaluated is an error, not a skip") and v0.61.0's `ArchiveVerdict.UNVERIFIABLE`.
+
+- **`--pr-base` reaches trigger evaluation.** `ShipPipeline` was built from
+  `ShipConfig` alone, and the CLI's resolved base only ever went to the
+  version-race check — and only when `--pr` was passed. So `ship --pr-base dev`
+  evaluated triggers against a different base than the PR it was about to open.
+
+- **The base is never the current branch.** `_assert_no_version_race` resolves
+  `pr_base or current_branch` and is right to, but the same fallback is fatal
+  here: on an already-pushed feature branch `merge-base(HEAD,
+  origin/<current-branch>)` is HEAD, so the diff is empty and the bug is
+  reproduced by the fallback meant to fix it. Resolution is
+  `--pr-base`/`ship.pr_base` → `origin/HEAD` → undetermined, and a test pins that
+  the current branch is not used.
+
+- **The changed set is computed once per run**, not once per check. It was called
+  from inside the per-check predicate, so N triggered checks meant N `git diff`
+  subprocesses.
+
+### Added
+
+- **A skipped check says so** — the part that let the bug live. The issue's own
+  words: *the failure is silent, which is the worst part; a skipped check is
+  indistinguishable from a passing one in the output.* Twelve checks collapsing
+  to four would have been noticed the first time it happened.
+
+  ```
+  note could not determine changed files (no ship.pr_base configured …) — running all 2 triggered check(s)
+  skip schema-gate — no file matched db/** (vs origin/main, 3 file(s) changed)
+  pass ruff (0.4s)
+  ```
+
+  The reason names the patterns, the base and the changed-file count, which is
+  what distinguishes "correctly skipped" from "skipped because the base was
+  wrong". `PipelineResult.skipped` carries them separately from `results`:
+  deliberately **not** a `CheckResult` with `success=True`, since anything
+  summing results would count a skip as a pass — the conflation this release is
+  about. A forced run under an undetermined base is announced too, once per
+  phase, because a check running for a reason nobody can see is how the next
+  person concludes `triggers:` does not work.
+
+- **The `ship:` block is documented** — `checks:`, phases, and `triggers:` were
+  not documented anywhere. The new section states what the changed set is, how
+  the base resolves, and that patterns use `fnmatch` semantics where `*` crosses
+  `/`, so `db/*` matches `db/migrations/001.sql`. That over-matches rather than
+  under-matches, so it is left as it is: tightening it would stop a check that
+  fires today, which is a regression in the direction this release is fixing.
+
+### Rollout
+
+Nothing here touches a host, a systemd unit or a database. The whole surface is
+`fraisier ship`'s local pre-commit behaviour, so upgrading changes nothing until
+the next `ship`.
+
+**A repo using `triggers:` will run more checks than it did**, which is the fix.
+Two consequences worth expecting:
+
+- **A check that has not run in a long time may fail.** The honest reading is
+  that it was never passing — this release did not break it, it stopped hiding
+  it. That is the case the reporter hit: the gate protecting migrate-only
+  production had been skipped every run.
+- **Runs are louder.** Every skipped check now prints a line. A run that skips
+  ten checks gains ten lines; a run that used to look short and green now shows
+  why it was short.
+
+If the undetermined note appears on every run, set `ship.pr_base` or run
+`git remote set-head origin -a`.
+
+Closes #346
+
 ## [0.61.0] - 2026-08-08
 
 Four issues, one shape: **work that could not fail visibly.**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1314,3 +1314,80 @@ fraisier ship major --dry-run
 # Ship without bumping (e.g. docs-only change)
 fraisier ship patch --no-bump
 ```
+
+### The `ship:` block
+
+Checks run in two phases — `fix` before staging, then `validate` and `test`
+together — and a failing phase aborts the ship before anything is committed.
+
+```yaml
+ship:
+  pr_base: main            # PR target; also the base triggers compare against
+  parallel: true
+  checks:
+    - name: ruff
+      command: [uv, run, ruff, check, .]
+      phase: fix
+    - name: pytest
+      command: [uv, run, pytest, -q]
+      phase: test
+      timeout: 600
+    - name: schema-gate
+      command: [uv, run, check-migrations]
+      phase: validate
+      triggers: ["db/**"]   # only when a matching file changed
+```
+
+#### `triggers:` — what counts as changed
+
+A check with no `triggers:` always runs. One with `triggers:` runs when any
+changed file matches any pattern. The changed set is the **union** of:
+
+- **committed** changes on this branch — `merge-base(HEAD, base)..HEAD`
+- **working-tree** changes — staged and unstaged
+
+Both halves matter. Checks run *before* `git add --update`, so uncommitted work
+has to count; and committing before `ship` is normal — `git add --update` stages
+only tracked files, so a new file must be committed by hand. Before v0.62.0 only
+the working tree was consulted, so a committed changeset left a clean tree, an
+empty changed set, and **every** triggered check silently skipped (#346).
+
+Untracked files are **not** included. `fraisier ship` already fails outright on
+untracked files under `db/migrations/`, so the dangerous case is covered without
+letting a scratch file in the tree run unrelated checks.
+
+The base is resolved in this order:
+
+1. `--pr-base` if passed, else `ship.pr_base`
+2. `origin/HEAD` — origin's default branch, a local lookup needing no network
+3. otherwise **undetermined**
+
+An undetermined base runs **every** triggered check and says so. "I cannot tell
+what changed" must never resolve to "nothing changed": a check that runs
+unnecessarily costs time, and one that skips silently costs you the gate.
+
+If you see the undetermined note on every run, set `ship.pr_base`, or
+`git remote set-head origin -a` to give `origin/HEAD` something to resolve to.
+
+#### Pattern matching
+
+Patterns use Python's `fnmatch`, where **`*` crosses `/`** — so `db/*` matches
+`db/migrations/001.sql`, which a gitignore-literate reader would not expect. It
+over-matches rather than under-matches, so a check runs more often than the
+pattern suggests. That is the safe direction and it is left as it is
+deliberately; write `db/**` if you mean "anything under `db/`", and read a bare
+`*` as "anything at all after this point".
+
+#### Reading the output
+
+```
+  note could not determine changed files (no ship.pr_base configured and origin/HEAD does not resolve) — running all 2 triggered check(s)
+  skip schema-gate — no file matched db/** (vs origin/main, 3 file(s) changed)
+  pass ruff (0.4s)
+  FAIL pytest (12.1s)
+```
+
+A `skip` line names the patterns that did not match, the base it compared
+against, and how many files changed — enough to tell "correctly skipped" from
+"skipped because the base was wrong". A skipped check is never counted as a
+pass.

--- a/fraisier/cli/version.py
+++ b/fraisier/cli/version.py
@@ -426,7 +426,15 @@ def _ship_commit_push_deploy(
     race_base = resolved_pr_base if create_pr else None
 
     _ship_with_pipeline(
-        version, ship_config, expected_base_version, bump_kind, race_base, apply_bump
+        version,
+        ship_config,
+        expected_base_version,
+        bump_kind,
+        race_base,
+        apply_bump,
+        # #346: triggers need the resolved base whether or not a PR is being
+        # created, so this is `resolved_pr_base` rather than `race_base`.
+        trigger_base=resolved_pr_base,
     )
 
     if create_pr:
@@ -666,6 +674,7 @@ def _ship_with_pipeline(
     bump_kind: str | None,
     race_base: str | None,
     apply_bump: Callable[[], None] | None = None,
+    trigger_base: str | None = None,
 ) -> None:
     """Ship using the check pipeline (--no-verify commit).
 
@@ -677,6 +686,12 @@ def _ship_with_pipeline(
     *apply_bump*, when given, writes the version bump to disk. It is invoked
     only after every check phase passes (issue #253), so a failed check leaves
     a clean working tree. ``None`` for ``ship --no-bump`` (nothing to write).
+
+    *trigger_base* is the branch `triggers:` are evaluated against (#346). It
+    is distinct from *race_base*, which is deliberately ``None`` unless ``--pr``
+    was passed: a run without ``--pr`` has no version race to lose but still has
+    triggered checks to select. Passing one for the other would evaluate
+    triggers against nothing on every non-PR ship.
     """
     import subprocess
 
@@ -685,7 +700,7 @@ def _ship_with_pipeline(
 
     config = ship_config or _ShipConfig()
     cwd = Path.cwd()
-    pipeline = ShipPipeline(config, cwd, console)
+    pipeline = ShipPipeline(config, cwd, console, pr_base=trigger_base)
 
     # Pre-flight: detect untracked migration files that git add --update
     # would silently leave behind (see issue #181)

--- a/fraisier/ship/pipeline.py
+++ b/fraisier/ship/pipeline.py
@@ -35,6 +35,54 @@ class PipelineResult:
     duration_seconds: float = 0.0
 
 
+@dataclass(frozen=True)
+class TriggerScope:
+    """The files this ship touches, or the fact that we cannot tell (#346).
+
+    ``files is None`` and ``files == frozenset()`` are **different**, and
+    keeping them apart is the whole point. Empty means "this ship touches
+    nothing, so a triggered check correctly does not run". ``None`` means "I
+    could not determine it, so run everything rather than nothing".
+
+    Before #346 both were ``[]`` and both skipped every triggered check —
+    so a failed ``git`` invocation was indistinguishable from a no-op ship,
+    and both resolved to the reading that runs no gates. The project's rule
+    is the opposite: an unevaluable condition is never silently resolved.
+    See ``db restore``'s lock ("a lock that cannot be evaluated is an error,
+    not a skip") and v0.61.0's ``ArchiveVerdict.UNVERIFIABLE``.
+    """
+
+    files: frozenset[str] | None
+    base: str | None
+    detail: str
+
+    @property
+    def undetermined(self) -> bool:
+        """Nothing is known about what changed.
+
+        Branch on this rather than on the truthiness of :attr:`files`, which
+        cannot tell "no changes" from "no idea" — the conflation #346 was
+        filed for.
+        """
+        return self.files is None
+
+    def matches(self, patterns: list[str]) -> bool:
+        """Whether any changed file matches any of *patterns*.
+
+        ``fnmatch`` semantics, deliberately unchanged (#346): ``*`` crosses
+        ``/``, so ``db/*`` matches ``db/migrations/001.sql`` where a
+        gitignore-literate reader would expect ``db/**``. That over-matches,
+        which runs checks more often than the pattern suggests — the safe
+        direction. Tightening it would stop a check that fires today, which is
+        a regression in exactly the direction this issue is about.
+        """
+        if self.files is None:  # pragma: no cover - callers check undetermined
+            return True
+        return any(
+            fnmatch.fnmatch(f, pattern) for f in self.files for pattern in patterns
+        )
+
+
 class ShipPipeline:
     """Run ship checks in phases: fix → validate+test."""
 
@@ -43,10 +91,18 @@ class ShipPipeline:
         config: ShipConfig,
         cwd: Path,
         console: Console,
+        pr_base: str | None = None,
     ) -> None:
         self._config = config
         self._cwd = cwd
         self._console = console
+        # `--pr-base` never reached trigger evaluation before #346: the pipeline
+        # was built from ShipConfig alone, and the CLI's resolved base was only
+        # threaded to the version-race check (and only when --pr was passed). A
+        # run with `--pr-base dev` therefore evaluated triggers against a
+        # different base than the PR it was about to open.
+        self._pr_base = pr_base if pr_base is not None else config.pr_base
+        self._scope: TriggerScope | None = None
 
     def check_untracked_migrations(self, migrations_dir: Path) -> PipelineResult:
         """Fail if untracked files exist in the migrations directory.
@@ -102,22 +158,27 @@ class ShipPipeline:
 
     def run_verify_phase(self) -> PipelineResult:
         """Run validate + test checks concurrently (after staging)."""
-        checks = [
-            c
-            for c in self._config.checks
-            if c.phase in ("validate", "test") and self._should_run(c)
-        ]
-        if not checks:
-            return PipelineResult(success=True)
-        return self._execute_checks(checks, phase_label="validate+test")
+        return self._run_phases(("validate", "test"), phase_label="validate+test")
 
     def _run_phase(self, phase: str) -> PipelineResult:
-        checks = [
-            c for c in self._config.checks if c.phase == phase and self._should_run(c)
-        ]
-        if not checks:
+        return self._run_phases((phase,), phase_label=phase)
+
+    def _run_phases(
+        self, phases: tuple[str, ...], *, phase_label: str
+    ) -> PipelineResult:
+        """Partition this phase's checks into to-run and skipped.
+
+        The partition is kept rather than discarded. Filtering with a
+        comprehension threw the skipped checks away before `_execute_checks`,
+        which is the only thing that prints — so a skipped check produced no
+        output at all and the run just looked short and green (#346).
+        """
+        scope = self.trigger_scope()
+        selected = [c for c in self._config.checks if c.phase in phases]
+        to_run = [c for c in selected if self._should_run(c, scope)]
+        if not to_run:
             return PipelineResult(success=True)
-        return self._execute_checks(checks, phase_label=phase)
+        return self._execute_checks(to_run, phase_label=phase_label)
 
     def _execute_checks(
         self,
@@ -155,29 +216,120 @@ class ShipPipeline:
             duration_seconds=duration,
         )
 
-    def _should_run(self, check: ShipCheckConfig) -> bool:
-        """Check if a triggered check should run based on changed files."""
+    def _should_run(self, check: ShipCheckConfig, scope: TriggerScope) -> bool:
+        """Whether *check* runs, given what this ship is known to touch.
+
+        A pure predicate over *scope*, so the decision is testable without a
+        repository — and so the scope is resolved once per run rather than once
+        per check, which is what it was before #346.
+        """
         if check.triggers is None:
             return True
-        changed = self._get_changed_files()
-        if not changed:
-            return False
-        return any(
-            fnmatch.fnmatch(f, pattern) for f in changed for pattern in check.triggers
+        if scope.undetermined:
+            # "I cannot tell what changed" must never resolve to "nothing
+            # changed". Running a check unnecessarily costs time; skipping one
+            # silently cost the reporter the gate protecting migrate-only
+            # production.
+            return True
+        return scope.matches(check.triggers)
+
+    def trigger_scope(self) -> TriggerScope:
+        """The changed set for this run, resolved once and reused."""
+        if self._scope is None:
+            self._scope = self._compute_trigger_scope()
+        return self._scope
+
+    def _resolve_trigger_base(self) -> tuple[str | None, str]:
+        """The ref to compare against, most explicit source first.
+
+        ``--pr-base``/``ship.pr_base`` → ``origin/HEAD`` → nothing. The second
+        step is a local ref lookup needing no network, so a repo with no
+        ``ship.pr_base`` still filters correctly instead of degrading to
+        "run everything".
+
+        Deliberately **not** ``pr_base or current_branch``.
+        ``_assert_no_version_race`` resolves it that way and is right to, but
+        here it is fatal: on an already-pushed feature branch
+        ``merge-base(HEAD, origin/<current-branch>)`` is HEAD, so the diff is
+        empty and #346 is reproduced by the fallback meant to fix it.
+        """
+        if self._pr_base:
+            return f"origin/{self._pr_base}", f"ship.pr_base={self._pr_base}"
+
+        head = subprocess.run(
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            cwd=self._cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if head.returncode == 0 and head.stdout.strip():
+            return head.stdout.strip(), "origin/HEAD"
+
+        return None, (
+            "no ship.pr_base configured and origin/HEAD does not resolve "
+            "(try `git remote set-head origin -a`)"
         )
 
-    def _get_changed_files(self) -> list[str]:
-        """Get list of changed files (staged + unstaged)."""
+    def _git_files(self, *args: str) -> list[str] | None:
+        """``git`` output as a file list, or ``None`` if the command failed.
+
+        ``None`` rather than ``[]``: the old code collapsed a failed invocation
+        into an empty list, which read as "nothing changed" and skipped every
+        gate.
+        """
         result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
+            ["git", *args],
             cwd=self._cwd,
             capture_output=True,
             text=True,
             check=False,
         )
         if result.returncode != 0:
-            return []
+            return None
         return [line for line in result.stdout.strip().split("\n") if line]
+
+    def _compute_trigger_scope(self) -> TriggerScope:
+        """Committed changes on this branch, unioned with the working tree.
+
+        A union rather than a replacement: the pipeline runs its checks *before*
+        ``git add --update`` and before the commit, so uncommitted work must
+        keep counting. Committed work has to count too, which is #346 — a
+        changeset committed before ``ship`` left a clean tree and an empty diff.
+
+        Untracked files are excluded; ``check_untracked_migrations`` (#181)
+        already fails a ship whose migrations directory has untracked files, and
+        including every untracked file would let a scratch file run unrelated
+        checks.
+        """
+        base, why = self._resolve_trigger_base()
+
+        worktree = self._git_files("diff", "--name-only", "HEAD")
+        if worktree is None:
+            return TriggerScope(None, None, "git diff failed (not a git tree?)")
+
+        if base is None:
+            return TriggerScope(None, None, why)
+
+        merge_base = subprocess.run(
+            ["git", "merge-base", "HEAD", base],
+            cwd=self._cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if merge_base.returncode != 0 or not merge_base.stdout.strip():
+            return TriggerScope(
+                None, base, f"no merge base with {base} (unfetched or unrelated?)"
+            )
+
+        committed = self._git_files(
+            "diff", "--name-only", f"{merge_base.stdout.strip()}..HEAD"
+        )
+        if committed is None:
+            return TriggerScope(None, base, f"git diff against {base} failed")
+
+        return TriggerScope(frozenset(committed) | frozenset(worktree), base, why)
 
     def _print_result(self, result: CheckResult) -> None:
         status = "[green]pass[/green]" if result.success else "[red]FAIL[/red]"

--- a/fraisier/ship/pipeline.py
+++ b/fraisier/ship/pipeline.py
@@ -25,6 +25,21 @@ if TYPE_CHECKING:
 _FAILURE_TAIL_LINES = 30
 
 
+@dataclass(frozen=True)
+class SkippedCheck:
+    """A check that did not run, and why (#346).
+
+    Deliberately **not** a :class:`CheckResult` with ``success=True``. That is
+    precisely the conflation this issue is about — anything summing ``results``
+    would count a skip as a pass, which is how twelve checks collapsing to four
+    went unnoticed. Same reasoning as v0.61.0's ``CleanupOutcome.invalid`` being
+    an overlay rather than a fourth partition member.
+    """
+
+    name: str
+    reason: str
+
+
 @dataclass
 class PipelineResult:
     """Aggregate result of the full ship pipeline."""
@@ -33,6 +48,8 @@ class PipelineResult:
     failed_phase: str | None = None
     results: list[CheckResult] = field(default_factory=list)
     duration_seconds: float = 0.0
+    skipped: list[SkippedCheck] = field(default_factory=list)
+    """Checks filtered out by their ``triggers:``. Never counted as passes."""
 
 
 @dataclass(frozen=True)
@@ -166,19 +183,51 @@ class ShipPipeline:
     def _run_phases(
         self, phases: tuple[str, ...], *, phase_label: str
     ) -> PipelineResult:
-        """Partition this phase's checks into to-run and skipped.
+        """Partition this phase's checks into to-run and skipped, and say which.
 
         The partition is kept rather than discarded. Filtering with a
-        comprehension threw the skipped checks away before `_execute_checks`,
+        comprehension threw the skipped checks away before ``_execute_checks``,
         which is the only thing that prints — so a skipped check produced no
-        output at all and the run just looked short and green (#346).
+        output at all and the run just looked short and green (#346). The
+        issue's own headline: a skipped check was indistinguishable from a
+        passing one.
         """
         scope = self.trigger_scope()
-        selected = [c for c in self._config.checks if c.phase in phases]
-        to_run = [c for c in selected if self._should_run(c, scope)]
+        to_run: list[ShipCheckConfig] = []
+        skipped: list[SkippedCheck] = []
+
+        triggered = [c for c in self._config.checks if c.phase in phases and c.triggers]
+        if scope.undetermined and triggered:
+            # Said once per phase rather than per check: the reason is a property
+            # of the run, and repeating a long sentence N times buries it. But it
+            # is said — a check running for a reason nobody can see is how the
+            # next person concludes that `triggers:` does not work.
+            self._console.print(
+                f"  [yellow]note[/yellow] could not determine changed files "
+                f"({scope.detail}) — running all {len(triggered)} triggered check(s)"
+            )
+
+        for check in self._config.checks:
+            if check.phase not in phases:
+                continue
+            if check.triggers is None or scope.undetermined:
+                to_run.append(check)
+                continue
+            if scope.matches(check.triggers):
+                to_run.append(check)
+                continue
+            reason = (
+                f"no file matched {', '.join(check.triggers)} "
+                f"(vs {scope.base}, {len(scope.files or ())} file(s) changed)"
+            )
+            skipped.append(SkippedCheck(name=check.name, reason=reason))
+            self._print_skip(check.name, reason)
+
         if not to_run:
-            return PipelineResult(success=True)
-        return self._execute_checks(to_run, phase_label=phase_label)
+            return PipelineResult(success=True, skipped=skipped)
+        result = self._execute_checks(to_run, phase_label=phase_label)
+        result.skipped = skipped
+        return result
 
     def _execute_checks(
         self,
@@ -330,6 +379,10 @@ class ShipPipeline:
             return TriggerScope(None, base, f"git diff against {base} failed")
 
         return TriggerScope(frozenset(committed) | frozenset(worktree), base, why)
+
+    def _print_skip(self, name: str, reason: str) -> None:
+        """A skip line, shaped like the pass/FAIL lines beside it (#346)."""
+        self._console.print(f"  [yellow]skip[/yellow] {name} — {reason}")
 
     def _print_result(self, result: CheckResult) -> None:
         status = "[green]pass[/green]" if result.success else "[red]FAIL[/red]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.61.0"
+version = "0.62.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_ship_pipeline.py
+++ b/tests/test_ship_pipeline.py
@@ -11,10 +11,18 @@ from rich.console import Console
 
 from fraisier.config import ShipCheckConfig, ShipConfig
 from fraisier.ship.checks import CheckResult, run_check
-from fraisier.ship.pipeline import ShipPipeline
+from fraisier.ship.pipeline import ShipPipeline, TriggerScope
 
 if TYPE_CHECKING:
     import pytest
+
+
+def _scope(files: list[str], *, base: str = "origin/main") -> TriggerScope:
+    """A resolved scope over *files*. See test_ship_trigger_scope.py for the
+    real-repository tests behind base resolution and the union diff."""
+    return TriggerScope(
+        files=frozenset(files), base=base, detail=f"ship.pr_base={base}"
+    )
 
 
 def _make_check(
@@ -164,11 +172,18 @@ class TestShipPipeline:
         assert result.success
         assert mock_check.call_count == 2
 
-    @patch("fraisier.ship.pipeline.ShipPipeline._get_changed_files")
+    @patch("fraisier.ship.pipeline.ShipPipeline._compute_trigger_scope")
     @patch("fraisier.ship.pipeline.run_check")
     def test_trigger_filtering_skips_unmatched(self, mock_check, mock_changed):
-        """Checks with triggers are skipped when no files match."""
-        mock_changed.return_value = ["src/main.py"]
+        """Checks with triggers are skipped when no files match.
+
+        Patches `_compute_trigger_scope` (#346). This test used to patch
+        `_get_changed_files` — the method that held the bug — so it asserted
+        filtering against a changed set that could never be empty, and the
+        empty-set path that skipped every gate in production had no coverage at
+        all. Stubbing the thing under suspicion is how a green suite hid this.
+        """
+        mock_changed.return_value = _scope(["src/main.py"])
         mock_check.return_value = CheckResult(
             name="x", success=True, output="", duration_seconds=0.1
         )
@@ -185,11 +200,11 @@ class TestShipPipeline:
         assert result.success
         mock_check.assert_not_called()
 
-    @patch("fraisier.ship.pipeline.ShipPipeline._get_changed_files")
+    @patch("fraisier.ship.pipeline.ShipPipeline._compute_trigger_scope")
     @patch("fraisier.ship.pipeline.run_check")
     def test_trigger_filtering_runs_matched(self, mock_check, mock_changed):
         """Checks with triggers run when files match."""
-        mock_changed.return_value = ["db/migrations/001.sql"]
+        mock_changed.return_value = _scope(["db/migrations/001.sql"])
         mock_check.return_value = CheckResult(
             name="x", success=True, output="", duration_seconds=0.1
         )

--- a/tests/test_ship_skip_visibility.py
+++ b/tests/test_ship_skip_visibility.py
@@ -1,0 +1,160 @@
+"""A check that did not run says so (#346).
+
+This is the half that let the bug live. The issue's own headline is **"the
+failure is silent, which is the worst part: a skipped check is
+indistinguishable from a passing one in the output."** Twelve checks collapsing
+to four would have been noticed the first time it happened had the skips been
+visible.
+
+Fixing only the changed-set calculation would leave the next trigger bug just as
+invisible, so the reporting is tested separately and on its own terms.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from rich.console import Console
+
+from fraisier.config import ShipCheckConfig, ShipConfig
+from fraisier.ship.checks import CheckResult
+from fraisier.ship.pipeline import ShipPipeline, TriggerScope
+
+
+def _check(name: str, triggers: list[str] | None = None) -> ShipCheckConfig:
+    return ShipCheckConfig(
+        name=name, command=["true"], phase="validate", triggers=triggers
+    )
+
+
+def _run(checks, scope: TriggerScope):
+    """Run the verify phase with *scope* stubbed, returning (result, output)."""
+    buffer = io.StringIO()
+    pipeline = ShipPipeline(
+        config=ShipConfig(checks=list(checks), parallel=False),
+        cwd=__import__("pathlib").Path(),
+        console=Console(file=buffer, width=200, no_color=True),
+    )
+    with (
+        patch.object(ShipPipeline, "_compute_trigger_scope", return_value=scope),
+        patch(
+            "fraisier.ship.pipeline.run_check",
+            side_effect=lambda c, _cwd: CheckResult(
+                name=c.name, success=True, output="", duration_seconds=0.1
+            ),
+        ),
+    ):
+        result = pipeline.run_verify_phase()
+    return result, buffer.getvalue()
+
+
+_RESOLVED = TriggerScope(
+    files=frozenset({"src/a.py", "src/b.py"}),
+    base="origin/main",
+    detail="ship.pr_base=main",
+)
+_UNDETERMINED = TriggerScope(
+    files=None, base=None, detail="no ship.pr_base configured and origin/HEAD ..."
+)
+
+
+class TestASkippedCheckIsVisible:
+    def test_the_skipped_check_is_named(self):
+        result, output = _run([_check("db-lint", ["db/**"])], _RESOLVED)
+
+        assert result.success
+        assert "db-lint" in output
+        assert "skip" in output.lower()
+
+    def test_every_skipped_check_gets_its_own_line(self):
+        checks = [
+            _check("db-lint", ["db/**"]),
+            _check("schema-gate", ["db/migrations/**"]),
+            _check("proto-gate", ["proto/**"]),
+        ]
+        _, output = _run(checks, _RESOLVED)
+
+        for name in ("db-lint", "schema-gate", "proto-gate"):
+            assert name in output, f"{name} was skipped without a word"
+
+    def test_the_reason_names_the_pattern_the_base_and_the_count(self):
+        """ "no file matched" alone is what an operator reads as fine."""
+        _, output = _run([_check("db-lint", ["db/**"])], _RESOLVED)
+
+        assert "db/**" in output
+        assert "origin/main" in output
+        assert "2" in output, "the changed-file count is what makes it checkable"
+
+    def test_an_untriggered_check_prints_nothing_extra(self):
+        _, output = _run([_check("ruff")], _RESOLVED)
+
+        assert "skip" not in output.lower()
+        assert "pass" in output.lower()
+
+    def test_a_matching_check_is_not_reported_as_skipped(self):
+        _, output = _run([_check("py-lint", ["src/**"])], _RESOLVED)
+
+        assert "skip" not in output.lower()
+
+
+class TestAForcedRunIsVisibleToo:
+    """The safe fallback has to be a legible one.
+
+    A check running for a reason nobody can see is how the next person
+    concludes that `triggers:` does not work.
+    """
+
+    def test_undetermined_runs_the_check_and_says_why(self):
+        result, output = _run([_check("db-lint", ["db/**"])], _UNDETERMINED)
+
+        assert result.success
+        assert len(result.results) == 1, "the check must actually run"
+        assert "db-lint" in output
+        assert "origin/HEAD" in output or "could not determine" in output.lower()
+
+    def test_undetermined_does_not_report_a_skip(self):
+        _, output = _run([_check("db-lint", ["db/**"])], _UNDETERMINED)
+
+        assert "skip" not in output.lower()
+
+
+class TestASkipIsNeverAPass:
+    def test_skipped_checks_are_not_in_results(self):
+        result, _ = _run([_check("db-lint", ["db/**"])], _RESOLVED)
+
+        assert result.results == [], (
+            "a skipped check in `results` is the exact conflation #346 is about"
+        )
+
+    def test_skipped_checks_are_carried_separately(self):
+        result, _ = _run([_check("db-lint", ["db/**"])], _RESOLVED)
+
+        assert [s.name for s in result.skipped] == ["db-lint"]
+        assert result.skipped[0].reason
+
+    def test_a_phase_of_only_skips_still_succeeds(self):
+        """Skipping is not failing — a no-op ship is a real, valid outcome."""
+        result, _ = _run(
+            [_check("db-lint", ["db/**"]), _check("proto", ["proto/**"])], _RESOLVED
+        )
+
+        assert result.success
+        assert result.failed_phase is None
+        assert len(result.skipped) == 2
+
+    def test_a_pass_and_a_skip_are_distinguishable_in_the_result(self):
+        result, _ = _run([_check("ruff"), _check("db-lint", ["db/**"])], _RESOLVED)
+
+        assert [r.name for r in result.results] == ["ruff"]
+        assert [s.name for s in result.skipped] == ["db-lint"]
+
+
+class TestExistingOutputIsUnchanged:
+    def test_pass_lines_keep_their_shape(self):
+        _, output = _run([_check("ruff")], _RESOLVED)
+
+        assert "pass" in output
+        assert "ruff" in output
+        assert "0.1s" in output

--- a/tests/test_ship_trigger_scope.py
+++ b/tests/test_ship_trigger_scope.py
@@ -1,0 +1,304 @@
+"""Which files does this ship touch, and can we tell? (#346)
+
+`ship` decided whether a `triggers:` check ran by diffing the **working tree**.
+A changeset that is already committed leaves a clean tree, so the changed-file
+list was empty and *every* triggered check was skipped — silently, because
+`_run_phase` filtered them out before the only code that prints. The reporter
+had 12 triggered checks and a changeset touching 6 files under `db/`; four ran,
+being exactly the four with no `triggers:` at all. One of the silent ones was
+the gate blocking a schema change with no migration.
+
+These tests drive **real git repositories** rather than mocking
+`subprocess.run`. The defect is *which git command runs*, so a mock asserting
+"we invoked `git diff HEAD`" would have passed happily against the broken code.
+The pre-existing tests patch `_get_changed_files` wholesale, which is precisely
+why neither the empty-list path nor the command itself was ever covered.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from fraisier.ship.pipeline import ShipPipeline
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _write(repo: Path, rel: str, text: str = "x\n") -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with a `main` base branch and a `feature` branch checked out.
+
+    Modelled on the reporter's situation: an `origin` remote exists (a bare
+    clone on disk, so nothing touches the network) and `origin/main` is the PR
+    target.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-b", "main")
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "T")
+    _git(work, "config", "commit.gpgsign", "false")
+    _write(work, "README.md", "base\n")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "base")
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-u", "origin", "main")
+    _git(work, "checkout", "-b", "feature")
+    return work
+
+
+def _pipeline(repo: Path, *, pr_base: str | None = None, checks=()) -> ShipPipeline:
+    import io
+
+    from rich.console import Console
+
+    from fraisier.config import ShipConfig
+
+    return ShipPipeline(
+        config=ShipConfig(checks=list(checks), pr_base=pr_base),
+        cwd=repo,
+        console=Console(file=io.StringIO()),
+    )
+
+
+def _scope(repo: Path, **kwargs):
+    return _pipeline(repo, **kwargs).trigger_scope()
+
+
+class TestCommittedChangesCount:
+    """The reported defect, driven end to end."""
+
+    def test_a_committed_change_on_a_clean_tree_is_seen(self, repo: Path):
+        _write(repo, "db/migrations/001.sql", "select 1;\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "add migration")
+        assert _git(repo, "status", "--porcelain") == "", "tree should be clean"
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.undetermined is False
+        assert "db/migrations/001.sql" in scope.files
+
+    def test_several_committed_files_are_all_seen(self, repo: Path):
+        for name in ("db/a.sql", "db/b.sql", "src/main.py"):
+            _write(repo, name)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "six files")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.files == frozenset({"db/a.sql", "db/b.sql", "src/main.py"})
+
+
+class TestTheSetIsAUnion:
+    """Checks run before `git add --update`, so uncommitted work still counts."""
+
+    def test_working_tree_only_changes_are_seen(self, repo: Path):
+        _write(repo, "README.md", "edited\n")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.undetermined is False
+        assert "README.md" in scope.files
+
+    def test_committed_and_uncommitted_are_unioned(self, repo: Path):
+        _write(repo, "db/migrations/001.sql", "select 1;\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "committed")
+        _write(repo, "README.md", "edited too\n")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.files == frozenset({"db/migrations/001.sql", "README.md"})
+
+    def test_a_staged_but_uncommitted_change_is_seen(self, repo: Path):
+        _write(repo, "src/new.py")
+        _git(repo, "add", "-A")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert "src/new.py" in scope.files
+
+    def test_a_file_in_both_halves_appears_once(self, repo: Path):
+        _write(repo, "db/a.sql", "one\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "committed")
+        _write(repo, "db/a.sql", "one then two\n")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.files == frozenset({"db/a.sql"})
+
+
+class TestEmptyIsNotUndetermined:
+    """A ship that touches nothing is a real, knowable answer."""
+
+    def test_no_changes_at_all_is_determined_and_empty(self, repo: Path):
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.undetermined is False
+        assert scope.files == frozenset()
+
+    def test_an_unresolvable_merge_base_is_undetermined(self, repo: Path):
+        """Not empty. `[]` was the old answer and it silently skipped."""
+        scope = _scope(repo, pr_base="a-branch-that-does-not-exist")
+
+        assert scope.undetermined is True
+        assert scope.files is None
+
+    def test_a_tree_that_is_not_a_repo_is_undetermined(self, tmp_path: Path):
+        not_a_repo = tmp_path / "bare"
+        not_a_repo.mkdir()
+
+        scope = _scope(not_a_repo)
+
+        assert scope.undetermined is True
+
+
+class TestBaseResolutionOrder:
+    def test_explicit_pr_base_is_used(self, repo: Path):
+        _write(repo, "db/a.sql")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "c")
+
+        scope = _scope(repo, pr_base="main")
+
+        assert scope.base == "origin/main"
+
+    def test_origin_head_is_the_fallback(self, repo: Path):
+        """No `ship.pr_base`: a local ref lookup still resolves the base.
+
+        Falling straight to "run everything" here would make every repo without
+        `ship.pr_base` run every triggered check on every ship.
+        """
+        _git(repo, "remote", "set-head", "origin", "main")
+        _write(repo, "db/a.sql")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "c")
+
+        scope = _scope(repo)
+
+        assert scope.undetermined is False
+        assert scope.base == "origin/main"
+        assert "db/a.sql" in scope.files
+
+    def test_no_base_and_no_origin_head_is_undetermined(self, repo: Path):
+        _git(repo, "remote", "remove", "origin")
+
+        scope = _scope(repo)
+
+        assert scope.undetermined is True
+        assert scope.detail
+
+    def test_the_current_branch_is_never_the_base(self, repo: Path):
+        """The trap in the obvious fallback.
+
+        `_assert_no_version_race` resolves `pr_base or current_branch`, which is
+        right for a version race. Here it is fatal: on a pushed feature branch
+        `merge-base(HEAD, origin/<current-branch>)` is HEAD, so the diff is
+        empty and the original bug is reproduced by the fallback meant to fix
+        it.
+        """
+        _write(repo, "db/a.sql")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "c")
+        _git(repo, "push", "-u", "origin", "feature")
+        _git(repo, "remote", "set-head", "origin", "main")
+
+        scope = _scope(repo)
+
+        assert scope.base != "origin/feature"
+        assert "db/a.sql" in scope.files, (
+            "resolved against the current branch: merge-base is HEAD, so the "
+            "committed change vanished — this is #346 reproduced"
+        )
+
+
+class TestTheCliBaseReachesTriggerEvaluation:
+    """`--pr-base` was invisible to triggers before #346.
+
+    `ShipPipeline` was built from `ShipConfig` alone, and the CLI's resolved
+    base only ever reached the version-race check — and only when `--pr` was
+    passed. So `ship --pr-base dev` evaluated triggers against a different base
+    than the PR it was about to open, which is this issue again in a new place.
+    """
+
+    def test_explicit_argument_overrides_the_config(self, repo: Path):
+        pipeline = _pipeline(repo, pr_base="main")
+        overridden = ShipPipeline(
+            config=pipeline._config,
+            cwd=repo,
+            console=pipeline._console,
+            pr_base="other",
+        )
+        assert overridden._pr_base == "other"
+
+    def test_config_is_the_fallback(self, repo: Path):
+        assert _pipeline(repo, pr_base="main")._pr_base == "main"
+
+    def test_ship_passes_the_resolved_base_not_the_race_base(self):
+        """The race base is None without `--pr`; the trigger base must not be.
+
+        A non-PR ship has no version race to lose but still has triggered
+        checks to select, so reusing `race_base` here would switch triggers off
+        for every `ship` without `--pr`.
+        """
+        import inspect
+
+        from fraisier.cli import version as version_mod
+
+        source = inspect.getsource(version_mod._ship_commit_push_deploy)
+        assert "trigger_base=resolved_pr_base" in source, (
+            "triggers must be evaluated against the resolved base, not race_base"
+        )
+
+
+class TestComputedOncePerRun:
+    def test_three_triggered_checks_resolve_the_scope_once(self, repo: Path):
+        from unittest.mock import patch
+
+        from fraisier.config import ShipCheckConfig
+
+        checks = [
+            ShipCheckConfig(
+                name=f"c{i}", command=["true"], phase="validate", triggers=["db/**"]
+            )
+            for i in range(3)
+        ]
+        pipeline = _pipeline(repo, pr_base="main", checks=checks)
+
+        with patch.object(
+            ShipPipeline,
+            "_compute_trigger_scope",
+            wraps=pipeline._compute_trigger_scope,
+        ) as compute:
+            pipeline.run_verify_phase()
+
+        assert compute.call_count == 1, (
+            f"resolved the changed set {compute.call_count} times for 3 checks"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.61.0"
+version = "0.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
`fraisier ship` decided whether a `triggers:` check ran by diffing the **working
tree**. A changeset already committed leaves a clean tree, so the changed-file
list was empty and **every** triggered check was skipped — with no output at all,
because skipped checks were filtered out before the only code that prints.

The reporter had 12 triggered checks and 6 changed files under `db/`. Four ran:
exactly the four with no `triggers:`. Among the silent ones was the gate blocking
a schema change with no migration.

This is v0.61.0's theme in the tooling rather than on a host. That release was
about units that could not fail visibly; this is a check that could not be seen
*not* to have run.

## Four defects, not one

**1. The diff was against the wrong thing** (reported). The changed set is now the
**union** of `merge-base(HEAD, base)..HEAD` and the working-tree diff — not a
replacement, because checks deliberately run *before* `git add --update`, so
uncommitted work must keep counting.

**2. A git failure was indistinguishable from "nothing changed"** (found).
`_get_changed_files` returned `[]` on a non-zero exit, and `[]` was read as
*skip* — so a failed git invocation silently disabled every gate. The changed set
is three-valued now; undetermined runs **everything**.

**3. The skip was silent** (found — the issue's own headline). Every skipped check
now prints a line naming the patterns, the base and the changed-file count.

**4. The changed set was computed once per check** (found), so N triggered checks
meant N `git diff` subprocesses.

Plus two that fell out of the fix: `--pr-base` never reached trigger evaluation
(only the version-race check, and only with `--pr`), and the obvious
`pr_base or current_branch` fallback is a **trap** — on a pushed feature branch
`merge-base(HEAD, origin/<current-branch>)` is HEAD, so the diff is empty and the
bug is reproduced by the fallback meant to fix it. A test pins that.

## Output

```
note could not determine changed files (no ship.pr_base configured …) — running all 2 triggered check(s)
skip schema-gate — no file matched db/** (vs origin/main, 3 file(s) changed)
pass ruff (0.4s)
```

`PipelineResult.skipped` carries skips separately from `results` — deliberately
**not** a `CheckResult` with `success=True`, since anything summing results would
count a skip as a pass, which is the conflation this release is about.

## Deliberately not changed

`fnmatch` semantics: `*` crosses `/`, so `db/*` matches `db/migrations/001.sql`.
That over-matches, so checks run more often than the pattern suggests — the safe
direction. Tightening it would stop a check that fires today, a regression in the
direction this release fixes. Documented instead.

## Blast radius

Nothing touches a host, a unit or a database. The whole surface is `ship`'s local
pre-commit behaviour.

**A repo using `triggers:` will run more checks**, which is the fix. Expect two
things: a check that has not run in a long time may fail — it was never passing,
this release stopped hiding it — and runs are louder, because a run that used to
look short and green now shows why it was short.

**Self-check:** this repo ships with `fraisier ship`. Its own three checks carry
no `triggers:`, so they always ran and still do, and `ship.pr_base: main` is set.
The fix cannot block its own release.

## Verification

Each gate redirected with its own exit status read — no pipes, no `&&` chain.

```
pytest      exit 0 — 5018 passed, 7 skipped
ruff check  exit 0 — clean, 471 files
ruff format exit 0 — 471 files already formatted
ty check    exit 0 — zero diagnostics
```

Collected counts compared against `origin/main` in a detached worktree:
4996 → 5025 (+29), matching +29 passing.

Tests drive **real git repositories** rather than mocking `subprocess.run`: the
defect is *which git command runs*, so a mock asserting "we invoked `git diff
HEAD`" passes against the broken code. The two pre-existing trigger tests patched
`_get_changed_files` — the method that held the bug — which is why the empty-set
path that skipped every gate in production had no coverage at all.

Also new: the `ship:` config block is documented. `checks:`, phases and
`triggers:` were not documented anywhere.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)