### PR TITLE
release: v0.63.0 — an install that killed the deploy that asked for it (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-08-09
+
+**An install that killed the deploy that asked for it.**
+
+When a deploy synced a changed `fraises.yaml`, it regenerated and installed the
+scaffold *in process*, and `install.sh` then ran
+`systemctl restart <project>-webhook.service` — SIGTERMing the very process
+running the deploy. The webhook does not exit while a deploy is in flight, so
+systemd's 90-second stop timeout expired, the process was SIGKILLed, and the
+deploy died mid-flight. **Any change to `fraises.yaml` failed its own deploy,
+deterministically**, and reported as "timeout waiting for deployment" — which
+reads as slow rather than killed.
+
+This is v0.61.0 and v0.62.0's theme once more — *work that could not fail
+visibly* — with the reporter itself destroyed. So this release states the
+invariant rather than patching the site:
+
+> **Nothing fraisier installs may terminate the work that asked for it, and work
+> that starts must end in a record.**
+
+### Fixed
+
+- **`install.sh` no longer restarts a unit that hosts a deploy while a deploy is
+  in flight** ([#349](https://github.com/fraiseql/fraisier/issues/349)). Every
+  such restart now goes through one seam, and a test asserts nothing bypasses it
+  — with a meta-test proving the guard can fail, because a tree-scanning guard
+  that silently matches nothing is indistinguishable from a passing one.
+- **The deploy sockets were the same bug, unreported.** There are *two*
+  deploy-hosting units, not one: the webhook, and a deploy socket's
+  `<stem>@N.service` instance running `fraisier deploy-daemon`. The generated
+  deploy service carries `Requires=<its socket>`, and systemd propagates an
+  explicit restart of a required unit to its dependents — the identical
+  mechanism behind the scaffold-install-helper self-restart race guarded since
+  v0.47.0. Routing them through the seam costs nothing: those restarts exist
+  because a *first-time* install wipes `/run/fraisier/`, and a first-time
+  install is by construction a state with no deploy in flight.
+- **The declaration reaches `install.sh` on every path.** The existing
+  `FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER` marker only exists on the helper-socket
+  path; the subprocess fallback runs `install.sh` as a child of the deploy, where
+  the restart kills the whole cgroup just the same. The deploy now declares
+  itself in the socket request payload *and* in the subprocess environment, and
+  `fraisier scaffold-install` re-states it as `install.sh --deploy-in-flight` —
+  `sudo` resets the environment, and that was the one hop that mattered. The
+  helper honours only a literal JSON `true`, mapped to a fixed variable name: the
+  request reaches a daemon running as root.
+- **`install.sh` also probes the deployment locks itself**, so the decision does
+  not rest on a claim it cannot check. The probe opens existing lock files
+  read-only and never creates one — a root-owned lock file is one the deploy user
+  cannot reopen for writing. An unevaluable probe resolves to "no deploy is
+  running", loudly and deliberately: the authoritative signal is the caller's
+  declaration, which is never unevaluable, and a backstop that cannot run must
+  not block the manual re-bake that is the documented remedy for a stale unit.
+
+### Added
+
+- **A deferred restart is a debt, and the deploy pays it.** Skipping the restart
+  alone would leave the webhook on its previous unit — old `ReadWritePaths=`, old
+  `Environment=` — so a `fraises.yaml` change adding an environment would make
+  the *next* deploy fail on a read-only filesystem. That is the "rendered ≠
+  installed" class v0.57.0 and v0.58.0 were about. The units are recorded in
+  `<deployment.lock_dir>/.deferred-restarts`, and at the end of the deploy a
+  detached worker raises the `.draining` flag, waits for the locks to release and
+  restarts over the systemctl-helper socket — the same sequence the self-upgrade
+  path already used, now shared rather than duplicated.
+- **A `deferred_restarts` doctor check.** An entry is cleared only when its
+  restart succeeded, so anything left is visible: a timed-out drain, a unit the
+  helper refuses (it allowlists services, not sockets), or a deploy run by
+  `deploy-daemon`, whose detached worker can die with its per-connection cgroup.
+  That bound is written down rather than implied.
+- **A killed deploy leaves a record.** `DeploymentStatusFile` gains
+  `owner_pid`, `owner_boot_id` and `owner_invocation_id`. The kernel releases the
+  flock when a deploy is SIGKILLed, so the *lock* recovered from the kill while
+  the record did not: it sat at `deploying` forever and `fraisier status` painted
+  it blue with a growing elapsed time, indistinguishable from a deploy that was
+  working. The webhook now reconciles orphaned records at startup — the restart
+  that kills a deploy is itself what brings the reconciler up — into a new
+  terminal state **`interrupted`**, which is in `FAILURE_STATES`.
+- `interrupted` is deliberately not `failed`: the deploy's own failure path never
+  ran, so nothing rolled back, `version.json` was not restored, and the tree may
+  be half-deployed. `owner_invocation_id` is not used to decide liveness; it is
+  recorded so an operator can recover the dead deploy's journal with
+  `journalctl _SYSTEMD_INVOCATION_ID=<id>`.
+
+### Changed
+
+- **Units are only reinstalled and restarted when their bytes changed.** Both of
+  the reporter's failing changesets edited `ship:` definitions and touched
+  nothing reaching the webhook unit, so most `fraises.yaml` edits now restart
+  nothing at all — and a rollback that reinstalls the previous config cancels its
+  own debt.
+- `read_status` ignores keys it does not know. A self-upgrade puts two fraisier
+  versions on one host by design, and `DeploymentStatusFile(**data)` turned a
+  field added by the newer one into a `TypeError` that took `fraisier status`
+  down with it.
+- Output is louder in the same direction as v0.62.0: every deferral prints the
+  unit and the signal that caused it, every unchanged unit says it was skipped,
+  and a restart that *does* happen announces that it terminates whatever is
+  running inside the unit — so a deploy killed by an older host still names its
+  cause in the journal.
+
+### Upgrade notes
+
+Nothing here adds or removes units, and a host that never changes `fraises.yaml`
+during a deploy behaves exactly as before. Hosts that do will see their
+config-changing deploys succeed for the first time, followed by a webhook restart
+once the deploy finishes rather than during it. Run `fraisier doctor` after
+upgrading: a unit deferred and never restarted is now reported instead of
+silently running an old configuration.
+
 ## [0.62.0] - 2026-08-08
 
 `fraisier ship` decided whether a `triggers:` check ran by diffing the **working

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -738,6 +738,29 @@ list them with their owner; `--prune-foreign` disables and deletes them.
 | `--verbose`, `-v` | Enable verbose output |
 | `--prune-foreign` | Disable and delete units owned by a fraise that does not run on this host. Never happens by default; run `scaffold-diff` first to see what would go. |
 
+**Restarts under a live deploy** (v0.63.0)
+
+A deploy runs `install.sh` whenever `fraises.yaml` changed, and it runs it from
+*inside* the unit hosting that deploy — the webhook, or a deploy socket's
+`deploy-daemon` instance. Restarting either from there SIGKILLs the deploy that
+asked for the install, which is why any `fraises.yaml` change used to fail its
+own deploy ([#349](https://github.com/fraiseql/fraisier/issues/349)).
+
+`install.sh` now defers those restarts while a deploy is in flight, prints what
+it deferred, and records it in `<deployment.lock_dir>/.deferred-restarts`. The
+deploy pays that back when it finishes: a detached worker waits for the
+deployment locks to drain, then restarts over the systemctl-helper socket. An
+entry is cleared only when its restart succeeded, and `fraisier doctor`'s
+`deferred_restarts` check reports whatever is left — see
+[restarts a deploy defers](doctor.md#restarts-a-deploy-defers).
+
+Units are also only reinstalled and restarted when their bytes actually changed,
+so most `fraises.yaml` edits now restart nothing at all.
+
+Running this command by hand is unaffected: no deploy holds a lock, so every
+restart happens as before. `install.sh --deploy-in-flight` is how fraisier tells
+it otherwise across the `sudo` boundary; it is not a flag to pass yourself.
+
 **Examples:**
 
 ```bash

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -42,6 +42,7 @@ passed.
 | `scaffold_artifact_coverage` | every artifact the manifest declares for this host is installed | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
 | `foreign_units` | no `fraisier` unit on this host belongs to a fraise or environment this host does not own | no | `sudo fraisier scaffold-install --prune` — see [one host authority](deployment-guide.md#scheduled-timers-you-switch-on) |
 | `webhook_hosted_trees_writable` | the installed webhook unit's `ReadWritePaths=` covers every tree it deploys | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
+| `deferred_restarts` | no unit is installed-and-daemon-reloaded while still running its previous version | no | `sudo systemctl restart <unit>` once no deploy is in flight — see [restarts a deploy defers](#restarts-a-deploy-defers) |
 | `sandbox_write_probe` | actually writes into the rendered unit's sandbox under `ProtectSystem=strict` | no | opt-in via `--probe-sandbox`; needs root, else `skip` |
 
 The catalog above is **complete**, and a test asserts it: every name in
@@ -74,6 +75,30 @@ this check to say.
   rendered fragment via `fraisier.scaffold.sudoers_diff.diff_sudoers`.
 - No check prints secret values. `fraises_yaml_resolves` lists env-var
   *names* that are unset, never values.
+
+## Restarts a deploy defers
+
+`install.sh` will not restart a unit that hosts a deploy while a deploy is in
+flight. The webhook runs deploys as in-process background tasks and a deploy
+socket propagates a restart to the `deploy-daemon` instance running one, so
+restarting either would SIGKILL the deploy that asked for the install — which is
+how a `fraises.yaml` change used to fail its own deploy, deterministically.
+
+It records what it skipped in `<deployment.lock_dir>/.deferred-restarts` and
+prints it. The deploy pays that back when it finishes: a detached worker raises
+the `.draining` flag, waits for the deployment locks to release, and sends the
+restart over the systemctl-helper socket. **A ledger entry is cleared only when
+its restart succeeded**, so `deferred_restarts` warns about anything left:
+
+- the drain timed out and the restart was not attempted;
+- the systemctl helper refused the unit — it allowlists services, not sockets;
+- the deploy ran under the socket-activated `deploy-daemon`, whose per-connection
+  service instance can take the detached worker down with its cgroup.
+
+A unit in that state works, on its previous configuration. What it costs is a
+stale `ReadWritePaths=` or `Environment=`, which surfaces later as a deploy
+failing on a read-only filesystem rather than as anything pointing back here.
+Restart the named units once no deploy is running.
 
 ## JSON output
 

--- a/fraisier/cli/_info.py
+++ b/fraisier/cli/_info.py
@@ -10,7 +10,12 @@ import click
 from rich.table import Table
 from rich.tree import Tree
 
-from fraisier.status import elapsed_seconds, read_status
+from fraisier.status import (
+    NON_TERMINAL_STATES,
+    elapsed_seconds,
+    owner_is_gone,
+    read_status,
+)
 
 from ._helpers import _get_deployer, console
 from .main import main
@@ -185,6 +190,13 @@ def status(
     _show_single_status(config, fraise, environment)
 
 
+#: A deploy that was killed did not run its own failure path: nothing rolled
+#: back and version.json was not restored, so this is louder than "failed".
+_INTERRUPTED = (
+    "[bold red]INTERRUPTED — deploy was killed, nothing rolled back[/bold red]"
+)
+
+
 def _compute_deployment_state(
     fraise_name: str, current: str | None, latest: str | None
 ) -> str:
@@ -192,11 +204,20 @@ def _compute_deployment_state(
     # Check status file for active deployment states
     status = read_status(fraise_name)
     if status:
+        if status.state in NON_TERMINAL_STATES and owner_is_gone(status):
+            # The record says a deploy is running and its process is gone: it
+            # was terminated rather than failing, so nothing rolled back. Read
+            # without writing — this path runs as whichever user typed the
+            # command, which may not own the status dir. The webhook's startup
+            # reconciler is what makes it stick (#349).
+            return _INTERRUPTED
         if status.state == "deploying":
             elapsed = elapsed_seconds(status)
             if elapsed is not None:
                 return f"[blue]deploying ({int(elapsed)}s)[/blue]"
             return "[blue]deploying[/blue]"
+        elif status.state == "interrupted":
+            return _INTERRUPTED
         elif status.state == "pending":
             return "[yellow]pending[/yellow]"
         elif status.state == "failed":

--- a/fraisier/cli/scaffold.py
+++ b/fraisier/cli/scaffold.py
@@ -241,6 +241,33 @@ def scaffold(
         console.print("     fraisier scaffold-install --yes        # Install")
 
 
+def _build_install_cmd(
+    install_script: str,
+    *,
+    dry_run: bool,
+    validate_only: bool,
+    verbose: bool,
+) -> list[str]:
+    """Build the ``sudo install.sh`` argv.
+
+    ``FRAISIER_DEPLOY_IN_FLIGHT`` is re-stated as ``--deploy-in-flight`` because
+    this is the one hop where the environment does not survive: a deploy sets
+    the variable, this process inherits it, and ``sudo`` resets it before
+    ``install.sh`` ever sees it. Without the flag, install.sh would restart the
+    webhook that is running the deploy invoking it (#349).
+    """
+    cmd: list[str] = ["sudo", install_script]
+    if dry_run:
+        cmd.append("--dry-run")
+    if validate_only:
+        cmd.append("--validate-only")
+    if verbose:
+        cmd.append("--verbose")
+    if os.environ.get("FRAISIER_DEPLOY_IN_FLIGHT"):
+        cmd.append("--deploy-in-flight")
+    return cmd
+
+
 def _run_script(cmd: list[str]) -> int:
     """Run a script and return the exit code."""
     try:
@@ -500,14 +527,12 @@ def scaffold_install(
             )
             raise SystemExit(1) from exc
 
-    # Build the command
-    cmd: list[str] = ["sudo", str(install_script)]
-    if dry_run:
-        cmd.append("--dry-run")
-    if validate_only:
-        cmd.append("--validate-only")
-    if verbose:
-        cmd.append("--verbose")
+    cmd = _build_install_cmd(
+        str(install_script),
+        dry_run=dry_run,
+        validate_only=validate_only,
+        verbose=verbose,
+    )
 
     # Show what will happen
     if validate_only:

--- a/fraisier/deferred_restart.py
+++ b/fraisier/deferred_restart.py
@@ -1,0 +1,234 @@
+"""Pay the restarts ``install.sh`` deferred because a deploy was in flight (#349).
+
+``install.sh`` may not restart a unit that hosts a deploy — doing so kills the
+deploy that asked for the install. So it records what it did not restart in
+``{lock_dir}/.deferred-restarts`` and leaves the units installed, daemon-reloaded
+and still running their previous version.
+
+That state is a debt, not a fix. A webhook running its old unit carries the old
+``ReadWritePaths=`` and ``Environment=``, so a ``fraises.yaml`` change that adds
+an environment leaves it unable to write the new ``app_path`` and the *next*
+deploy fails on a read-only filesystem. The debt is paid here: once the deploy
+releases its lock, a detached worker drains and sends the restart over the
+systemctl-helper socket, reusing the sequence :mod:`fraisier.drain_restart`
+already performs for the self-upgrade restart.
+
+**A ledger entry is cleared only when its restart succeeded.** A unit the helper
+refuses — deploy sockets are not in its allowlist — stays recorded, so
+``fraisier doctor`` keeps reporting a unit that is installed and not running.
+
+Scope, stated: the worker is spawned from the webhook's deploy path, where it
+outlives the process that spawned it. A deploy run by the socket-activated
+``deploy-daemon`` exits with its per-connection service instance, and systemd
+kills that instance's cgroup — so a worker spawned there may not survive its own
+drain. The ledger is what covers that: it is not cleared, and ``doctor`` reports
+it until an operator or a later webhook deploy pays it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from fraisier.drain_restart import (
+    DEFAULT_DRAIN_POLL_S,
+    DEFAULT_DRAIN_SETTLE_S,
+    DEFAULT_DRAIN_TIMEOUT_S,
+    DEFAULT_LOCK_DIR,
+    DRAIN_TIMEOUT_RC,
+    draining_flag,
+    send_restart,
+    wait_for_deploys_to_drain,
+)
+
+log = logging.getLogger(__name__)
+
+#: Lives beside ``.draining`` in the lock dir, and dot-prefixed for the same
+#: reason: ``count_held_deployment_locks`` globs ``*.lock`` and must not see it.
+DEFERRED_RESTART_FILE = ".deferred-restarts"
+
+#: No RPC channel, so the debt could not even be attempted.
+NO_SOCKET_RC = 3
+
+
+def read_deferred_restarts(lock_dir: Path) -> list[str]:
+    """Units ``install.sh`` installed but did not restart, in recorded order."""
+    path = Path(lock_dir) / DEFERRED_RESTART_FILE
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        # A debt we cannot read must not break the deploy that just succeeded.
+        # `doctor` reads the same file and reports the failure in its own right.
+        log.warning("could not read deferred restarts at %s: %s", path, exc)
+        return []
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def settle_deferred_restarts(lock_dir: Path, *, paid: list[str]) -> None:
+    """Drop the units whose restart succeeded; keep everything else on the books."""
+    path = Path(lock_dir) / DEFERRED_RESTART_FILE
+    remaining = [u for u in read_deferred_restarts(lock_dir) if u not in set(paid)]
+    try:
+        if not remaining:
+            path.unlink(missing_ok=True)
+            return
+        path.write_text("".join(f"{u}\n" for u in remaining))
+    except OSError as exc:
+        log.warning("could not update deferred restarts at %s: %s", path, exc)
+
+
+def run_deferred_restarts(
+    socket_path: str,
+    *,
+    lock_dir: Path,
+    drain_timeout_s: int = DEFAULT_DRAIN_TIMEOUT_S,
+    drain_poll_s: float = DEFAULT_DRAIN_POLL_S,
+    drain_settle_s: float = DEFAULT_DRAIN_SETTLE_S,
+) -> int:
+    """Drain, then restart every unit on the ledger. Returns a worker exit code."""
+    pending = read_deferred_restarts(lock_dir)
+    if not pending:
+        return 0
+    if not socket_path:
+        log.warning(
+            "deferred-restart: FRAISIER_SYSTEMCTL_SOCKET not set; %s still needs "
+            "a restart. Run: sudo systemctl restart %s",
+            ", ".join(pending),
+            " ".join(pending),
+        )
+        return NO_SOCKET_RC
+
+    # The flag covers settle + drain so dispatch refuses new deploys for the
+    # whole window, exactly as the self-upgrade worker does.
+    with draining_flag(Path(lock_dir)):
+        # Brief settle so a deploy accepted in the dispatch->lock window reaches
+        # `with deployment_lock(...)` before we count.
+        time.sleep(drain_settle_s)
+        result = wait_for_deploys_to_drain(
+            Path(lock_dir), drain_timeout_s, drain_poll_s
+        )
+        if not result.drained:
+            log.warning(
+                "deferred-restart: drain timeout (%ds) — held locks: %s; %s still "
+                "needs a restart and stays recorded for `fraisier doctor`.",
+                drain_timeout_s,
+                ", ".join(result.held),
+                ", ".join(pending),
+            )
+            return DRAIN_TIMEOUT_RC
+
+    paid = [unit for unit in pending if send_restart(socket_path, unit) == 0]
+    settle_deferred_restarts(Path(lock_dir), paid=paid)
+    unpaid = [unit for unit in pending if unit not in set(paid)]
+    if unpaid:
+        log.warning(
+            "deferred-restart: could not restart %s (the systemctl helper "
+            "allowlists services, not sockets). Restart manually: sudo systemctl "
+            "restart %s",
+            ", ".join(unpaid),
+            " ".join(unpaid),
+        )
+        return 1
+    log.info("deferred-restart: restarted %s", ", ".join(paid))
+    return 0
+
+
+def maybe_apply_deferred_restarts(
+    *,
+    lock_dir: Path,
+    socket_path: str,
+    drain_timeout_s: int = DEFAULT_DRAIN_TIMEOUT_S,
+    drain_poll_s: float = DEFAULT_DRAIN_POLL_S,
+    drain_settle_s: float = DEFAULT_DRAIN_SETTLE_S,
+) -> None:
+    """Best-effort: spawn the detached worker when a debt is recorded.
+
+    Never raises. This runs at the end of a deploy, and a failure to schedule a
+    restart must not turn a deploy that succeeded into one that reports failure —
+    the ledger survives either way and ``doctor`` reports it.
+    """
+    try:
+        pending = read_deferred_restarts(lock_dir)
+        if not pending:
+            return
+        if not socket_path:
+            log.warning(
+                "deferred-restart: no systemctl-helper socket configured; %s is "
+                "installed but still running its previous version. Restart it "
+                "manually, or run `fraisier doctor` to see the pending set.",
+                ", ".join(pending),
+            )
+            return
+        log.info(
+            "deferred-restart: %s pending; draining before restart", ", ".join(pending)
+        )
+        cmd = [
+            sys.executable,
+            "-m",
+            "fraisier.deferred_restart",
+            "--socket",
+            socket_path,
+            "--lock-dir",
+            str(lock_dir),
+            "--drain-timeout",
+            str(drain_timeout_s),
+            "--drain-poll",
+            str(drain_poll_s),
+            "--drain-settle",
+            str(drain_settle_s),
+        ]
+        # start_new_session so the worker survives the restart it is about to
+        # request, the same reason the self-upgrade worker detaches.
+        subprocess.Popen(
+            cmd,
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        log.exception("deferred-restart: could not schedule the pending restarts")
+
+
+def _main() -> None:  # pragma: no cover - exercised via run_deferred_restarts
+    parser = argparse.ArgumentParser(prog="fraisier.deferred_restart")
+    parser.add_argument(
+        "--socket", default=os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", "")
+    )
+    parser.add_argument("--lock-dir", default=DEFAULT_LOCK_DIR, dest="lock_dir")
+    parser.add_argument(
+        "--drain-timeout",
+        type=int,
+        default=DEFAULT_DRAIN_TIMEOUT_S,
+        dest="drain_timeout",
+    )
+    parser.add_argument(
+        "--drain-poll", type=float, default=DEFAULT_DRAIN_POLL_S, dest="drain_poll"
+    )
+    parser.add_argument(
+        "--drain-settle",
+        type=float,
+        default=DEFAULT_DRAIN_SETTLE_S,
+        dest="drain_settle",
+    )
+    args = parser.parse_args()
+    sys.exit(
+        run_deferred_restarts(
+            args.socket,
+            lock_dir=Path(args.lock_dir),
+            drain_timeout_s=args.drain_timeout,
+            drain_poll_s=args.drain_poll,
+            drain_settle_s=args.drain_settle,
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _main()

--- a/fraisier/deployers/base.py
+++ b/fraisier/deployers/base.py
@@ -598,7 +598,15 @@ class BaseDeployer(ABC):
                 _socket_mod.AF_UNIX, _socket_mod.SOCK_STREAM
             ) as sock:
                 sock.connect(socket_path)
-                sock.sendall(b'{"action": "install"}\n')
+                # `deploy_in_flight` tells install.sh that restarting a
+                # deploy-hosting unit would terminate its own caller (#349).
+                # It travels in the payload because the helper runs as a
+                # separate root service and does not inherit this process's
+                # environment. An older helper ignores the extra key.
+                sock.sendall(
+                    json.dumps({"action": "install", "deploy_in_flight": True}).encode()
+                    + b"\n"
+                )
                 with sock.makefile("rb") as f:
                     raw = f.readline()
             response = json.loads(raw.decode())
@@ -652,6 +660,14 @@ class BaseDeployer(ABC):
 
         logger.info("Installing updated scaffold files")
 
+        # The subprocess fallback runs install.sh as a child of this process, so
+        # an unguarded `systemctl restart <webhook>` in it kills this deploy with
+        # the rest of the cgroup — the socket path is not the only one that needs
+        # the declaration (#349). Merged onto os.environ because LocalRunner
+        # hands `env` straight to subprocess.run, which replaces rather than
+        # extends the environment.
+        install_env = {**os.environ, "FRAISIER_DEPLOY_IN_FLIGHT": "1"}
+
         if config_path:
             config_path = Path(config_path)
 
@@ -684,13 +700,16 @@ class BaseDeployer(ABC):
                     "--yes",
                 ],
                 cwd=str(config_path.parent),
+                env=install_env,
             )
         else:
             logger.warning(
                 "No config_path provided to _install_scaffold(); CWD may be wrong"
             )
             fraisier_exe = self._get_fraisier_executable()
-            result = self.runner.run([fraisier_exe, "scaffold-install", "--yes"])
+            result = self.runner.run(
+                [fraisier_exe, "scaffold-install", "--yes"], env=install_env
+            )
 
         if result.returncode != 0:
             raise DeploymentError(f"Failed to install scaffold files: {result.stdout}")

--- a/fraisier/deployers/mixins.py
+++ b/fraisier/deployers/mixins.py
@@ -20,7 +20,12 @@ from fraisier.git.operations import (
     fetch_and_checkout,
     get_worktree_sha,
 )
-from fraisier.status import DEFAULT_STATUS_DIR, DeploymentStatusFile, write_status
+from fraisier.status import (
+    DEFAULT_STATUS_DIR,
+    DeploymentStatusFile,
+    current_owner,
+    write_status,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -394,10 +399,14 @@ class GitDeployMixin:
 
     def _write_status(self, state: str, **kwargs: Any) -> None:
         """Write deployment status file."""
+        # Stamped on every write, not only the first: the record must always
+        # name a process a reader can look for, so a deploy killed mid-flight is
+        # distinguishable from one still running (#349).
         status = DeploymentStatusFile(
             fraise_name=self.fraise_name,
             environment=self.environment,
             state=state,
+            **current_owner(),
             **kwargs,
         )
         try:

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -977,3 +977,47 @@ def _check_backup_retention(config: FraisierConfig | None) -> CheckResult:
             f"{', '.join(entry.dir for entry in missing)}"
         ),
     )
+
+
+@register_check("deferred_restarts")
+def _check_deferred_restarts(config: FraisierConfig | None) -> CheckResult:
+    """Units installed by a deploy and still running their previous version.
+
+    ``install.sh`` may not restart a unit that hosts a deploy — the webhook runs
+    deploys in process, so restarting it mid-deploy SIGKILLs the deploy that
+    asked for the install (#349). It records what it deferred instead, and the
+    deploy pays that back once its lock releases.
+
+    This is the backstop for a debt that was never paid: a drain that timed out,
+    a unit the systemctl helper refuses (it allowlists services, not sockets), or
+    a deploy run by the socket-activated ``deploy-daemon``, whose detached worker
+    can be killed with its own per-connection service instance.
+
+    ``warn``, not ``fail``: the host is running, just on an older unit. What it
+    costs is a stale ``ReadWritePaths=`` or ``Environment=``, which is how a
+    later deploy meets a read-only filesystem.
+    """
+    name = "deferred_restarts"
+    if config is None:
+        return CheckResult(name, "skip", "no config loaded")
+
+    from fraisier.deferred_restart import read_deferred_restarts
+
+    lock_dir = getattr(getattr(config, "deployment", None), "lock_dir", None)
+    if not lock_dir:
+        return CheckResult(name, "skip", "no deployment.lock_dir configured")
+
+    pending = read_deferred_restarts(Path(lock_dir))
+    if not pending:
+        return CheckResult(name, "pass", f"nothing pending under {lock_dir}")
+
+    return CheckResult(
+        name,
+        "warn",
+        f"installed but not restarted: {', '.join(pending)}",
+        fix_hint=(
+            "these units are on disk and daemon-reloaded but are running their "
+            "previous version; restart them once no deploy is in flight: "
+            f"sudo systemctl restart {' '.join(pending)}"
+        ),
+    )

--- a/fraisier/drain_restart.py
+++ b/fraisier/drain_restart.py
@@ -1,0 +1,105 @@
+"""Restart a unit only once the deploys running inside it have finished.
+
+Restarting a unit that hosts a deploy kills that deploy: the webhook runs its
+deploys as in-process background tasks and does not exit while one is running,
+so systemd's stop timeout expires and the process is SIGKILLed (#349). The
+sequence that avoids it is always the same — raise the ``.draining`` flag so no
+new deploy is accepted, wait for the in-flight ones to release their locks, then
+send the restart over the systemctl-helper socket.
+
+Extracted from :mod:`fraisier.webhook_self_upgrade`, which needed exactly this
+for the self-upgrade restart, so the deferred restarts recorded by ``install.sh``
+share one implementation rather than growing a second one that drifts.
+
+Scope, as before: the drain is correct for ``lock_backend=file`` (the default).
+On ``lock_backend=database`` hosts no ``*.lock`` file exists, so the drain loop
+sees nothing held and proceeds immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from fraisier.locking import DRAINING_FLAG_NAME, count_held_deployment_locks
+from fraisier.service_managers.systemd import _call_via_socket
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Iterator
+    from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: Distinct from install-failure rc=1 / restart-RPC-failure rc=1 so operators
+#: scanning a per-event log can tell drain-timeout apart at a glance.
+DRAIN_TIMEOUT_RC = 2
+
+DEFAULT_DRAIN_TIMEOUT_S = 600
+DEFAULT_DRAIN_POLL_S = 1.0
+DEFAULT_DRAIN_SETTLE_S = 2.0
+DEFAULT_LOCK_DIR = "/run/fraisier"
+
+
+@dataclass(frozen=True)
+class DrainResult:
+    drained: bool
+    held: list[str]
+
+
+@contextmanager
+def draining_flag(lock_dir: Path) -> Iterator[Path]:
+    """Touch ``{lock_dir}/.draining`` on entry; always unlink on exit.
+
+    Only one worker may hold this at a time: the flag is a single file and the
+    exit unlinks it unconditionally, so a second concurrent holder would have
+    its flag cleared by the first one to finish. Callers coordinate by never
+    spawning two workers for one deploy.
+    """
+    flag = lock_dir / DRAINING_FLAG_NAME
+    flag.touch()
+    try:
+        yield flag
+    finally:
+        flag.unlink(missing_ok=True)
+
+
+def held_lock_basenames(lock_dir: Path) -> list[str]:
+    """Names of ``*.lock`` files currently present — used for timeout logging."""
+    if not lock_dir.exists():
+        return []
+    return sorted(p.name for p in lock_dir.glob("*.lock"))
+
+
+def wait_for_deploys_to_drain(
+    lock_dir: Path,
+    timeout_s: float,
+    poll_s: float,
+) -> DrainResult:
+    """Block until no ``*.lock`` is flock'd, or the deadline expires.
+
+    Returns a :class:`DrainResult` so callers can log which locks are still
+    held on timeout (the helper does not parse ``/proc/locks`` for holder
+    PIDs — basenames are enough to identify which fraise hung).
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        held = count_held_deployment_locks(lock_dir)
+        if held == 0:
+            return DrainResult(drained=True, held=[])
+        if time.monotonic() >= deadline:
+            return DrainResult(drained=False, held=held_lock_basenames(lock_dir))
+        time.sleep(poll_s)
+
+
+def send_restart(socket_path: str, service: str) -> int:
+    """Send the ``restart`` RPC, returning 0 on success and 1 on failure."""
+    try:
+        _call_via_socket(socket_path, "restart", service)
+    except (ConnectionRefusedError, subprocess.CalledProcessError) as exc:
+        log.error("restart RPC failed for %s: %s", service, exc)
+        return 1
+    return 0

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -83,6 +83,211 @@ if [[ -z "$SCAFFOLD_DIR" ]]; then
   SCAFFOLD_DIR="$(dirname "$(realpath "$0")")"
 fi
 
+# Helper function to run commands conditionally
+_run() {
+  if [[ "$VALIDATE_ONLY" == "true" ]]; then
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "  [validate] $*"
+    fi
+    return 0
+  elif [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [would run] $*"
+    return 0
+  else
+    if [[ "$VERBOSE" == "true" ]]; then
+      "$@"
+    else
+      "$@" 2>/dev/null || true
+    fi
+  fi
+}
+
+# Like _run, but failures are FATAL — no `|| true`, no stderr suppression — so
+# a broken step surfaces a non-zero exit (with `set -e`) instead of being
+# silently swallowed. Use for steps whose failure a caller must be able to
+# detect, e.g. the install-helper allowlist re-bake (#279): if the helper
+# can't be restarted, the deploy must fail loudly here rather than later at the
+# install step with a misleading "command not allowed".
+_run_strict() {
+  if [[ "$VALIDATE_ONLY" == "true" ]]; then
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "  [validate] $*"
+    fi
+    return 0
+  elif [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [would run] $*"
+    return 0
+  else
+    "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Nothing installed here may terminate the work that asked for it (#349).
+#
+# A deploy runs *in process* inside one of two units: the webhook service,
+# which executes deploys as background tasks, and a deploy socket's
+# `<stem>@N.service` instance running `fraisier deploy-daemon`. A changed
+# fraises.yaml makes that deploy run this script — so restarting either unit
+# from here kills the deploy that asked for the install. The webhook will not
+# exit while a deploy is in flight, so systemd's stop timeout expires and the
+# process is SIGKILLed, taking the deploy with it and leaving no failure record
+# of its own; the caller sees only a timeout.
+#
+# The deploy socket is the same hazard one step removed: the generated deploy
+# service carries `Requires=<its socket>`, and systemd propagates an explicit
+# restart of a required unit to its dependents. That is the identical mechanism
+# behind the scaffold-install-helper self-restart race guarded further down —
+# that helper's .service also `Requires=` its socket.
+#
+# So every restart of a deploy-hosting unit goes through
+# `_restart_deploy_host_unit`, which defers under a live deploy, names what it
+# deferred and why, and records the debt for the deploy to pay once it has
+# released its lock. A restart that is merely skipped would leave the webhook
+# running its previous unit — old ReadWritePaths=, old Environment= — which is
+# how a fraises.yaml change that adds an environment makes the *next* deploy
+# fail on a read-only filesystem.
+_FRAISIER_DEPLOY_LOCK_DIR="{{ deployment.lock_dir }}"
+_FRAISIER_DEFERRED_LEDGER="${_FRAISIER_DEPLOY_LOCK_DIR}/.deferred-restarts"
+_FRAISIER_DEPLOY_SIGNAL=""
+_FRAISIER_DEFERRED_RESTARTS=()
+# Counted separately because bash's array-length expansion opens with the two
+# characters Jinja uses to start a comment, so writing it here would swallow the
+# rest of this template until the next `#}`.
+_FRAISIER_DEFERRED_COUNT=0
+
+# Is any deployment lock held right now?
+#
+# Probes only lock files that already exist, and opens them read-only: creating
+# one here would leave a root-owned file that the deploy user cannot reopen for
+# writing, which is how `file_deployment_lock` acquires — so a probe would break
+# the next deploy it was meant to protect.
+#
+# Returns 2, not 1, when the probe cannot run at all, so the caller can tell
+# "no deploy is running" from "I could not look".
+_deploy_locks_held() {
+    command -v flock >/dev/null 2>&1 || return 2
+    [ -d "$_FRAISIER_DEPLOY_LOCK_DIR" ] || return 1
+    local f fd
+    for f in "$_FRAISIER_DEPLOY_LOCK_DIR"/*.lock; do
+        [ -e "$f" ] || continue
+        exec {fd}<"$f" 2>/dev/null || continue
+        if flock -n "$fd" 2>/dev/null; then
+            flock -u "$fd" 2>/dev/null || true
+            exec {fd}<&-
+        else
+            exec {fd}<&-
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Is a deploy in flight? Three signals, OR'd, because each covers the others'
+# gaps:
+#
+#   FRAISIER_DEPLOY_IN_FLIGHT   the caller's declaration. `_install_scaffold`
+#                               sets it on BOTH install paths — helper socket
+#                               and subprocess fallback — and it is the only
+#                               signal that works on `lock_backend=database`
+#                               hosts, where there is no *.lock file to probe.
+#   the lock probe              the backstop, so this script does not rest on a
+#                               claim it cannot check, and still protects a
+#                               deploy run by an older fraisier that does not
+#                               declare.
+#   FRAISIER_VIA_SCAFFOLD_...   an older webhook talking to a newer install.sh
+#                               over the helper socket sets only this one.
+#
+# An unevaluable probe resolves to "no deploy is running", with a warning —
+# deliberately the opposite of the rule this project applies elsewhere, and for
+# a stated reason: the authoritative signal for the dangerous path is the
+# caller's declaration, which is never unevaluable. The probe is a backstop, and
+# a backstop that cannot run must not block a manual `scaffold-install`, which
+# is the documented remedy for a unit that has gone stale.
+_deploy_in_flight() {
+    if [ -n "${FRAISIER_DEPLOY_IN_FLIGHT:-}" ]; then
+        _FRAISIER_DEPLOY_SIGNAL="the caller declared a deploy in flight"
+        return 0
+    fi
+    if [ -n "${FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER:-}" ]; then
+        _FRAISIER_DEPLOY_SIGNAL="invoked via the scaffold-install helper, which only a deploy does"
+        return 0
+    fi
+    local rc=0
+    _deploy_locks_held || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        _FRAISIER_DEPLOY_SIGNAL="a deployment lock is held under ${_FRAISIER_DEPLOY_LOCK_DIR}"
+        return 0
+    fi
+    if [ "$rc" -eq 2 ]; then
+        echo "  Warning: could not probe deployment locks under ${_FRAISIER_DEPLOY_LOCK_DIR}" >&2
+        echo "    (flock(1) unavailable). Proceeding as if no deploy were running." >&2
+    fi
+    return 1
+}
+
+# The one place a deploy-hosting unit may be restarted.
+_restart_deploy_host_unit() {
+    local unit="$1"
+    if _deploy_in_flight; then
+        echo "  Deferring restart of ${unit} — ${_FRAISIER_DEPLOY_SIGNAL}."
+        echo "    The new unit is on disk and daemon-reloaded; restarting it now"
+        echo "    would terminate the deploy that asked for this install."
+        _FRAISIER_DEFERRED_RESTARTS+=("${unit}")
+        _FRAISIER_DEFERRED_COUNT=$((_FRAISIER_DEFERRED_COUNT + 1))
+        return 0
+    fi
+    echo "  Restarting ${unit} (terminates anything running inside it)"
+    _run sudo systemctl restart "${unit}" || true
+}
+
+# Record and report the debt, so a restart nobody performed is visible rather
+# than silent. Merged with anything an earlier install left unpaid, because two
+# config-changing deploys in a row must not lose the first one's entry.
+_report_deferred_restarts() {
+    [ "${_FRAISIER_DEFERRED_COUNT}" -gt 0 ] || return 0
+    echo ""
+    echo "Deferred restarts (${_FRAISIER_DEFERRED_COUNT}):"
+    local u
+    for u in "${_FRAISIER_DEFERRED_RESTARTS[@]}"; do
+        echo "  - ${u}"
+    done
+    echo "  These units are installed and daemon-reloaded but are still running"
+    echo "  their previous version. The deploy that requested this install"
+    echo "  restarts them once it releases its deployment lock; 'fraisier doctor'"
+    echo "  reports any that are still pending."
+
+    if [[ "$DRY_RUN" == "true" || "$VALIDATE_ONLY" == "true" ]]; then
+        echo "  [would record] ${_FRAISIER_DEFERRED_LEDGER}"
+        return 0
+    fi
+
+    local pending=()
+    if [ -r "${_FRAISIER_DEFERRED_LEDGER}" ]; then
+        mapfile -t pending < "${_FRAISIER_DEFERRED_LEDGER}"
+    fi
+    if ! printf '%s\n' "${pending[@]}" "${_FRAISIER_DEFERRED_RESTARTS[@]}" \
+        | grep -v '^$' | sort -u > "${_FRAISIER_DEFERRED_LEDGER}" 2>/dev/null; then
+        echo "  Warning: could not record deferred restarts at ${_FRAISIER_DEFERRED_LEDGER}." >&2
+        echo "    Restart these units manually once the deploy finishes:" >&2
+        printf '      %s\n' "${_FRAISIER_DEFERRED_RESTARTS[@]}" >&2
+        return 0
+    fi
+    # The webhook clears this file after paying the debt, and it runs as the
+    # deploy user while this script runs as root.
+    _run sudo chown "${DEPLOY_USER}:${DEPLOY_USER}" "${_FRAISIER_DEFERRED_LEDGER}" || true
+}
+
+# Sourcing this script defines the guard above and stops here; everything below
+# installs. fraisier's own tests source it to drive `_deploy_in_flight` and
+# `_restart_deploy_host_unit` for real, because the defect the guard exists for
+# is *which* systemctl command runs — and a test that stubs the restart proves
+# nothing about that.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+# ---------------------------------------------------------------------------
+
 # Server detection (baked at scaffold time by fraisier)
 {% if machine_env_map %}
 # Multi-server mode: filter based on runtime hostname.
@@ -154,45 +359,6 @@ echo "Error: 'servers:' section is required in fraises.yaml." >&2
 echo "  Add logical servers and machine hostnames, then re-run 'fraisier scaffold'." >&2
 exit 1
 {% endif %}
-
-# Helper function to run commands conditionally
-_run() {
-  if [[ "$VALIDATE_ONLY" == "true" ]]; then
-    if [[ "$VERBOSE" == "true" ]]; then
-      echo "  [validate] $*"
-    fi
-    return 0
-  elif [[ "$DRY_RUN" == "true" ]]; then
-    echo "  [would run] $*"
-    return 0
-  else
-    if [[ "$VERBOSE" == "true" ]]; then
-      "$@"
-    else
-      "$@" 2>/dev/null || true
-    fi
-  fi
-}
-
-# Like _run, but failures are FATAL — no `|| true`, no stderr suppression — so
-# a broken step surfaces a non-zero exit (with `set -e`) instead of being
-# silently swallowed. Use for steps whose failure a caller must be able to
-# detect, e.g. the install-helper allowlist re-bake (#279): if the helper
-# can't be restarted, the deploy must fail loudly here rather than later at the
-# install step with a misleading "command not allowed".
-_run_strict() {
-  if [[ "$VALIDATE_ONLY" == "true" ]]; then
-    if [[ "$VERBOSE" == "true" ]]; then
-      echo "  [validate] $*"
-    fi
-    return 0
-  elif [[ "$DRY_RUN" == "true" ]]; then
-    echo "  [would run] $*"
-    return 0
-  else
-    "$@"
-  fi
-}
 
 # Verify one manifest artifact against the tree, before anything is installed.
 #
@@ -501,18 +667,33 @@ if [ ! -f "${WEBHOOK_SRC}" ]; then
     echo "  Re-run 'fraisier scaffold' against the full fraises.yaml." >&2
     exit 1
 fi
-echo "  Installing webhook service"
-_run sudo cp "${WEBHOOK_SRC}" "${WEBHOOK_DST}"
-_run sudo systemctl daemon-reload
-_run sudo systemctl restart {{ webhook_service }} || true
+# Only reinstall and restart when the bytes differ. Most fraises.yaml changes
+# touch nothing that reaches this unit — #349's two failing changesets edited
+# `ship:` check definitions — so the common case becomes no restart at all
+# rather than a deferred one. This also makes the rollback path self-cancelling:
+# `_rollback_config` reinstalls the previous fraises.yaml, the unit returns to
+# its old bytes, and the debt recorded above never needed paying.
+if cmp -s "${WEBHOOK_SRC}" "${WEBHOOK_DST}" 2>/dev/null; then
+    echo "  Webhook service unit unchanged — not reinstalled"
+else
+    echo "  Installing webhook service"
+    _run sudo cp "${WEBHOOK_SRC}" "${WEBHOOK_DST}"
+    _run sudo systemctl daemon-reload
+    _restart_deploy_host_unit {{ webhook_service }}
+fi
 # Restart deploy sockets so their socket files are recreated under /run/fraisier/.
 # The webhook service owns RuntimeDirectory=fraisier; even with
 # RuntimeDirectoryPreserve=restart, a first-time install wipes the dir.
+#
+# That reason is also why routing these through the guard costs nothing: a
+# first-time install is, by construction, a state in which no deploy is in
+# flight, so the only case these restarts exist for is the case where the guard
+# lets them through.
 {% for fraise in local_fraises %}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% set socket_unit = deploy_socket_name(env_config, env_name, fraise.name) %}
 if _scope_active "{{ fraise.name }}" "{{ env_name }}"; then
-    _run sudo systemctl restart {{ socket_unit }} || true
+    _restart_deploy_host_unit {{ socket_unit }}
 fi
 {% endfor %}
 {% endfor %}
@@ -532,12 +713,14 @@ if [ -f "${HELPER_SERVICE_SRC}" ] && [ -f "${HELPER_SOCKET_SRC}" ]; then
     # wipe /run/fraisier/ because older versions had RuntimeDirectory=fraisier.
     _run sudo systemctl daemon-reload
     _run sudo systemctl restart fraisier-{{ project_name }}-systemctl-helper.service 2>/dev/null || true
-    # Restart deploy sockets to ensure socket files exist after any transition turbulence
+    # Restart deploy sockets to ensure socket files exist after any transition
+    # turbulence — through the guard, for the reason given at the first copy of
+    # this loop above.
 {% for fraise in local_fraises %}
 {% for env_name, env_config in fraise.get('environments', {}).items() %}
 {% set socket_unit = deploy_socket_name(env_config, env_name, fraise.name) %}
     if _scope_active "{{ fraise.name }}" "{{ env_name }}"; then
-        _run sudo systemctl restart {{ socket_unit }} || true
+        _restart_deploy_host_unit {{ socket_unit }}
     fi
 {% endfor %}
 {% endfor %}
@@ -878,6 +1061,13 @@ echo "        {{ timer.note }}"
 {% endfor %}
 echo "    Set the flag in fraises.yaml and re-run this script to start one."
 {% endif %}
+
+{#- The fourth "here is something this installer did not do" block, and the
+    only one that is owed back: a deferred restart leaves a unit installed and
+    not running, which is the state the three blocks above exist to make
+    visible. Reported last so it sits next to the completion line, and recorded
+    so the deploy can pay it. -#}
+_report_deferred_restarts
 
 echo ""
 echo "==> Setup complete for {{ project_name }}"

--- a/fraisier/scaffold/templates/core/install.sh.j2
+++ b/fraisier/scaffold/templates/core/install.sh.j2
@@ -29,6 +29,11 @@ VALIDATE_ONLY=false
 VERBOSE=false
 STANDALONE=false
 SCAFFOLD_DIR=""
+# Set by --deploy-in-flight. The env-var form cannot cross `sudo`, which resets
+# the environment, and the subprocess install path is
+# deployer -> `fraisier scaffold-install` -> `sudo install.sh`. See the deploy
+# host restart guard below.
+DEPLOY_IN_FLIGHT=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -53,6 +58,10 @@ while [[ $# -gt 0 ]]; do
       STANDALONE=true
       shift 2
       ;;
+    --deploy-in-flight)
+      DEPLOY_IN_FLIGHT=true
+      shift
+      ;;
     -h|--help)
       echo "Usage: $0 [OPTIONS]"
       echo ""
@@ -62,6 +71,8 @@ while [[ $# -gt 0 ]]; do
       echo "  --verbose, -v             Enable verbose output"
       echo "  --standalone              Run without requiring PROJECT_DIR to exist"
       echo "  --scaffold-dir <path>     Path to scaffold files (implies --standalone)"
+      echo "  --deploy-in-flight        A deploy is running; defer restarts of the"
+      echo "                            units that host it (set by fraisier, not you)"
       echo "  --help, -h                Show this help message"
       exit 0
       ;;
@@ -183,14 +194,19 @@ _deploy_locks_held() {
     return 1
 }
 
-# Is a deploy in flight? Three signals, OR'd, because each covers the others'
+# Is a deploy in flight? Four signals, OR'd, because each covers the others'
 # gaps:
 #
-#   FRAISIER_DEPLOY_IN_FLIGHT   the caller's declaration. `_install_scaffold`
-#                               sets it on BOTH install paths — helper socket
-#                               and subprocess fallback — and it is the only
-#                               signal that works on `lock_backend=database`
-#                               hosts, where there is no *.lock file to probe.
+#   --deploy-in-flight          the caller's declaration when it had to cross a
+#                               `sudo`, which resets the environment. This is
+#                               the subprocess install path:
+#                               deploy -> `fraisier scaffold-install` ->
+#                               `sudo install.sh`.
+#   FRAISIER_DEPLOY_IN_FLIGHT   the same declaration where the environment does
+#                               survive: the helper socket forwards it from the
+#                               request payload. Either form is the only signal
+#                               that works on `lock_backend=database` hosts,
+#                               where there is no *.lock file to probe.
 #   the lock probe              the backstop, so this script does not rest on a
 #                               claim it cannot check, and still protects a
 #                               deploy run by an older fraisier that does not
@@ -205,6 +221,10 @@ _deploy_locks_held() {
 # a backstop that cannot run must not block a manual `scaffold-install`, which
 # is the documented remedy for a unit that has gone stale.
 _deploy_in_flight() {
+    if [[ "$DEPLOY_IN_FLIGHT" == "true" ]]; then
+        _FRAISIER_DEPLOY_SIGNAL="the caller declared a deploy in flight (--deploy-in-flight)"
+        return 0
+    fi
     if [ -n "${FRAISIER_DEPLOY_IN_FLIGHT:-}" ]; then
         _FRAISIER_DEPLOY_SIGNAL="the caller declared a deploy in flight"
         return 0

--- a/fraisier/scaffold_install_helper.py
+++ b/fraisier/scaffold_install_helper.py
@@ -103,6 +103,18 @@ def _handle_connection(conn: socket.socket, allowed_script: str) -> None:
         # webhook's NoNewPrivileges (which cannot fall back) — the deploy aborts
         # before the DB step. See install.sh.j2's scaffold-install-helper block.
         helper_env = {**os.environ, "FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER": "1"}
+
+        # Forward the client's declaration that a deploy is in flight, so
+        # install.sh does not restart the unit that deploy is running inside
+        # (#349). This travels in the request because the helper is a separate
+        # root service and does not inherit the deploy's environment.
+        #
+        # Only a literal JSON `true` is honoured, and it is mapped to a fixed
+        # value rather than interpolated: the payload reaches a daemon running
+        # as root, so a client must not be able to name an environment variable
+        # or choose its contents.
+        if request.get("deploy_in_flight") is True:
+            helper_env["FRAISIER_DEPLOY_IN_FLIGHT"] = "1"
         try:
             result = subprocess.run(
                 [_BASH, allowed_script],

--- a/fraisier/status.py
+++ b/fraisier/status.py
@@ -12,7 +12,7 @@ import os
 import re
 import tempfile
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any
 
@@ -36,7 +36,13 @@ def _validate_fraise_name(name: str) -> None:
 #: than ``state == "failed"``: a consumer that tests equality reports
 #: ``rollback_failed`` — the state where the schema may be half-migrated — as
 #: though nothing were wrong (#293).
-FAILURE_STATES = frozenset({"failed", "rolled_back", "rollback_failed"})
+FAILURE_STATES = frozenset({"failed", "rolled_back", "rollback_failed", "interrupted"})
+
+#: States a deploy passes *through*. A record left in one of these has either a
+#: live owner or none at all — see :func:`reconcile_orphaned_deploys`.
+NON_TERMINAL_STATES = frozenset({"pending", "deploying"})
+
+_BOOT_ID_PATH = Path("/proc/sys/kernel/random/boot_id")
 
 
 @dataclass
@@ -44,13 +50,26 @@ class DeploymentStatusFile:
     """Deployment status as a state machine.
 
     States: idle -> pending -> deploying -> success | failed | rolled_back
-    | rollback_failed
+    | rollback_failed | interrupted
 
     ``rolled_back`` means the deploy failed and the previous state was restored;
     ``rollback_failed`` means the restore itself failed and the database schema
     may be half-migrated — the service must not be restarted until an operator
     has resolved it. Consumers that branch on this field must handle both, or
     they will silently mis-report a dirty schema.
+
+    ``interrupted`` is deliberately *not* ``failed``: the deploy's own failure
+    path never ran. Nothing rolled back, ``version.json`` was not restored, and
+    the tree may be half-deployed. It is written by
+    :func:`reconcile_orphaned_deploys`, never by a deploy — a deploy that could
+    write it would not have been interrupted.
+
+    The four ``owner_*`` fields exist so a reader can tell a deploy that is
+    running from one whose process is gone. Without them a SIGKILLed deploy sits
+    at ``deploying`` for good, which is exactly how it looks while it works.
+    ``owner_invocation_id`` is not used to decide liveness; it is recorded so an
+    operator can pull the deploy's own journal back out afterwards with
+    ``journalctl _SYSTEMD_INVOCATION_ID=<id>``.
     """
 
     fraise_name: str
@@ -63,6 +82,64 @@ class DeploymentStatusFile:
     error_message: str | None = None
     migration_report: dict[str, Any] | None = None
     last_error: dict[str, Any] | None = None
+    owner_pid: int | None = None
+    owner_boot_id: str | None = None
+    owner_invocation_id: str | None = None
+
+
+def _read_boot_id() -> str | None:
+    """This boot's kernel-assigned id, or None where there is no such file."""
+    try:
+        return _BOOT_ID_PATH.read_text().strip() or None
+    except OSError:
+        return None
+
+
+def current_owner() -> dict[str, Any]:
+    """Identity fields for the process about to claim a deployment record."""
+    return {
+        "owner_pid": os.getpid(),
+        "owner_boot_id": _read_boot_id(),
+        "owner_invocation_id": os.environ.get("INVOCATION_ID") or None,
+    }
+
+
+def _pid_alive(pid: int) -> bool:
+    """True when a process with *pid* exists (any owner)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # It exists and belongs to someone else.
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def owner_is_gone(status: DeploymentStatusFile) -> bool:
+    """True only when the process that wrote *status* provably no longer exists.
+
+    Two definitive answers and one deliberate abstention:
+
+    - a different boot id means the machine restarted, so nothing from that boot
+      is running;
+    - no process with that pid means the owner is gone;
+    - anything else — including a record written before this release, which
+      carries no identity at all — returns False.
+
+    The abstention is the safe direction. Declaring a live deploy dead would
+    overwrite the record it is still going to write; failing to reconcile a dead
+    one leaves the pre-existing behaviour, which ``fraisier doctor`` and the
+    elapsed time already make visible.
+    """
+    boot_id = _read_boot_id()
+    if status.owner_boot_id and boot_id and status.owner_boot_id != boot_id:
+        return True
+    if status.owner_pid is None:
+        return False
+    return not _pid_alive(status.owner_pid)
 
 
 def write_status(
@@ -118,8 +195,19 @@ def read_status(
     if not path.exists():
         return None
 
-    data = json.loads(path.read_text())
-    return DeploymentStatusFile(**data)
+    return _from_dict(json.loads(path.read_text()))
+
+
+def _from_dict(data: dict[str, Any]) -> DeploymentStatusFile:
+    """Build a status from JSON, ignoring fields this version does not know.
+
+    A self-upgrade puts two fraisier versions on one host by design, so a file
+    written by the newer one is read by the older until it restarts. Passing the
+    raw dict straight into the dataclass turns that into a ``TypeError`` and
+    takes ``fraisier status`` down with it.
+    """
+    known = {f.name for f in fields(DeploymentStatusFile)}
+    return DeploymentStatusFile(**{k: v for k, v in data.items() if k in known})
 
 
 def elapsed_seconds(status: DeploymentStatusFile) -> float | None:
@@ -148,3 +236,66 @@ def elapsed_seconds(status: DeploymentStatusFile) -> float | None:
         return time.time() - started_ts
     except (ValueError, TypeError, AttributeError):
         return None
+
+
+def reconcile_orphaned_deploys(
+    status_dir: Path = DEFAULT_STATUS_DIR,
+) -> list[str]:
+    """Give a terminal record to every deploy whose process is provably gone.
+
+    A deploy killed mid-flight cannot report: that is the whole point of #349,
+    where restarting the webhook from inside its own deploy left the record at
+    ``deploying`` for good while the kernel quietly released the flock. So the
+    record is closed by whoever comes next — this runs at webhook startup, and
+    the restart that killed the deploy is itself what brings it up.
+
+    Returns the fraise names that were reconciled. A file that cannot be read or
+    written is skipped: one bad record must not stop the others being closed,
+    and must not stop the webhook from starting.
+    """
+    if not status_dir.exists():
+        return []
+
+    reconciled: list[str] = []
+    for path in sorted(status_dir.glob("*.status.json")):
+        try:
+            status = _from_dict(json.loads(path.read_text()))
+        except (OSError, ValueError, TypeError):
+            logger.warning("Skipping unreadable status file %s", path)
+            continue
+        if status.state not in NON_TERMINAL_STATES or not owner_is_gone(status):
+            continue
+
+        status.state = "interrupted"
+        status.finished_at = _now_iso()
+        status.error_message = (
+            f"The deploy did not report: the process that started it "
+            f"(pid {status.owner_pid}) no longer exists. It was terminated "
+            f"rather than failing, so nothing rolled back and the tree may be "
+            f"half-deployed — check before redeploying."
+            + (
+                f" Its journal: journalctl _SYSTEMD_INVOCATION_ID="
+                f"{status.owner_invocation_id}"
+                if status.owner_invocation_id
+                else ""
+            )
+        )
+        try:
+            write_status(status, status_dir=status_dir)
+        except (OSError, ValidationError):
+            logger.warning("Could not reconcile status file %s", path, exc_info=True)
+            continue
+        logger.warning(
+            "Deployment record for %s was left at %r by a process that is gone; "
+            "recorded as interrupted",
+            status.fraise_name,
+            "deploying",
+        )
+        reconciled.append(status.fraise_name)
+    return reconciled
+
+
+def _now_iso() -> str:
+    import datetime
+
+    return datetime.datetime.now(tz=datetime.UTC).isoformat()

--- a/fraisier/webhook.py
+++ b/fraisier/webhook.py
@@ -23,6 +23,7 @@ from .config._lazy_env import LazyEnv, to_str
 if TYPE_CHECKING:
     from .config.loader import FraisierConfig
     from .database import FraisierDB
+from .deferred_restart import maybe_apply_deferred_restarts
 from .duration_estimate import build_estimate, to_dispatch_dict
 from .errors import ConfigurationError, DeploymentError, DeploymentLockError
 from .git import GitProvider, WebhookEvent, get_provider
@@ -341,6 +342,7 @@ async def _run_deployment(
     db: "FraisierDB",
 ) -> None:
     """Run the actual deployment within a lock."""
+    upgrading = False
     try:
         fraise_type = fraise_config.get("type")
 
@@ -409,7 +411,7 @@ async def _run_deployment(
             app_path = fraise_config.get("app_path")
             if app_path:
                 webhook_cfg = config.webhook
-                maybe_self_upgrade(
+                upgrading = maybe_self_upgrade(
                     Path(app_path),
                     project_name=config.project_name,
                     enabled=bool(webhook_cfg.get("self_upgrade", True)),
@@ -419,6 +421,23 @@ async def _run_deployment(
                 f"Deployment failed: {fraise_name}/{environment} "
                 f"- {result.error_message}"
             )
+
+        # Pay whatever install.sh deferred because this deploy was in flight
+        # (#349). Run on failure too: the units were installed either way, and a
+        # rollback that restores the previous fraises.yaml reinstalls their old
+        # bytes, so install.sh records no debt and this is a no-op.
+        #
+        # Skipped while a self-upgrade is in flight. That worker restarts the
+        # webhook anyway, which is the debt — and both workers raise the same
+        # single `.draining` flag, so the first to finish would clear it out
+        # from under the other.
+        if not upgrading:
+            lock_dir = _get_lock_dir(config)
+            if lock_dir is not None:
+                maybe_apply_deferred_restarts(
+                    lock_dir=lock_dir,
+                    socket_path=os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", ""),
+                )
 
     except (DeploymentError, ConfigurationError, OSError) as e:
         logger.exception(

--- a/fraisier/webhook.py
+++ b/fraisier/webhook.py
@@ -33,7 +33,7 @@ from .locking import (
     is_deployment_locked,
     is_draining,
 )
-from .status import FAILURE_STATES, read_status
+from .status import FAILURE_STATES, read_status, reconcile_orphaned_deploys
 from .webhook_rate_limit import check_rate_limit
 from .webhook_self_upgrade import maybe_self_upgrade
 
@@ -67,6 +67,28 @@ def _clear_stale_drain_flag() -> None:
         clear_draining_flag(lock_dir)
     except OSError:
         logger.debug("Could not clear stale draining flag", exc_info=True)
+
+
+def _reconcile_orphaned_deploys() -> None:
+    """Close the record of any deploy whose process did not survive.
+
+    Sits beside ``_clear_stale_drain_flag`` because it cleans up after the same
+    kind of event, and runs at startup for a reason specific to #349: the thing
+    that kills a deploy is a restart of this unit, so the restart that killed it
+    is what brings this function up. Best-effort — a webhook that cannot tidy
+    old records must still start and serve.
+    """
+    try:
+        reconciled = reconcile_orphaned_deploys()
+    except OSError:
+        logger.debug("Could not reconcile orphaned deployment records", exc_info=True)
+        return
+    if reconciled:
+        logger.warning(
+            "Recorded %s as interrupted: the deploys that owned those records "
+            "were terminated without reporting",
+            ", ".join(reconciled),
+        )
 
 
 def _install_sighup_reload() -> asyncio.AbstractEventLoop | None:
@@ -120,6 +142,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Manage webhook server lifecycle."""
     logger.info("Fraisier webhook server starting")
     _clear_stale_drain_flag()
+    _reconcile_orphaned_deploys()
     sighup_loop = _install_sighup_reload()
     yield
     _remove_sighup_reload(sighup_loop)

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -41,19 +41,29 @@ import os
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fraisier.config import get_config
-from fraisier.locking import DRAINING_FLAG_NAME, count_held_deployment_locks
+from fraisier.drain_restart import (
+    DEFAULT_DRAIN_POLL_S,
+    DEFAULT_DRAIN_SETTLE_S,
+    DEFAULT_DRAIN_TIMEOUT_S,
+    DEFAULT_LOCK_DIR,
+    DRAIN_TIMEOUT_RC,
+    DrainResult,
+    draining_flag,
+    held_lock_basenames,
+    send_restart,
+    wait_for_deploys_to_drain,
+)
 from fraisier.service_managers.systemd import _call_via_socket
 from fraisier.versioning import detect_required_fraisier_version
 
 if TYPE_CHECKING:  # pragma: no cover
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
 
 log = logging.getLogger(__name__)
 
@@ -61,20 +71,20 @@ log = logging.getLogger(__name__)
 # ReadWritePaths, so a sibling directory is writable by the deploy user.
 _LOG_DIR = Path("/var/lib/fraisier/self-upgrade")
 
-# Distinct from install-failure rc=1 / restart-RPC-failure rc=1 so operators
-# scanning the per-event log can tell drain-timeout apart at a glance.
-_DRAIN_TIMEOUT_RC = 2
-
-_DEFAULT_DRAIN_TIMEOUT_S = 600
-_DEFAULT_DRAIN_POLL_S = 1.0
-_DEFAULT_DRAIN_SETTLE_S = 2.0
-_DEFAULT_LOCK_DIR = "/run/fraisier"
-
-
-@dataclass(frozen=True)
-class _DrainResult:
-    drained: bool
-    held: list[str]
+# Re-exported under their historical private names: this module is where the
+# drain sequence was written, and its tests and callers still reach for these
+# spellings. The implementation now lives in `drain_restart` so the deferred
+# restarts recorded by install.sh share it rather than growing a second copy.
+_DRAIN_TIMEOUT_RC = DRAIN_TIMEOUT_RC
+_DEFAULT_DRAIN_TIMEOUT_S = DEFAULT_DRAIN_TIMEOUT_S
+_DEFAULT_DRAIN_POLL_S = DEFAULT_DRAIN_POLL_S
+_DEFAULT_DRAIN_SETTLE_S = DEFAULT_DRAIN_SETTLE_S
+_DEFAULT_LOCK_DIR = DEFAULT_LOCK_DIR
+_DrainResult = DrainResult
+_with_draining_flag = draining_flag
+_held_lock_basenames = held_lock_basenames
+_wait_for_deploys_to_drain = wait_for_deploys_to_drain
+_send_restart = send_restart
 
 
 @dataclass(frozen=True)
@@ -140,23 +150,28 @@ def maybe_self_upgrade(
     project_name: str,
     enabled: bool,
     spawn: Callable[[str, str], None] | None = None,
-) -> None:
+) -> bool:
     """Best-effort: detect a newer pinned fraisier and spawn a detached upgrade.
+
+    Returns True iff an upgrade worker was spawned. Callers use that to avoid
+    starting a second drain worker: both raise the same single ``.draining``
+    flag, and the first to finish would unlink it out from under the other
+    (#349).
 
     Never raises — a failure here must not break a successful deploy. The
     *spawn* parameter is a test seam; production code leaves it at None and
     uses :func:`_spawn_upgrade`.
     """
     if not enabled:
-        return
+        return False
     try:
         required = detect_required_fraisier_version(app_path)
         if required is None:
-            return
+            return False
         installed = importlib_metadata.version("fraisier")
         try:
             if _parse_semver(required) <= _parse_semver(installed):
-                return
+                return False
         except ValueError:
             log.warning(
                 "self-upgrade: skipping — non-semver version comparison "
@@ -164,7 +179,7 @@ def maybe_self_upgrade(
                 required,
                 installed,
             )
-            return
+            return False
         socket_path = os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", "")
         service = f"fraisier-{project_name}-webhook.service"
         rejection = _preflight_helper_allowlist(socket_path, service)
@@ -179,7 +194,7 @@ def maybe_self_upgrade(
                 required,
                 rejection,
             )
-            return
+            return False
         log.info(
             "self-upgrade: required=%s installed=%s — spawning upgrade for %s",
             required,
@@ -187,8 +202,10 @@ def maybe_self_upgrade(
             project_name,
         )
         (spawn or _spawn_upgrade)(required, project_name)
+        return True
     except Exception:
         log.exception("self-upgrade: skipped due to unexpected error")
+    return False
 
 
 def _open_log_fd(project_name: str):
@@ -270,55 +287,6 @@ def _spawn_upgrade(required: str, project_name: str) -> None:
         stdout=stdout,
         stderr=subprocess.STDOUT,
     )
-
-
-@contextmanager
-def _with_draining_flag(lock_dir: Path) -> Iterator[Path]:
-    """Touch ``{lock_dir}/.draining`` on entry; always unlink on exit."""
-    flag = lock_dir / DRAINING_FLAG_NAME
-    flag.touch()
-    try:
-        yield flag
-    finally:
-        flag.unlink(missing_ok=True)
-
-
-def _held_lock_basenames(lock_dir: Path) -> list[str]:
-    """Names of ``*.lock`` files currently present — used for timeout logging."""
-    if not lock_dir.exists():
-        return []
-    return sorted(p.name for p in lock_dir.glob("*.lock"))
-
-
-def _wait_for_deploys_to_drain(
-    lock_dir: Path,
-    timeout_s: float,
-    poll_s: float,
-) -> _DrainResult:
-    """Block until no ``*.lock`` is flock'd, or the deadline expires.
-
-    Returns a :class:`_DrainResult` so callers can log which locks are still
-    held on timeout (the helper does not parse ``/proc/locks`` for holder
-    PIDs — basenames are enough to identify which fraise hung).
-    """
-    deadline = time.monotonic() + timeout_s
-    while True:
-        held = count_held_deployment_locks(lock_dir)
-        if held == 0:
-            return _DrainResult(drained=True, held=[])
-        if time.monotonic() >= deadline:
-            return _DrainResult(drained=False, held=_held_lock_basenames(lock_dir))
-        time.sleep(poll_s)
-
-
-def _send_restart(socket_path: str, service: str) -> int:
-    """Send the ``restart`` RPC, returning the same rc shape today's code does."""
-    try:
-        _call_via_socket(socket_path, "restart", service)
-    except (ConnectionRefusedError, subprocess.CalledProcessError) as exc:
-        log.error("self-upgrade: restart RPC failed: %s", exc)
-        return 1
-    return 0
 
 
 def _run_install(required: str) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.62.0"
+version = "0.63.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/integration/test_self_upgrade_concurrent_deploy.py
+++ b/tests/integration/test_self_upgrade_concurrent_deploy.py
@@ -46,7 +46,7 @@ class TestConcurrentDeployNotKilled:
                     return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
                 ),
                 patch(
-                    "fraisier.webhook_self_upgrade._call_via_socket",
+                    "fraisier.drain_restart._call_via_socket",
                     side_effect=restart_mock,
                 ),
             ):
@@ -147,7 +147,7 @@ class TestDrainTimeoutObservable:
                     "fraisier.webhook_self_upgrade.subprocess.run",
                     return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
                 ),
-                patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+                patch("fraisier.drain_restart._call_via_socket") as mock_socket,
                 caplog.at_level(
                     logging.WARNING, logger="fraisier.webhook_self_upgrade"
                 ),

--- a/tests/test_deferred_restart.py
+++ b/tests/test_deferred_restart.py
@@ -1,0 +1,193 @@
+"""A restart install.sh deferred is a debt, and something has to pay it (#349).
+
+Skipping the restart alone would leave the webhook running its previous unit —
+old ReadWritePaths=, old Environment= — which is how a fraises.yaml change that
+adds an environment makes the *next* deploy fail on a read-only filesystem.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fraisier.deferred_restart import (
+    DEFERRED_RESTART_FILE,
+    maybe_apply_deferred_restarts,
+    read_deferred_restarts,
+    run_deferred_restarts,
+    settle_deferred_restarts,
+)
+
+
+@pytest.fixture
+def lock_dir(tmp_path):
+    d = tmp_path / "run-fraisier"
+    d.mkdir()
+    return d
+
+
+def _write_ledger(lock_dir, *units):
+    (lock_dir / DEFERRED_RESTART_FILE).write_text("".join(f"{u}\n" for u in units))
+
+
+class TestReadTheLedger:
+    def test_no_ledger_is_no_debt(self, lock_dir):
+        assert read_deferred_restarts(lock_dir) == []
+
+    def test_entries_are_returned_in_order(self, lock_dir):
+        _write_ledger(lock_dir, "b.service", "a.socket")
+        assert read_deferred_restarts(lock_dir) == ["b.service", "a.socket"]
+
+    def test_blank_lines_are_ignored(self, lock_dir):
+        (lock_dir / DEFERRED_RESTART_FILE).write_text("a.service\n\n  \nb.service\n")
+        assert read_deferred_restarts(lock_dir) == ["a.service", "b.service"]
+
+    def test_a_missing_lock_dir_is_no_debt(self, tmp_path):
+        assert read_deferred_restarts(tmp_path / "nope") == []
+
+    def test_unreadable_ledger_is_reported_as_no_debt(self, lock_dir, caplog):
+        """A debt we cannot read must not crash the deploy that just succeeded."""
+        with patch(
+            "fraisier.deferred_restart.Path.read_text", side_effect=OSError("boom")
+        ):
+            assert read_deferred_restarts(lock_dir) == []
+
+
+class TestSettleTheLedger:
+    def test_paid_entries_are_removed(self, lock_dir):
+        _write_ledger(lock_dir, "a.service", "b.socket")
+        settle_deferred_restarts(lock_dir, paid=["a.service"])
+        assert read_deferred_restarts(lock_dir) == ["b.socket"]
+
+    def test_the_file_goes_when_the_debt_is_cleared(self, lock_dir):
+        _write_ledger(lock_dir, "a.service")
+        settle_deferred_restarts(lock_dir, paid=["a.service"])
+        assert not (lock_dir / DEFERRED_RESTART_FILE).exists()
+
+    def test_an_unpaid_entry_survives_so_doctor_still_reports_it(self, lock_dir):
+        _write_ledger(lock_dir, "a.service", "b.socket")
+        settle_deferred_restarts(lock_dir, paid=[])
+        assert read_deferred_restarts(lock_dir) == ["a.service", "b.socket"]
+
+
+class TestRunDeferredRestarts:
+    """flag -> settle -> drain -> restart each -> settle the ledger."""
+
+    def test_restart_is_sent_after_the_drain(self, lock_dir):
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        with (
+            patch("fraisier.deferred_restart.time.sleep"),
+            patch(
+                "fraisier.deferred_restart.wait_for_deploys_to_drain",
+                return_value=MagicMock(drained=True, held=[]),
+            ),
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
+        ):
+            rc = run_deferred_restarts("/run/x.sock", lock_dir=lock_dir)
+        assert rc == 0
+        mock_socket.assert_called_once_with(
+            "/run/x.sock", "restart", "fraisier-p-webhook.service"
+        )
+        assert read_deferred_restarts(lock_dir) == []
+
+    def test_the_draining_flag_is_raised_for_the_whole_window(self, lock_dir):
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        seen = []
+
+        def _drain(*_args, **_kwargs):
+            seen.append((lock_dir / ".draining").exists())
+            return MagicMock(drained=True, held=[])
+
+        with (
+            patch("fraisier.deferred_restart.time.sleep"),
+            patch("fraisier.deferred_restart.wait_for_deploys_to_drain", _drain),
+            patch("fraisier.drain_restart._call_via_socket"),
+        ):
+            run_deferred_restarts("/run/x.sock", lock_dir=lock_dir)
+        assert seen == [True]
+        assert not (lock_dir / ".draining").exists()
+
+    def test_drain_timeout_sends_nothing_and_keeps_the_debt(self, lock_dir, caplog):
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        with (
+            patch("fraisier.deferred_restart.time.sleep"),
+            patch(
+                "fraisier.deferred_restart.wait_for_deploys_to_drain",
+                return_value=MagicMock(drained=False, held=["api.lock"]),
+            ),
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
+        ):
+            rc = run_deferred_restarts("/run/x.sock", lock_dir=lock_dir)
+        assert rc != 0
+        mock_socket.assert_not_called()
+        assert read_deferred_restarts(lock_dir) == ["fraisier-p-webhook.service"]
+
+    def test_a_rejected_unit_stays_in_the_ledger(self, lock_dir):
+        """Deploy sockets are not in the systemctl-helper allowlist, so their
+        restart is refused — an unpaid debt, not a paid one."""
+        _write_ledger(
+            lock_dir, "fraisier-p-webhook.service", "fraisier-api-prod.socket"
+        )
+
+        def _call(_sock, _action, service):
+            if service.endswith(".socket"):
+                raise subprocess.CalledProcessError(
+                    1, "restart", stderr="service not allowed"
+                )
+
+        with (
+            patch("fraisier.deferred_restart.time.sleep"),
+            patch(
+                "fraisier.deferred_restart.wait_for_deploys_to_drain",
+                return_value=MagicMock(drained=True, held=[]),
+            ),
+            patch("fraisier.drain_restart._call_via_socket", side_effect=_call),
+        ):
+            run_deferred_restarts("/run/x.sock", lock_dir=lock_dir)
+        assert read_deferred_restarts(lock_dir) == ["fraisier-api-prod.socket"]
+
+    def test_no_debt_is_a_no_op(self, lock_dir):
+        with patch("fraisier.drain_restart._call_via_socket") as mock_socket:
+            rc = run_deferred_restarts("/run/x.sock", lock_dir=lock_dir)
+        assert rc == 0
+        mock_socket.assert_not_called()
+
+    def test_no_socket_configured_keeps_the_debt(self, lock_dir):
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        rc = run_deferred_restarts("", lock_dir=lock_dir)
+        assert rc != 0
+        assert read_deferred_restarts(lock_dir) == ["fraisier-p-webhook.service"]
+
+
+class TestMaybeApplyDeferredRestarts:
+    def test_spawns_a_detached_worker_when_a_debt_exists(self, lock_dir):
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        with patch("fraisier.deferred_restart.subprocess.Popen") as mock_popen:
+            maybe_apply_deferred_restarts(lock_dir=lock_dir, socket_path="/run/x.sock")
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
+        assert "fraisier.deferred_restart" in cmd
+        assert mock_popen.call_args.kwargs["start_new_session"] is True
+
+    def test_does_nothing_when_there_is_no_debt(self, lock_dir):
+        with patch("fraisier.deferred_restart.subprocess.Popen") as mock_popen:
+            maybe_apply_deferred_restarts(lock_dir=lock_dir, socket_path="/run/x.sock")
+        mock_popen.assert_not_called()
+
+    def test_does_nothing_without_a_helper_socket(self, lock_dir, caplog):
+        """No RPC channel means the debt cannot be paid here; leave it for doctor."""
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        with patch("fraisier.deferred_restart.subprocess.Popen") as mock_popen:
+            maybe_apply_deferred_restarts(lock_dir=lock_dir, socket_path="")
+        mock_popen.assert_not_called()
+        assert read_deferred_restarts(lock_dir) == ["fraisier-p-webhook.service"]
+
+    def test_never_raises(self, lock_dir):
+        """A failure here must not turn a successful deploy into a failed one."""
+        _write_ledger(lock_dir, "fraisier-p-webhook.service")
+        with patch(
+            "fraisier.deferred_restart.subprocess.Popen", side_effect=OSError("boom")
+        ):
+            maybe_apply_deferred_restarts(lock_dir=lock_dir, socket_path="/run/x.sock")

--- a/tests/test_deployers_base_unit.py
+++ b/tests/test_deployers_base_unit.py
@@ -176,6 +176,97 @@ class TestInstallScaffold:
         assert "cd " not in " ".join(cmd)
 
 
+class TestInstallScaffoldDeclaresTheDeploy:
+    """install.sh must know a deploy is in flight, on *both* install paths (#349).
+
+    The helper-socket marker only exists on the socket path; the subprocess
+    fallback runs install.sh as a child of the deploy process, where an
+    unguarded `systemctl restart <webhook>` kills the whole cgroup just the
+    same. The caller is the only party that knows, so it declares on both.
+    """
+
+    def test_subprocess_fallback_declares_the_deploy(self, tmp_path):
+        config_path = tmp_path / "fraises.yaml"
+        config_path.write_text("name: myproj\nfraises: {}\n")
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="")
+
+        deployer = _make_deployer_with_runner(mock_runner)
+        deployer._install_scaffold(config_path=config_path)
+
+        env = mock_runner.run.call_args[1]["env"]
+        assert env["FRAISIER_DEPLOY_IN_FLIGHT"] == "1"
+
+    def test_subprocess_fallback_keeps_the_ambient_environment(self, tmp_path):
+        """LocalRunner hands env straight to subprocess.run, which *replaces* it."""
+        config_path = tmp_path / "fraises.yaml"
+        config_path.write_text("name: myproj\nfraises: {}\n")
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="")
+
+        deployer = _make_deployer_with_runner(mock_runner)
+        deployer._install_scaffold(config_path=config_path)
+
+        env = mock_runner.run.call_args[1]["env"]
+        assert "PATH" in env
+
+    def test_configless_fallback_declares_the_deploy(self):
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = MagicMock(returncode=0, stdout="")
+
+        deployer = _make_deployer_with_runner(mock_runner)
+        deployer._install_scaffold(config_path=None)
+
+        env = mock_runner.run.call_args[1]["env"]
+        assert env["FRAISIER_DEPLOY_IN_FLIGHT"] == "1"
+
+    def test_socket_request_declares_the_deploy(self, tmp_path, monkeypatch):
+        """The helper does not inherit the deploy's environment, so the
+        declaration has to travel in the request payload."""
+        import json
+
+        config_path = tmp_path / "fraises.yaml"
+        config_path.write_text("name: myproj\nfraises: {}\n")
+
+        sent: list[bytes] = []
+
+        class _FakeSock:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def connect(self, _path):
+                return None
+
+            def sendall(self, payload):
+                sent.append(payload)
+
+            def makefile(self, _mode):
+                import io
+
+                return io.BytesIO(b'{"ok": true, "stdout": "", "stderr": ""}\n')
+
+        from fraisier.deployers import base as base_mod
+
+        def _fake_socket(*_args, **_kwargs):
+            return _FakeSock()
+
+        monkeypatch.setattr(base_mod._socket_mod, "socket", _fake_socket)
+        monkeypatch.setattr(base_mod.Path, "exists", lambda _self: True)
+
+        deployer = _make_deployer_with_runner(MagicMock())
+        deployer._try_scaffold_install_via_socket(config_path)
+
+        assert sent, "no request was sent"
+        request = json.loads(sent[0].decode())
+        assert request["action"] == "install"
+        assert request["deploy_in_flight"] is True
+
+
 # ---------------------------------------------------------------------------
 # _get_fraisier_executable — resolves the fraisier binary across installs
 # ---------------------------------------------------------------------------

--- a/tests/test_install_sh_deploy_host_restarts.py
+++ b/tests/test_install_sh_deploy_host_restarts.py
@@ -1,0 +1,357 @@
+"""The generated install.sh must not restart the unit running the deploy (#349).
+
+A deploy runs in-process inside either the webhook service or a deploy socket's
+``<stem>@N.service`` instance, and a changed ``fraises.yaml`` makes that deploy
+run ``install.sh``. Restarting either unit from there kills the deploy that
+asked for the install.
+
+The defect is *which* systemctl command runs, so these tests drive the rendered
+script with a recording ``sudo`` on ``PATH`` rather than mocking the restart —
+a mock asserting "we invoked systemctl restart" passes against the broken code.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.naming import deploy_socket_name
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """\
+name: testapp
+servers:
+  example.com:
+    machine_hostnames: [default-testrunner]
+
+fraises:
+  api:
+    type: api
+    environments:
+      production:
+        server: example.com
+
+deployment:
+  lock_dir: {lock_dir}
+
+scaffold:
+  deploy_user: testapp_deploy
+"""
+
+_WEBHOOK_UNIT = "fraisier-testapp-webhook.service"
+_DEPLOY_SOCKET = deploy_socket_name({}, "production", "api")
+
+_SUDO_STUB = """\
+#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$FRAISIER_TEST_SUDO_LOG"
+exit 0
+"""
+
+
+def _render(tmp_path, lock_dir):
+    cfg_path = tmp_path / "fraises.yaml"
+    cfg_path.write_text(_YAML.format(lock_dir=lock_dir))
+    renderer = ScaffoldRenderer(FraisierConfig(cfg_path))
+    renderer.output_dir = tmp_path / "generated"
+    renderer.render()
+    return tmp_path / "generated" / "install.sh"
+
+
+class _Harness:
+    """Sources the rendered install.sh and runs a snippet against its guard."""
+
+    def __init__(self, tmp_path):
+        self.tmp_path = tmp_path
+        self.lock_dir = tmp_path / "lockdir"
+        self.lock_dir.mkdir()
+        self.install_sh = _render(tmp_path, self.lock_dir)
+        self.bin = tmp_path / "bin"
+        self.bin.mkdir()
+        self.sudo_log = tmp_path / "sudo.log"
+        sudo = self.bin / "sudo"
+        sudo.write_text(_SUDO_STUB)
+        sudo.chmod(0o755)
+
+    def run(self, snippet: str, *, env=None, with_flock: bool = True, expect_ok=True):
+        script = self.tmp_path / "harness.sh"
+        script.write_text(
+            f'. "{self.install_sh}"\n{textwrap.dedent(snippet)}\n',
+        )
+        run_env = {
+            **os.environ,
+            "FRAISIER_TEST_SUDO_LOG": str(self.sudo_log),
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+        }
+        run_env.pop("FRAISIER_DEPLOY_IN_FLIGHT", None)
+        run_env.pop("FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER", None)
+        if not with_flock:
+            # A PATH with the stub dir and the coreutils dir but no flock(1).
+            stripped = self.tmp_path / "noflock"
+            stripped.mkdir(exist_ok=True)
+            for tool in ("bash", "realpath", "dirname", "grep", "sort", "cat", "rm"):
+                found = shutil.which(tool)
+                if found and not (stripped / tool).exists():
+                    (stripped / tool).symlink_to(found)
+            run_env["PATH"] = f"{self.bin}:{stripped}"
+        run_env.update(env or {})
+        result = subprocess.run(
+            ["bash", str(script)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=run_env,
+        )
+        if expect_ok:
+            # An undefined function exits non-zero and leaves an empty sudo log,
+            # which is exactly what a deferral looks like. Assert the snippet
+            # actually ran before any test reads that emptiness as evidence.
+            assert result.returncode == 0, (
+                f"harness snippet failed: {result.stderr}\n{result.stdout}"
+            )
+        return result
+
+    def sudo_calls(self) -> list[str]:
+        if not self.sudo_log.exists():
+            return []
+        return [ln for ln in self.sudo_log.read_text().splitlines() if ln.strip()]
+
+    def ledger(self) -> list[str]:
+        path = self.lock_dir / ".deferred-restarts"
+        if not path.exists():
+            return []
+        return [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+
+@pytest.fixture
+def harness(tmp_path):
+    return _Harness(tmp_path)
+
+
+# --------------------------------------------------------------------------
+# The seam behaves: restart when free, defer when a deploy is in flight.
+# --------------------------------------------------------------------------
+
+
+class TestRestartsWhenNoDeployIsInFlight:
+    def test_webhook_is_restarted(self, harness):
+        result = harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert result.returncode == 0, result.stderr
+        assert any(
+            f"systemctl restart {_WEBHOOK_UNIT}" in call
+            for call in harness.sudo_calls()
+        ), harness.sudo_calls()
+
+    def test_restart_announces_its_intent_before_issuing_it(self, harness):
+        """A SIGKILLed deploy cannot report; the restart that causes it can."""
+        result = harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert "Restarting" in result.stdout
+        assert _WEBHOOK_UNIT in result.stdout
+        assert "terminates" in result.stdout.lower()
+
+    def test_nothing_is_recorded_as_deferred(self, harness):
+        harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert harness.ledger() == []
+
+
+class TestDefersUnderALiveDeploy:
+    def test_caller_declaration_defers_the_restart(self, harness):
+        result = harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert result.returncode == 0, result.stderr
+        assert harness.sudo_calls() == []
+
+    def test_helper_marker_defers_the_restart(self, harness):
+        """An older webhook over the socket sets only the legacy marker."""
+        harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}",
+            env={"FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER": "1"},
+        )
+        assert harness.sudo_calls() == []
+
+    def test_a_held_deployment_lock_defers_the_restart(self, harness):
+        """The probe is the backstop for a caller that does not declare."""
+        lock = harness.lock_dir / "api.lock"
+        lock.touch()
+        with lock.open("w") as fd:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert harness.sudo_calls() == []
+
+    def test_a_free_lock_file_does_not_defer(self, harness):
+        """A lock file left behind by a finished deploy is not a live deploy."""
+        (harness.lock_dir / "api.lock").touch()
+        harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert any(
+            f"systemctl restart {_WEBHOOK_UNIT}" in call
+            for call in harness.sudo_calls()
+        )
+
+    def test_deferral_names_the_unit_and_the_signal(self, harness):
+        result = harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert "Deferring restart" in result.stdout
+        assert _WEBHOOK_UNIT in result.stdout
+        assert "declared" in result.stdout
+
+    def test_deploy_socket_is_deferred_too(self, harness):
+        """The deploy socket propagates a restart to the deploy-daemon instance."""
+        harness.run(
+            f"_restart_deploy_host_unit {_DEPLOY_SOCKET}",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert harness.sudo_calls() == []
+
+
+class TestLockProbeSideEffects:
+    def test_probe_creates_no_lock_files(self, harness):
+        """Creating a root-owned lock file would break the deploy user's open('w')."""
+        harness.run(f"_restart_deploy_host_unit {_WEBHOOK_UNIT}")
+        assert list(harness.lock_dir.glob("*.lock")) == []
+
+    def test_missing_flock_warns_and_still_restarts(self, harness):
+        """A backstop that cannot run must not block a manual re-bake."""
+        result = harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}", with_flock=False
+        )
+        assert "could not probe deployment locks" in result.stderr
+        assert any(
+            f"systemctl restart {_WEBHOOK_UNIT}" in call
+            for call in harness.sudo_calls()
+        )
+
+    def test_missing_flock_does_not_override_a_declaring_caller(self, harness):
+        """The caller's declaration is authoritative and never needs the probe."""
+        result = harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+            with_flock=False,
+        )
+        assert harness.sudo_calls() == []
+        assert "could not probe" not in result.stderr
+
+
+# --------------------------------------------------------------------------
+# The debt is recorded, so nothing pays it silently or forgets it.
+# --------------------------------------------------------------------------
+
+
+class TestDeferredRestartLedger:
+    def test_deferred_unit_is_recorded(self, harness):
+        harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}\n_report_deferred_restarts",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert harness.ledger() == [_WEBHOOK_UNIT]
+
+    def test_ledger_merges_with_an_unpaid_entry_from_an_earlier_install(self, harness):
+        (harness.lock_dir / ".deferred-restarts").write_text(f"{_DEPLOY_SOCKET}\n")
+        harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}\n_report_deferred_restarts",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert sorted(harness.ledger()) == sorted([_WEBHOOK_UNIT, _DEPLOY_SOCKET])
+
+    def test_ledger_does_not_duplicate_a_unit_already_pending(self, harness):
+        (harness.lock_dir / ".deferred-restarts").write_text(f"{_WEBHOOK_UNIT}\n")
+        harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}\n_report_deferred_restarts",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert harness.ledger() == [_WEBHOOK_UNIT]
+
+    def test_summary_lists_what_is_still_running_its_old_unit(self, harness):
+        result = harness.run(
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}\n_report_deferred_restarts",
+            env={"FRAISIER_DEPLOY_IN_FLIGHT": "1"},
+        )
+        assert "Deferred restarts" in result.stdout
+        assert _WEBHOOK_UNIT in result.stdout
+
+    def test_no_summary_and_no_ledger_when_nothing_was_deferred(self, harness):
+        result = harness.run("_report_deferred_restarts")
+        assert "Deferred restarts" not in result.stdout
+        assert harness.ledger() == []
+
+
+# --------------------------------------------------------------------------
+# The guard: no deploy-hosting unit is restarted outside the seam.
+# --------------------------------------------------------------------------
+
+_SEAM = "_restart_deploy_host_unit"
+
+
+def _unguarded_deploy_host_restarts(text: str, units: set[str]) -> list[str]:
+    """Lines that restart a deploy-hosting unit outside the seam function.
+
+    The seam is the only place these units may be restarted; inside it the unit
+    is a shell variable, never a literal, so any literal occurrence in a
+    ``systemctl restart`` line is by definition a bypass.
+    """
+    offenders = []
+    in_seam = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{_SEAM}()"):
+            in_seam = True
+            continue
+        if in_seam and stripped == "}":
+            in_seam = False
+            continue
+        if in_seam or "systemctl restart" not in line:
+            continue
+        if any(unit in line for unit in units):
+            offenders.append(line.strip())
+    return offenders
+
+
+class TestNoUnguardedDeployHostRestart:
+    """A restart of a deploy-hosting unit outside the seam is the whole bug."""
+
+    @pytest.fixture
+    def rendered(self, tmp_path):
+        return _render(tmp_path, tmp_path / "lockdir").read_text()
+
+    def test_no_deploy_hosting_unit_is_restarted_outside_the_seam(self, rendered):
+        offenders = _unguarded_deploy_host_restarts(
+            rendered, {_WEBHOOK_UNIT, _DEPLOY_SOCKET}
+        )
+        assert offenders == [], (
+            "these lines restart a unit that may be running a deploy; route them "
+            f"through {_SEAM}: {offenders}"
+        )
+
+    def test_the_seam_is_actually_used(self, rendered):
+        """A guard that nothing calls is indistinguishable from a passing one."""
+        calls = [ln for ln in rendered.splitlines() if ln.strip().startswith(_SEAM)]
+        assert len(calls) >= 2, (
+            "expected the webhook unit and at least one deploy socket to be "
+            f"restarted through {_SEAM}, found: {calls}"
+        )
+
+    def test_guard_detects_a_bypass(self, rendered):
+        """Meta-test: a tree-scanning guard that matches nothing always passes."""
+        mutated = rendered + (
+            f"\n_run sudo systemctl restart {_WEBHOOK_UNIT} || true\n"
+        )
+        offenders = _unguarded_deploy_host_restarts(
+            mutated, {_WEBHOOK_UNIT, _DEPLOY_SOCKET}
+        )
+        assert offenders, "the guard cannot detect an unguarded restart"
+
+    def test_guard_ignores_units_that_do_not_host_deploys(self, rendered):
+        """The install-helper re-bake (#279) must stay outside the seam."""
+        offenders = _unguarded_deploy_host_restarts(
+            rendered + "\n_run sudo systemctl restart some-other.service\n",
+            {_WEBHOOK_UNIT, _DEPLOY_SOCKET},
+        )
+        assert offenders == []

--- a/tests/test_scaffold_install_declares_deploy.py
+++ b/tests/test_scaffold_install_declares_deploy.py
@@ -1,0 +1,149 @@
+"""The "a deploy is in flight" declaration must survive `sudo` (#349).
+
+The subprocess install path is deployer → ``fraisier scaffold-install`` →
+``sudo install.sh``. An environment variable crosses the first hop and dies at
+the second, because sudo resets the environment. So the CLI reads the variable
+it inherited and re-states it as a flag, which sudo passes through untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+from fraisier.config import FraisierConfig
+from fraisier.scaffold.renderer import ScaffoldRenderer
+
+_YAML = """\
+name: testapp
+servers:
+  example.com:
+    machine_hostnames: [default-testrunner]
+
+fraises:
+  api:
+    type: api
+    environments:
+      production:
+        server: example.com
+
+deployment:
+  lock_dir: {lock_dir}
+
+scaffold:
+  deploy_user: testapp_deploy
+"""
+
+_WEBHOOK_UNIT = "fraisier-testapp-webhook.service"
+
+_SUDO_STUB = """\
+#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$FRAISIER_TEST_SUDO_LOG"
+exit 0
+"""
+
+
+@pytest.fixture
+def rendered(tmp_path):
+    lock_dir = tmp_path / "lockdir"
+    lock_dir.mkdir()
+    cfg_path = tmp_path / "fraises.yaml"
+    cfg_path.write_text(_YAML.format(lock_dir=lock_dir))
+    renderer = ScaffoldRenderer(FraisierConfig(cfg_path))
+    renderer.output_dir = tmp_path / "generated"
+    renderer.render()
+    return tmp_path / "generated" / "install.sh"
+
+
+def _source_with_args(tmp_path, install_sh, args: str, snippet: str):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    sudo = bin_dir / "sudo"
+    sudo.write_text(_SUDO_STUB)
+    sudo.chmod(0o755)
+    sudo_log = tmp_path / "sudo.log"
+
+    script = tmp_path / "flagharness.sh"
+    script.write_text(f'. "{install_sh}" {args}\n{textwrap.dedent(snippet)}\n')
+    env = {
+        **os.environ,
+        "FRAISIER_TEST_SUDO_LOG": str(sudo_log),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+    }
+    env.pop("FRAISIER_DEPLOY_IN_FLIGHT", None)
+    env.pop("FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER", None)
+    result = subprocess.run(
+        ["bash", str(script)], check=False, capture_output=True, text=True, env=env
+    )
+    calls = (
+        [ln for ln in sudo_log.read_text().splitlines() if ln.strip()]
+        if sudo_log.exists()
+        else []
+    )
+    return result, calls
+
+
+class TestInstallShDeployInFlightFlag:
+    def test_flag_defers_the_restart(self, tmp_path, rendered):
+        result, calls = _source_with_args(
+            tmp_path,
+            rendered,
+            "--deploy-in-flight",
+            f"_restart_deploy_host_unit {_WEBHOOK_UNIT}",
+        )
+        assert result.returncode == 0, result.stderr
+        assert calls == []
+        assert "Deferring restart" in result.stdout
+
+    def test_without_the_flag_the_restart_happens(self, tmp_path, rendered):
+        result, calls = _source_with_args(
+            tmp_path, rendered, "", f"_restart_deploy_host_unit {_WEBHOOK_UNIT}"
+        )
+        assert result.returncode == 0, result.stderr
+        assert any(f"systemctl restart {_WEBHOOK_UNIT}" in c for c in calls)
+
+    def test_help_documents_the_flag(self, rendered):
+        result = subprocess.run(
+            ["bash", str(rendered), "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert "--deploy-in-flight" in result.stdout
+
+
+class TestCliForwardsTheDeclarationAcrossSudo:
+    """`sudo` resets the environment, so the variable must become a flag."""
+
+    def test_flag_is_added_when_the_deployer_declared_a_deploy(self, monkeypatch):
+        from fraisier.cli import scaffold as scaffold_cli
+
+        monkeypatch.setenv("FRAISIER_DEPLOY_IN_FLIGHT", "1")
+        cmd = scaffold_cli._build_install_cmd(
+            "/tmp/install.sh", dry_run=False, validate_only=False, verbose=False
+        )
+        assert "--deploy-in-flight" in cmd
+
+    def test_flag_is_absent_for_an_operator_run(self, monkeypatch):
+        from fraisier.cli import scaffold as scaffold_cli
+
+        monkeypatch.delenv("FRAISIER_DEPLOY_IN_FLIGHT", raising=False)
+        cmd = scaffold_cli._build_install_cmd(
+            "/tmp/install.sh", dry_run=False, validate_only=False, verbose=False
+        )
+        assert "--deploy-in-flight" not in cmd
+
+    def test_sudo_still_leads_the_command(self, monkeypatch):
+        from fraisier.cli import scaffold as scaffold_cli
+
+        monkeypatch.setenv("FRAISIER_DEPLOY_IN_FLIGHT", "1")
+        cmd = scaffold_cli._build_install_cmd(
+            "/tmp/install.sh", dry_run=True, validate_only=False, verbose=True
+        )
+        assert cmd[0] == "sudo"
+        assert cmd[1] == "/tmp/install.sh"
+        assert "--dry-run" in cmd
+        assert "--verbose" in cmd

--- a/tests/test_scaffold_install_helper.py
+++ b/tests/test_scaffold_install_helper.py
@@ -121,6 +121,64 @@ class TestHandleConnection:
         # Inherits the ambient environment rather than replacing it wholesale.
         assert "PATH" in env
 
+    def test_declared_deploy_reaches_install_sh(self, tmp_path):
+        """A request declaring a live deploy sets the marker install.sh reads to
+        decide whether restarting the webhook would kill its own caller (#349)."""
+        script = tmp_path / "install.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _call(
+                {"action": "install", "deploy_in_flight": True},
+                allowed_script=str(script),
+            )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["FRAISIER_DEPLOY_IN_FLIGHT"] == "1"
+
+    def test_undeclared_request_leaves_the_marker_unset(self, tmp_path):
+        """An operator-invoked install must keep restarting units normally."""
+        script = tmp_path / "install.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _call({"action": "install"}, allowed_script=str(script))
+
+        env = mock_run.call_args.kwargs["env"]
+        assert "FRAISIER_DEPLOY_IN_FLIGHT" not in env
+
+    def test_non_boolean_declaration_is_not_trusted(self, tmp_path):
+        """The payload reaches a root daemon; only a real `true` counts."""
+        script = tmp_path / "install.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _call(
+                {"action": "install", "deploy_in_flight": "yes; rm -rf /"},
+                allowed_script=str(script),
+            )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert "FRAISIER_DEPLOY_IN_FLIGHT" not in env
+
     def test_unknown_action_is_rejected(self, tmp_path):
         """Unknown actions are rejected without running the script."""
         script = tmp_path / "install.sh"

--- a/tests/test_status_owner_and_reconcile.py
+++ b/tests/test_status_owner_and_reconcile.py
@@ -1,0 +1,247 @@
+"""A deploy that is killed must still leave a record (#349).
+
+The webhook is SIGKILLed at systemd's stop timeout when something restarts it
+mid-deploy. The kernel releases the flock, so the *lock* recovers — but the
+status file is left saying ``deploying`` forever, and `fraisier status` paints
+that blue with an ever-growing elapsed time. Nothing distinguishes a deploy in
+progress from one whose process no longer exists.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from fraisier.status import (
+    FAILURE_STATES,
+    NON_TERMINAL_STATES,
+    DeploymentStatusFile,
+    current_owner,
+    owner_is_gone,
+    read_status,
+    reconcile_orphaned_deploys,
+    write_status,
+)
+
+
+def _read(tmp_path, name="api") -> DeploymentStatusFile:
+    status = read_status(name, status_dir=tmp_path)
+    assert status is not None, f"no status file for {name}"
+    return status
+
+
+def _status(tmp_path, **kwargs):
+    base: dict[str, Any] = {
+        "fraise_name": "api",
+        "environment": "production",
+        "state": "deploying",
+        "started_at": "2026-08-08T19:11:58",
+    }
+    base.update(kwargs)
+    status = DeploymentStatusFile(**base)
+    write_status(status, status_dir=tmp_path)
+    return status
+
+
+class TestOwnerIdentity:
+    def test_current_owner_records_this_process(self):
+        owner = current_owner()
+        assert owner["owner_pid"] == os.getpid()
+
+    def test_boot_id_is_recorded_when_the_kernel_exposes_one(self):
+        owner = current_owner()
+        # Linux exposes /proc/sys/kernel/random/boot_id; elsewhere None is
+        # honest rather than fabricated.
+        assert "owner_boot_id" in owner
+
+    def test_invocation_id_comes_from_systemd(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "cafe1234")
+        assert current_owner()["owner_invocation_id"] == "cafe1234"
+
+    def test_absent_invocation_id_is_none_not_empty(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        assert current_owner()["owner_invocation_id"] is None
+
+
+class TestOwnerIsGone:
+    def test_a_different_boot_is_definitive(self):
+        status = DeploymentStatusFile(
+            fraise_name="api",
+            environment="production",
+            state="deploying",
+            owner_pid=os.getpid(),
+            owner_boot_id="not-this-boot",
+        )
+        assert owner_is_gone(status) is True
+
+    def test_a_live_pid_on_this_boot_is_not_gone(self):
+        status = DeploymentStatusFile(
+            fraise_name="api",
+            environment="production",
+            state="deploying",
+            **current_owner(),
+        )
+        assert owner_is_gone(status) is False
+
+    def test_a_dead_pid_is_gone(self):
+        owner = current_owner()
+        # PID 2^22 + 1 is above the default pid_max, so it cannot exist.
+        owner["owner_pid"] = 4194305
+        status = DeploymentStatusFile(
+            fraise_name="api", environment="production", state="deploying", **owner
+        )
+        assert owner_is_gone(status) is True
+
+    def test_no_owner_recorded_is_not_provably_gone(self):
+        """Status files written before this release carry no identity."""
+        status = DeploymentStatusFile(
+            fraise_name="api", environment="production", state="deploying"
+        )
+        assert owner_is_gone(status) is False
+
+
+class TestInterruptedIsAFailure:
+    def test_interrupted_is_in_failure_states(self):
+        assert "interrupted" in FAILURE_STATES
+
+    def test_deploying_and_pending_are_the_non_terminal_states(self):
+        assert frozenset({"pending", "deploying"}) == NON_TERMINAL_STATES
+
+    def test_no_state_is_both_terminal_and_non_terminal(self):
+        assert not (FAILURE_STATES & NON_TERMINAL_STATES)
+
+
+class TestReconcileOrphanedDeploys:
+    def test_a_dead_owner_becomes_interrupted(self, tmp_path):
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, **owner)
+
+        changed = reconcile_orphaned_deploys(status_dir=tmp_path)
+
+        assert changed == ["api"]
+        assert _read(tmp_path).state == "interrupted"
+
+    def test_the_record_says_the_deploy_never_reported(self, tmp_path):
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, **owner)
+        reconcile_orphaned_deploys(status_dir=tmp_path)
+
+        status = _read(tmp_path)
+        assert "did not report" in (status.error_message or "").lower()
+        assert status.finished_at is not None
+        assert status.started_at == "2026-08-08T19:11:58"
+
+    def test_a_live_owner_is_left_alone(self, tmp_path):
+        _status(tmp_path, **current_owner())
+        assert reconcile_orphaned_deploys(status_dir=tmp_path) == []
+        assert _read(tmp_path).state == "deploying"
+
+    def test_a_terminal_state_is_never_rewritten(self, tmp_path):
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, state="success", **owner)
+        assert reconcile_orphaned_deploys(status_dir=tmp_path) == []
+        assert _read(tmp_path).state == "success"
+
+    def test_a_missing_status_dir_is_not_an_error(self, tmp_path):
+        assert reconcile_orphaned_deploys(status_dir=tmp_path / "nope") == []
+
+    def test_an_unparseable_status_file_is_skipped_not_fatal(self, tmp_path):
+        (tmp_path / "api.status.json").write_text("{not json")
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, fraise_name="other", **owner)
+        assert reconcile_orphaned_deploys(status_dir=tmp_path) == ["other"]
+
+
+class TestStatusFileWireFormat:
+    def test_read_status_ignores_keys_it_does_not_know(self, tmp_path):
+        """A host mid-self-upgrade runs two fraisier versions; the reader must
+        not crash on a field the writer added."""
+        (tmp_path / "api.status.json").write_text(
+            json.dumps(
+                {
+                    "fraise_name": "api",
+                    "environment": "production",
+                    "state": "success",
+                    "some_future_field": 1,
+                }
+            )
+        )
+        status = read_status("api", status_dir=tmp_path)
+        assert status is not None
+        assert status.state == "success"
+
+    def test_a_file_without_owner_fields_still_loads(self, tmp_path):
+        (tmp_path / "api.status.json").write_text(
+            json.dumps(
+                {
+                    "fraise_name": "api",
+                    "environment": "production",
+                    "state": "deploying",
+                }
+            )
+        )
+        status = read_status("api", status_dir=tmp_path)
+        assert status is not None
+        assert status.owner_pid is None
+
+
+class TestConsumersHandleInterrupted:
+    def test_cli_renders_interrupted_loudly(self, tmp_path, monkeypatch):
+        from fraisier.cli import _info
+
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, state="interrupted", **owner)
+        monkeypatch.setattr(
+            _info, "read_status", lambda name: read_status(name, status_dir=tmp_path)
+        )
+        rendered = _info._compute_deployment_state("api", "abc", "abc")
+        assert "interrupt" in rendered.lower()
+        assert "red" in rendered
+
+    def test_cli_does_not_show_a_dead_deploy_as_deploying(self, tmp_path, monkeypatch):
+        """The blue `deploying (86400s)` is the symptom the issue describes."""
+        from fraisier.cli import _info
+
+        owner = current_owner()
+        owner["owner_pid"] = 4194305
+        _status(tmp_path, **owner)
+        monkeypatch.setattr(
+            _info, "read_status", lambda name: read_status(name, status_dir=tmp_path)
+        )
+        rendered = _info._compute_deployment_state("api", "abc", "abc")
+        assert "deploying" not in rendered.lower()
+
+    def test_webhook_failure_details_answer_for_interrupted(self):
+        """`/api/status/{fraise}/details` gates on FAILURE_STATES, so membership
+        is what stops it answering 'No failure to report' (#293's consumer)."""
+        assert "interrupted" in FAILURE_STATES
+
+
+class TestDeployersRecordTheirIdentity:
+    def test_write_status_stamps_the_owner(self, tmp_path):
+        from fraisier.deployers.mixins import GitDeployMixin
+
+        class _D(GitDeployMixin):
+            def __init__(self):
+                self.fraise_name = "api"
+                self.environment = "production"
+                self.status_dir = tmp_path
+
+        _D()._write_status("deploying")
+        assert _read(tmp_path).owner_pid == os.getpid()
+
+
+@pytest.mark.parametrize("state", ["pending", "deploying"])
+def test_every_non_terminal_state_is_reconciled(tmp_path, state):
+    owner = current_owner()
+    owner["owner_pid"] = 4194305
+    _status(tmp_path, state=state, **owner)
+    assert reconcile_orphaned_deploys(status_dir=tmp_path) == ["api"]

--- a/tests/test_webhook_pays_deferred_restarts.py
+++ b/tests/test_webhook_pays_deferred_restarts.py
@@ -1,0 +1,101 @@
+"""The deploy that caused a deferral is what pays it back (#349).
+
+`install.sh` records the restarts it did not perform; the webhook spawns the
+drain worker at the end of the deploy, while the lock it must wait for is still
+held. Skipped only when a self-upgrade is already draining, because both raise
+the same single ``.draining`` flag.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fraisier import webhook as webhook_mod
+
+
+class _Result:
+    def __init__(self, success: bool):
+        self.success = success
+        self.new_version = "abc1234"
+        self.old_version = "def5678"
+        self.error_message = None if success else "boom"
+        self.status = SimpleNamespace(value="success" if success else "failed")
+
+
+def _config(tmp_path):
+    return SimpleNamespace(
+        project_name="testapp",
+        webhook={},
+        deployment=SimpleNamespace(lock_dir=str(tmp_path)),
+        get_deploy_user=lambda *_a, **_k: "deployer",
+    )
+
+
+@pytest.fixture
+def wiring(tmp_path, monkeypatch):
+    """Drive `_run_deployment` with the deployer and side effects stubbed out."""
+    calls = SimpleNamespace(deferred=[], upgrade=[])
+
+    deployer = MagicMock()
+    monkeypatch.setattr(webhook_mod, "get_config", lambda: _config(tmp_path))
+    monkeypatch.setenv("FRAISIER_SYSTEMCTL_SOCKET", "/run/x.sock")
+
+    def _fake_deferred(**kwargs):
+        calls.deferred.append(kwargs)
+
+    def _fake_upgrade(*_a, **_k):
+        calls.upgrade.append(True)
+        return calls.upgrade_returns
+
+    calls.upgrade_returns = False
+    monkeypatch.setattr(webhook_mod, "maybe_apply_deferred_restarts", _fake_deferred)
+    monkeypatch.setattr(webhook_mod, "maybe_self_upgrade", _fake_upgrade)
+    calls.deployer = deployer
+    calls.tmp_path = tmp_path
+    return calls
+
+
+async def _run(wiring, *, success: bool):
+    wiring.deployer.execute.return_value = _Result(success)
+    # Patch the name `_run_deployment` imports, not `APIDeployer.__new__`:
+    # restoring a patched `__new__` leaves a real attribute on the class where
+    # there was only an inherited one, and every later test that builds an
+    # APIDeployer inherits that.
+    with patch("fraisier.deployers.api.APIDeployer", return_value=wiring.deployer):
+        await webhook_mod._run_deployment(
+            "api",
+            "production",
+            {"type": "api", "app_path": str(wiring.tmp_path / "app")},
+            None,
+            "main",
+            "abc1234",
+            MagicMock(),
+        )
+
+
+class TestDeferredRestartsArePaid:
+    @pytest.mark.asyncio
+    async def test_paid_after_a_successful_deploy(self, wiring):
+        await _run(wiring, success=True)
+        assert len(wiring.deferred) == 1
+        assert str(wiring.deferred[0]["lock_dir"]) == str(wiring.tmp_path)
+        assert wiring.deferred[0]["socket_path"] == "/run/x.sock"
+
+    @pytest.mark.asyncio
+    async def test_paid_after_a_failed_deploy_too(self, wiring):
+        """The units were installed either way; a rollback makes it a no-op."""
+        await _run(wiring, success=False)
+        assert len(wiring.deferred) == 1
+
+    @pytest.mark.asyncio
+    async def test_skipped_while_a_self_upgrade_is_draining(self, wiring):
+        """Two workers would fight over the one `.draining` flag."""
+        wiring.upgrade_returns = True
+        await _run(wiring, success=True)
+        # `_run_deployment` swallows exceptions, so an empty list would also be
+        # what a crashed deploy looks like. Prove the path was reached first.
+        assert wiring.upgrade == [True]
+        assert wiring.deferred == []

--- a/tests/test_webhook_self_upgrade.py
+++ b/tests/test_webhook_self_upgrade.py
@@ -296,7 +296,7 @@ class TestRunUpgrade:
     def test_install_success_triggers_restart_rpc(self):
         with (
             patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
         ):
             mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
             rc = _run_upgrade("0.17.0", "fraisier-foo-webhook.service", "/run/x.sock")
@@ -309,7 +309,7 @@ class TestRunUpgrade:
     def test_install_failure_skips_restart(self):
         with (
             patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
         ):
             mock_run.return_value = SimpleNamespace(
                 returncode=1, stdout="", stderr="oops"
@@ -323,7 +323,7 @@ class TestRunUpgrade:
 
         with (
             patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
             caplog.at_level(logging.WARNING, logger="fraisier.webhook_self_upgrade"),
         ):
             mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -336,7 +336,7 @@ class TestRunUpgrade:
         with (
             patch("fraisier.webhook_self_upgrade.subprocess.run") as mock_run,
             patch(
-                "fraisier.webhook_self_upgrade._call_via_socket",
+                "fraisier.drain_restart._call_via_socket",
                 side_effect=ConnectionRefusedError("nope"),
             ),
         ):
@@ -410,7 +410,7 @@ class TestWaitForDeploysToDrain:
 
         counts = iter([2, 1, 0])
         with patch(
-            "fraisier.webhook_self_upgrade.count_held_deployment_locks",
+            "fraisier.drain_restart.count_held_deployment_locks",
             side_effect=lambda _ld: next(counts),
         ):
             result = _wait_for_deploys_to_drain(tmp_path, 5, 0.01)
@@ -423,7 +423,7 @@ class TestWaitForDeploysToDrain:
         (tmp_path / "api.lock").touch()
         (tmp_path / "worker.lock").touch()
         with patch(
-            "fraisier.webhook_self_upgrade.count_held_deployment_locks",
+            "fraisier.drain_restart.count_held_deployment_locks",
             return_value=2,
         ):
             result = _wait_for_deploys_to_drain(tmp_path, 0.05, 0.01)
@@ -438,7 +438,7 @@ class TestSendRestart:
         from fraisier.webhook_self_upgrade import _send_restart
 
         with patch(
-            "fraisier.webhook_self_upgrade._call_via_socket",
+            "fraisier.drain_restart._call_via_socket",
             return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
         ) as mock_socket:
             rc = _send_restart("/run/x.sock", "fraisier-foo-webhook.service")
@@ -451,7 +451,7 @@ class TestSendRestart:
         from fraisier.webhook_self_upgrade import _send_restart
 
         with patch(
-            "fraisier.webhook_self_upgrade._call_via_socket",
+            "fraisier.drain_restart._call_via_socket",
             side_effect=ConnectionRefusedError("no socket"),
         ):
             rc = _send_restart("/run/x.sock", "svc")
@@ -461,7 +461,7 @@ class TestSendRestart:
         from fraisier.webhook_self_upgrade import _send_restart
 
         with patch(
-            "fraisier.webhook_self_upgrade._call_via_socket",
+            "fraisier.drain_restart._call_via_socket",
             side_effect=subprocess.CalledProcessError(1, "restart"),
         ):
             rc = _send_restart("/run/x.sock", "svc")
@@ -515,7 +515,7 @@ class TestRunUpgradeDrainCoordination:
                 side_effect=fake_drain,
             ),
             patch(
-                "fraisier.webhook_self_upgrade._call_via_socket",
+                "fraisier.drain_restart._call_via_socket",
                 side_effect=fake_socket,
             ),
         ):
@@ -558,7 +558,7 @@ class TestRunUpgradeDrainCoordination:
                 "fraisier.webhook_self_upgrade._wait_for_deploys_to_drain",
                 return_value=_DrainResult(drained=False, held=["api.lock"]),
             ),
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
             caplog.at_level(logging.WARNING, logger="fraisier.webhook_self_upgrade"),
         ):
             rc = _run_upgrade(
@@ -589,7 +589,7 @@ class TestRunUpgradeDrainCoordination:
             patch(
                 "fraisier.webhook_self_upgrade._wait_for_deploys_to_drain"
             ) as mock_drain,
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
         ):
             rc = _run_upgrade(
                 "0.31.0",
@@ -617,7 +617,7 @@ class TestRunUpgradeDrainCoordination:
             patch(
                 "fraisier.webhook_self_upgrade._wait_for_deploys_to_drain"
             ) as mock_drain,
-            patch("fraisier.webhook_self_upgrade._call_via_socket") as mock_socket,
+            patch("fraisier.drain_restart._call_via_socket") as mock_socket,
             caplog.at_level(logging.WARNING, logger="fraisier.webhook_self_upgrade"),
         ):
             rc = _run_upgrade(

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.62.0"
+version = "0.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #349.

## The bug

When a deploy synced a changed `fraises.yaml`, it installed the scaffold *in
process*, and `install.sh` then ran `systemctl restart <project>-webhook.service`
— SIGTERMing the very process running the deploy. The webhook does not exit
while a deploy is in flight, so systemd's 90-second stop timeout expired, the
process was SIGKILLed, and the deploy died mid-flight. **Any change to
`fraises.yaml` failed its own deploy, deterministically**, reported as "timeout
waiting for deployment" — which reads as slow rather than killed.

Fourth instance of v0.61.0/v0.62.0's theme, *work that could not fail visibly*,
with the reporter itself destroyed. So this states the invariant rather than
patching the site:

> Nothing fraisier installs may terminate the work that asked for it, and work
> that starts must end in a record.

## What the issue's one-liner would have left behind

The suggested `FRAISIER_VIA_SCAFFOLD_INSTALL_HELPER` guard is necessary and not
sufficient, for two reasons found by reading the code:

- **There are two deploy-hosting units, not one.** `deploy-service.j2` carries
  `Requires=<its socket>`, and systemd propagates an explicit restart of a
  required unit to its dependents — so restarting a deploy socket restarts the
  `deploy-daemon` instance running a deploy. Same mechanism as the
  scaffold-install-helper race already guarded 60 lines below. Routing those
  through the guard costs nothing: they exist because a *first-time* install
  wipes `/run/fraisier/`, and a first-time install has no deploy in flight.
- **A deferral nothing pays back recreates the "rendered ≠ installed" class**
  v0.57.0 and v0.58.0 were about. The webhook keeps its old `ReadWritePaths=`,
  so a `fraises.yaml` change adding an environment makes the *next* deploy fail
  read-only.

The marker also only exists on the helper-socket path. The subprocess fallback
runs `install.sh` as a child of the deploy, where the restart kills the cgroup
just the same — and `sudo` in the middle of that path resets the environment,
so the declaration has to become a flag to survive it.

## Commits

| commit | scope |
|---|---|
| `fec2749` | one seam for a dangerous restart, the in-flight predicate, content diff |
| `5ef825a` | the caller declares a deploy in flight, on every path and across `sudo` |
| `7710ee3` | a deferred restart is a debt: `drain_restart` extraction + `doctor` check |
| `110eff0` | a deploy that is killed leaves a record: owner identity + `interrupted` |
| `f3a0c1a` | CHANGELOG, docs, v0.63.0 |

## Blast radius

Nothing here adds or removes units, so the opposite-directions release split
does not apply. A host that never changes `fraises.yaml` during a deploy behaves
exactly as before; hosts that do will see those deploys succeed for the first
time, with the webhook restart landing after the deploy rather than during it.
Manual `scaffold-install` is unaffected — no lock held, no declaration, every
restart as today.

`fraisier doctor` gains `deferred_restarts`, which reports a unit that was
deferred and never restarted instead of leaving it silently on an old config.

## Verification

- 5098 passed / 7 skipped (5105 collected, vs 5025 on `main`: **+80**)
- `ruff check` clean, `ruff format --check` clean on 478 files
- `ty check` exit 0, zero diagnostics
- rendered `install.sh` passes `bash -n`

Each gate run separately with its own exit status echoed. Collected counts
compared against `origin/main` in a detached worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)