### PR TITLE
fix(ship): the release gate runs the suite plainly (#352)

### DIFF
--- a/fraises.yaml
+++ b/fraises.yaml
@@ -42,11 +42,6 @@ ship:
       command: ["uv", "run", "ruff", "check", "."]
       phase: validate
     - name: pytest
-      command:
-        - "uv"
-        - "run"
-        - "pytest"
-        - "--deselect"
-        - "tests/test_install_helper.py::TestMainConnectionErrorLogging::test_handler_crash_is_logged_with_exception_object"
+      command: ["uv", "run", "pytest"]
       phase: test
       timeout: 300


### PR DESCRIPTION
Closes #352.

The pytest check in this project's own `ship:` config still carried a `--deselect`
for the old "install-helper flake". PR #306 diagnosed that flake as **argv
dependence** and fixed it at the source; the workaround outlived the cause.

A `--deselect` in a ship check is the same shape #306 removed: it makes the result
depend on the argv the gate happens to use, and it permanently hides one test from
the single run that decides whether a release goes out. If that test ever starts
failing for a real reason, `fraisier ship` would not say so.

## Change

```diff
     - name: pytest
-      command:
-        - "uv"
-        - "run"
-        - "pytest"
-        - "--deselect"
-        - "tests/test_install_helper.py::TestMainConnectionErrorLogging::test_handler_crash_is_logged_with_exception_object"
+      command: ["uv", "run", "pytest"]
       phase: test
       timeout: 300
```

Back to the same inline form as the two ruff checks above it.

## Why no version bump or CHANGELOG entry

This is the project's own deploy/ship config. No source file changes, so nothing
shipped to users differs. `main` still carries the unreleased v0.63.0 bump.

## Verification

The formerly deselected test passes three ways on `main` @ `d4895fe`:

| run | result |
|---|---|
| the test alone | `1 passed in 0.03s` |
| its whole file | `24 passed in 0.05s` |
| the full suite, no `--deselect` | `5098 passed, 7 skipped` |

Gates on this branch, each with its own exit status read separately:

- ✅ `uv run pytest` — **5098 passed / 7 skipped in 92.46s**, exit 0. Identical to
  `main`: no test reads the repo's own `fraises.yaml` (all use `tmp_path`
  fixtures), so the change is inert to the suite. Also comfortably inside the
  check's own `timeout: 300`.
- ✅ `uv run ruff check .` — All checks passed, exit 0
- ✅ `uv run ruff format --check .` — 478 files already formatted, exit 0
- ✅ `uv run ty check` — All checks passed, exit 0, **zero diagnostics**
- ✅ `get_config("fraises.yaml").ship` parses; the pytest check resolves to
  `['uv', 'run', 'pytest']`, phase `test`, timeout 300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
