### PR TITLE
fix(self-upgrade): a tool that replaces itself must leave a working tool (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ invariant rather than patching the site:
 > **Nothing fraisier installs may terminate the work that asked for it, and work
 > that starts must end in a record.**
 
+[#351](https://github.com/fraiseql/fraisier/issues/351) turned out to be the same
+invariant one level up, so it ships here too: a failed self-upgrade left the tool
+venv half-removed and every entrypoint dangling, reported only to a file nothing
+reads. Where #349 was an install destroying the deploy that asked for it, #351
+was fraisier destroying *itself* and staying quiet about it. The reach extends
+accordingly:
+
+> **A tool that replaces itself must leave a working tool, and must say so.**
+
 ### Fixed
 
 - **`install.sh` no longer restarts a unit that hosts a deploy while a deploy is
@@ -89,6 +98,35 @@ invariant rather than patching the site:
   be half-deployed. `owner_invocation_id` is not used to decide liveness; it is
   recorded so an operator can recover the dead deploy's journal with
   `journalctl _SYSTEMD_INVOCATION_ID=<id>`.
+- **A self-upgrade that does not land says so, and does not make it worse**
+  ([#351](https://github.com/fraiseql/fraisier/issues/351)). `uv tool install
+  --force` removes before it verifies, so an install that failed partway left the
+  tool venv half-removed — `bin/` gone, `lib/` intact — and every
+  `~/.local/bin/fraisier*` symlink dangling, including the one the webhook unit
+  names in `ExecStart=`. The running process outlived its deleted binary, so
+  `is-active`, the health check and the version endpoint all looked normal; the
+  damage surfaced only at the next restart, as 203/EXEC.
+  - The worker now **resolves its own unit's entrypoint after the install and
+    refuses the restart when it does not resolve** — on a zero rc as well as a
+    non-zero one, because success is not proof. Restarting at that moment would
+    turn a latent problem into an outage: the process running is the only working
+    fraisier left on the host.
+  - A failed upgrade is recorded in
+    `<deployment.lock_dir>/.self-upgrade-failure`, **cleared only when a later
+    upgrade lands**, and reported by a new `self_upgrade_failure` doctor check.
+  - A new **`unit_entrypoints`** doctor check asks the question from the other
+    end: every installed unit's `ExecStart=` fraisier binary must exist and be
+    executable. It takes no config — the units on disk are the input — and it
+    does not care how the host got there, so it catches a machine that is already
+    in this state today.
+- **Both detached workers were mute, and that had a one-line cause.** Neither
+  `webhook_self_upgrade` nor `deferred_restart` configured logging, so Python fell
+  back to `logging.lastResort` — WARNING level, straight to stderr — and every
+  `log.info` was dropped, including the line naming the command about to run. The
+  deferred-restart worker was additionally spawned onto `DEVNULL` for both stdout
+  and stderr, so even its warnings were unrecoverable: the ledger recorded *that*
+  a debt went unpaid and nothing recorded *why*. Both now route through one named
+  seam, with a guard test asserting every `python -m` worker uses it.
 
 ### Changed
 
@@ -127,6 +165,12 @@ Upgrading will also pull confiture forward from 0.38.x to 0.44.x. Nothing in
 fraisier's behaviour changes with it — the full suite passes unmodified against
 0.44.0 — but the resolved version moves, so a host that pins its own confiture
 should check that pin.
+
+`fraisier doctor` gains two checks worth running once after upgrading.
+`unit_entrypoints` reports `fail` if any installed unit names a fraisier binary
+that no longer resolves — a host whose earlier self-upgrade failed is already in
+that state, and will not restart until it is repaired. `self_upgrade_failure`
+reports the upgrade that left it there, if one did.
 
 ## [0.62.0] - 2026-08-08
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -39,6 +39,7 @@ passed.
 | `inert_timers` | which `scaffold.systemd.timers` families this host runs, and which it only carries | no | none needed — see [scheduled timers you switch on](deployment-guide.md#scheduled-timers-you-switch-on) |
 | `backup_retention` | every declared `retain` corpus has both halves of its prune unit on disk | no | `sudo fraisier scaffold-install` — until then nothing prunes that corpus |
 | `self_upgrade_failure` | the last webhook self-upgrade landed, rather than leaving the tool venv half-removed | no | clear foreign-owned `__pycache__`, then `uv tool install --force fraisier==<version>` — see [a self-upgrade that did not land](#a-self-upgrade-that-did-not-land) |
+| `unit_entrypoints` | every installed unit's `ExecStart=` fraisier binary exists and is executable | no | reinstall the tool venv — a unit whose entrypoint dangles fails 203/EXEC at its next restart |
 | `backup_corpus_free_space` | each `retain[].dir` exists and its volume meets the entry's `min_free_gb` | no | free space on the volume, or declare a threshold — see [`min_free_gb`](deployment-guide.md#min_free_gb--a-policy-is-not-a-disk-alarm) |
 | `scaffold_artifact_coverage` | every artifact the manifest declares for this host is installed | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
 | `foreign_units` | no `fraisier` unit on this host belongs to a fraise or environment this host does not own | no | `sudo fraisier scaffold-install --prune` — see [one host authority](deployment-guide.md#scheduled-timers-you-switch-on) |
@@ -136,6 +137,24 @@ sudo systemctl restart fraisier-<project>-webhook.service
 
 The worker's own log, which records the command it ran and the full stderr, is
 under `/var/lib/fraisier/self-upgrade/`.
+
+`unit_entrypoints` asks the same question from the other end, and does not care
+how the host got there: it reads every `*.service` under `/etc/systemd/system`,
+takes the binary from each `ExecStart=`, keeps the ones named `fraisier*`, and
+checks that each still exists and is executable. A failed self-upgrade, a
+half-finished manual install and a pruned venv all read the same to it. It takes
+no configuration — the units on disk are the input — so it still answers on a
+host whose `fraises.yaml` will not load.
+
+It reports `fail` rather than `warn`, because unlike a deferred restart the unit
+cannot start at all: the service running now is the last one that ever will,
+until it is fixed. Existence is checked before `os.access`, since `os.access`
+with `X_OK` is permissive for root and a root-run `doctor` would otherwise call
+a missing file executable.
+
+If no unit names a fraisier binary, the check reports `skip` and says so, rather
+than `pass`. A scan that matched nothing must not read as a clean bill of
+health.
 
 ## JSON output
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -38,6 +38,7 @@ passed.
 | `install_compile_bytecode` | a `uv sync` `install.command` passes `--compile-bytecode` | no | add `--compile-bytecode` to `install.command` — see [bytecode and startup time](deployment-guide.md#bytecode-and-startup-time) |
 | `inert_timers` | which `scaffold.systemd.timers` families this host runs, and which it only carries | no | none needed — see [scheduled timers you switch on](deployment-guide.md#scheduled-timers-you-switch-on) |
 | `backup_retention` | every declared `retain` corpus has both halves of its prune unit on disk | no | `sudo fraisier scaffold-install` — until then nothing prunes that corpus |
+| `self_upgrade_failure` | the last webhook self-upgrade landed, rather than leaving the tool venv half-removed | no | clear foreign-owned `__pycache__`, then `uv tool install --force fraisier==<version>` — see [a self-upgrade that did not land](#a-self-upgrade-that-did-not-land) |
 | `backup_corpus_free_space` | each `retain[].dir` exists and its volume meets the entry's `min_free_gb` | no | free space on the volume, or declare a threshold — see [`min_free_gb`](deployment-guide.md#min_free_gb--a-policy-is-not-a-disk-alarm) |
 | `scaffold_artifact_coverage` | every artifact the manifest declares for this host is installed | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
 | `foreign_units` | no `fraisier` unit on this host belongs to a fraise or environment this host does not own | no | `sudo fraisier scaffold-install --prune` — see [one host authority](deployment-guide.md#scheduled-timers-you-switch-on) |
@@ -99,6 +100,42 @@ A unit in that state works, on its previous configuration. What it costs is a
 stale `ReadWritePaths=` or `Environment=`, which surfaces later as a deploy
 failing on a read-only filesystem rather than as anything pointing back here.
 Restart the named units once no deploy is running.
+
+## A self-upgrade that did not land
+
+When a deployed `pyproject.toml` pins a newer fraisier, the webhook detaches a
+worker that runs `uv tool install --force`. That command **removes before it
+verifies**, so a failure partway through can leave the tool venv half-removed —
+`bin/` gone, `lib/` intact — and every `~/.local/bin/fraisier*` symlink
+dangling, including the one the webhook unit names in `ExecStart=`.
+
+The running webhook survives this, because a live process outlives its deleted
+binary. That is exactly what makes it dangerous: `systemctl is-active`, the
+health check and the version endpoint all look normal, and nothing reveals the
+damage until the next restart fails with status 203/EXEC — which, on a deploy
+host, is often the restart you are relying on to fix something else.
+
+`self_upgrade_failure` reads
+`<deployment.lock_dir>/.self-upgrade-failure`, written by the worker when the
+install returns non-zero and **cleared only when a later upgrade lands**. It
+reports the version pair, the exit code and the recorded cause.
+
+The most common cause is foreign-owned bytecode the deploy user cannot delete:
+the helper daemons run as root out of the same venv, and while every unit sets
+`PYTHONDONTWRITEBYTECODE=1`, an interpreter started as root *outside* a unit
+still writes `fraisier/__pycache__/__init__.*.pyc` before fraisier's own
+in-process guard can take effect. To recover:
+
+```bash
+ls -l ~/.local/bin/fraisier*                     # dangling?
+sudo find ~/.local/share/uv/tools -name __pycache__ \
+     ! -user "$(id -un)" -type d -exec rm -rf {} +
+uv tool install --force fraisier==<version>
+sudo systemctl restart fraisier-<project>-webhook.service
+```
+
+The worker's own log, which records the command it ran and the full stderr, is
+under `/var/lib/fraisier/self-upgrade/`.
 
 ## JSON output
 

--- a/fraisier/deferred_restart.py
+++ b/fraisier/deferred_restart.py
@@ -45,8 +45,15 @@ from fraisier.drain_restart import (
     send_restart,
     wait_for_deploys_to_drain,
 )
+from fraisier.worker_logging import configure_worker_logging, open_worker_log
 
 log = logging.getLogger(__name__)
+
+#: Beside the self-upgrade worker's logs, for the same reason: this worker is
+#: detached and outlives its parent, so its stderr has nowhere else to go.
+#: It used to be spawned onto DEVNULL, which discarded the only explanation of
+#: *why* a deferred restart went unpaid.
+_LOG_DIR = Path("/var/lib/fraisier/deferred-restart")
 
 #: Lives beside ``.draining`` in the lock dir, and dot-prefixed for the same
 #: reason: ``count_held_deployment_locks`` globs ``*.lock`` and must not see it.
@@ -185,19 +192,24 @@ def maybe_apply_deferred_restarts(
             str(drain_settle_s),
         ]
         # start_new_session so the worker survives the restart it is about to
-        # request, the same reason the self-upgrade worker detaches.
+        # request, the same reason the self-upgrade worker detaches. Its output
+        # goes to a file rather than DEVNULL: the ledger records *that* a debt
+        # went unpaid, and only this log records *why* — a drain that timed out
+        # reads nothing like a unit the helper refused (#351).
+        stdout = open_worker_log(_LOG_DIR, "deferred-restart")
         subprocess.Popen(
             cmd,
             start_new_session=True,
             stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
         )
     except Exception:
         log.exception("deferred-restart: could not schedule the pending restarts")
 
 
 def _main() -> None:  # pragma: no cover - exercised via run_deferred_restarts
+    configure_worker_logging()
     parser = argparse.ArgumentParser(prog="fraisier.deferred_restart")
     parser.add_argument(
         "--socket", default=os.environ.get("FRAISIER_SYSTEMCTL_SOCKET", "")

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -328,6 +328,28 @@ def _check_install_compile_bytecode(config: FraisierConfig | None) -> CheckResul
     return CheckResult(name, "pass", f"{checked} `uv sync` command(s) compile bytecode")
 
 
+#: Where installed units live. A module constant so tests can point it at a
+#: temporary tree rather than needing a real systemd.
+SYSTEMD_UNIT_DIR = Path("/etc/systemd/system")
+
+#: systemd allows these before the executable in ``ExecStart=``: ``@`` (override
+#: argv[0]), ``-`` (ignore failure), ``:`` (no variable expansion), ``+``/``!``/
+#: ``!!`` (privilege modifiers). They are not part of the path.
+_EXEC_PREFIXES = "@-:+!"
+
+
+def _exec_start_binary(line: str) -> str | None:
+    """The executable named by an ``ExecStart=`` line, or None for other lines."""
+    stripped = line.strip()
+    directive, sep, value = stripped.partition("=")
+    if not sep or directive.strip() != "ExecStart":
+        return None
+    value = value.strip().lstrip(_EXEC_PREFIXES).strip()
+    if not value:
+        return None
+    return value.split()[0]
+
+
 def _installed_webhook_unit(project_name: str) -> Path:
     """Where scaffold-install puts the webhook unit. Seam for tests."""
     return Path("/etc/systemd/system") / f"fraisier-{project_name}-webhook.service"
@@ -1019,6 +1041,82 @@ def _check_deferred_restarts(config: FraisierConfig | None) -> CheckResult:
             "these units are on disk and daemon-reloaded but are running their "
             "previous version; restart them once no deploy is in flight: "
             f"sudo systemctl restart {' '.join(pending)}"
+        ),
+    )
+
+
+@register_check("unit_entrypoints")
+def _check_unit_entrypoints(_config: FraisierConfig | None) -> CheckResult:
+    """Every installed unit names a fraisier binary that is still executable (#351).
+
+    A failed ``uv tool install --force`` can leave the tool venv half-removed —
+    ``bin/`` gone, ``lib/`` intact — so every ``~/.local/bin/fraisier*`` symlink
+    dangles, including the one the webhook unit names in ``ExecStart=``. The
+    running process outlives its deleted binary, so ``is-active``, the health
+    check and the version endpoint all look normal. The damage surfaces only at
+    the next restart, as status 203/EXEC.
+
+    This asks the question directly and does not care how the host got there: a
+    failed self-upgrade, a half-finished manual install and a pruned venv all
+    read the same. It takes no config — the units on disk are the input — so it
+    still answers on a host whose ``fraises.yaml`` will not load.
+
+    ``fail``, not ``warn``: unlike a deferred restart, this unit cannot start at
+    all. The service running now is the last one that ever will, until it is
+    fixed.
+    """
+    name = "unit_entrypoints"
+    try:
+        unit_files = sorted(SYSTEMD_UNIT_DIR.glob("*.service"))
+    except OSError as exc:
+        return CheckResult(name, "skip", f"could not read {SYSTEMD_UNIT_DIR}: {exc}")
+    if not unit_files:
+        return CheckResult(name, "skip", f"no units installed under {SYSTEMD_UNIT_DIR}")
+
+    broken: list[tuple[str, str]] = []
+    checked = 0
+    for unit in unit_files:
+        try:
+            text = unit.read_text()
+        except (OSError, UnicodeDecodeError):
+            # A unit we cannot read is not evidence of anything; the artifact
+            # coverage check is what reports units that should not be here.
+            continue
+        for line in text.splitlines():
+            binary = _exec_start_binary(line)
+            if binary is None or not Path(binary).name.startswith("fraisier"):
+                continue
+            checked += 1
+            # Existence first: os.access(X_OK) is permissive for root, so a
+            # root-run doctor would otherwise call a missing file executable.
+            target = Path(binary)
+            if not target.exists() or not os.access(binary, os.X_OK):
+                broken.append((unit.name, binary))
+
+    if not checked:
+        # Distinct from "pass" on purpose: a scan that matched nothing must not
+        # read as a clean bill of health.
+        return CheckResult(
+            name,
+            "skip",
+            f"no fraisier entrypoints named by units in {SYSTEMD_UNIT_DIR}",
+        )
+    if not broken:
+        return CheckResult(name, "pass", f"{checked} unit entrypoint(s) resolve")
+
+    listed = "; ".join(f"{unit} -> {binary}" for unit, binary in broken)
+    return CheckResult(
+        name,
+        "fail",
+        f"{len(broken)} of {checked} unit entrypoint(s) do not resolve: {listed}",
+        fix_hint=(
+            "these units cannot start — the next restart fails 203/EXEC. A "
+            "failed `uv tool install --force` leaves the tool venv half-removed "
+            "(bin/ gone, lib/ intact). Reinstall:\n"
+            "  sudo find ~/.local/share/uv/tools -name __pycache__ "
+            "! -user $(id -un) -type d -exec rm -rf {} +\n"
+            "  uv tool install --force fraisier==<version>\n"
+            "then verify with `ls -l ~/.local/bin/fraisier*`."
         ),
     )
 

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -1021,3 +1021,54 @@ def _check_deferred_restarts(config: FraisierConfig | None) -> CheckResult:
             f"sudo systemctl restart {' '.join(pending)}"
         ),
     )
+
+
+@register_check("self_upgrade_failure")
+def _check_self_upgrade_failure(config: FraisierConfig | None) -> CheckResult:
+    """A self-upgrade that ran and did not land (#351).
+
+    ``uv tool install --force`` removes before it verifies, so a failed upgrade
+    can leave the tool venv half-removed — ``bin/`` gone, ``lib/`` intact, every
+    ``~/.local/bin/fraisier*`` symlink dangling. The running webhook survives it
+    (a live process outlives its deleted binary), which is precisely why this
+    needs reporting: nothing looks wrong until the next restart fails 203/EXEC,
+    and on a deploy host that restart is often what you are relying on to fix
+    something else.
+
+    ``warn``, not ``fail``: the host is up and serving. What it has lost is the
+    ability to come back if it stops.
+    """
+    name = "self_upgrade_failure"
+    if config is None:
+        return CheckResult(name, "skip", "no config loaded")
+
+    from fraisier.self_upgrade_record import read_self_upgrade_failure
+
+    lock_dir = getattr(getattr(config, "deployment", None), "lock_dir", None)
+    if not lock_dir:
+        return CheckResult(name, "skip", "no deployment.lock_dir configured")
+
+    failure = read_self_upgrade_failure(Path(lock_dir))
+    if failure is None:
+        return CheckResult(name, "pass", "the last self-upgrade landed")
+
+    when = f" at {failure.recorded_at}" if failure.recorded_at else ""
+    return CheckResult(
+        name,
+        "warn",
+        (
+            f"upgrade to {failure.required} from {failure.installed} failed"
+            f" (rc={failure.rc}){when}"
+        ),
+        fix_hint=(
+            "check the entrypoints are still executable — a failed "
+            "`uv tool install --force` can leave the tool venv half-removed:\n"
+            "  ls -l ~/.local/bin/fraisier*\n"
+            "If they dangle, clear any foreign-owned bytecode blocking the "
+            "removal and reinstall:\n"
+            "  sudo find ~/.local/share/uv/tools -name __pycache__ "
+            "! -user $(id -un) -type d -exec rm -rf {} +\n"
+            f"  uv tool install --force fraisier=={failure.required}\n"
+            f"Recorded cause: {failure.detail[:300]}"
+        ),
+    )

--- a/fraisier/self_upgrade_record.py
+++ b/fraisier/self_upgrade_record.py
@@ -1,0 +1,125 @@
+"""The record a failed self-upgrade leaves behind (#351).
+
+``maybe_self_upgrade`` detaches a worker that runs
+``uv tool install --force fraisier==X`` against the webhook user's own uv tool
+dir. ``--force`` removes before it verifies, so *any* mid-install failure — a
+root-owned ``__pycache__`` it cannot delete, a full disk, a network error, a
+killed worker — can leave the venv half-removed: ``bin/`` gone, ``lib/`` intact,
+and every ``~/.local/bin/fraisier*`` symlink dangling.
+
+The running webhook survives that, because a live process outlives its deleted
+binary. Nothing looks wrong until the next restart fails 203/EXEC — and on a
+deploy host the next restart is often the thing you are relying on to fix
+something else.
+
+Until now the only trace was a file under ``/var/lib/fraisier/self-upgrade/``
+that nothing reads. This ledger is what ``fraisier doctor`` reports instead, in
+the shape v0.63.0 gave deferred restarts: **the entry is cleared only when a
+later upgrade succeeds**, so a debt nobody paid stays on the books rather than
+looking settled.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: Lives beside ``.draining`` and ``.deferred-restarts`` in the lock dir, and is
+#: dot-prefixed for the same reason: ``count_held_deployment_locks`` globs
+#: ``*.lock`` there and a stray match changes the answer to "is a deploy in
+#: flight".
+SELF_UPGRADE_FAILURE_FILE = ".self-upgrade-failure"
+
+#: uv's stderr is unbounded and this file sits in a runtime directory, so the
+#: detail is truncated. The head is what carries the cause; the full text stays
+#: in the worker's own log under /var/lib/fraisier/self-upgrade/.
+_MAX_DETAIL = 4000
+
+
+@dataclass(frozen=True)
+class SelfUpgradeFailure:
+    """An upgrade that ran and did not land."""
+
+    required: str
+    installed: str
+    rc: int
+    detail: str
+    recorded_at: str
+
+
+def record_self_upgrade_failure(
+    lock_dir: Path | str,
+    *,
+    required: str,
+    installed: str,
+    rc: int,
+    detail: str,
+) -> None:
+    """Write the failure record, replacing any previous one.
+
+    Best-effort and never raises: this runs on the path where an upgrade has
+    *already* failed, and an error here must not mask the error it exists to
+    report.
+    """
+    path = Path(lock_dir) / SELF_UPGRADE_FAILURE_FILE
+    payload = {
+        "required": required,
+        "installed": installed,
+        "rc": rc,
+        "detail": (detail or "")[:_MAX_DETAIL],
+        "recorded_at": datetime.now(tz=UTC).isoformat(),
+    }
+    try:
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    except OSError as exc:
+        log.warning("could not record the self-upgrade failure at %s: %s", path, exc)
+
+
+def read_self_upgrade_failure(lock_dir: Path | str) -> SelfUpgradeFailure | None:
+    """The recorded failure, or None when the last upgrade landed.
+
+    A record written by a *newer* fraisier may carry keys this version does not
+    know — a self-upgrade puts two versions on one host by design — so unknown
+    keys are ignored rather than raising, the same tolerance ``read_status``
+    gained in v0.63.0.
+    """
+    path = Path(lock_dir) / SELF_UPGRADE_FAILURE_FILE
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        log.warning("could not read the self-upgrade record at %s: %s", path, exc)
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        # A half-written record must not take `doctor` down with it.
+        log.warning("self-upgrade record at %s is not valid JSON; ignoring", path)
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return SelfUpgradeFailure(
+            required=str(data.get("required", "")),
+            installed=str(data.get("installed", "")),
+            rc=int(data.get("rc", 0)),
+            detail=str(data.get("detail", "")),
+            recorded_at=str(data.get("recorded_at", "")),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def clear_self_upgrade_failure(lock_dir: Path | str) -> None:
+    """Drop the record. Called only where an upgrade is known to have landed."""
+    path = Path(lock_dir) / SELF_UPGRADE_FAILURE_FILE
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        log.warning("could not clear the self-upgrade record at %s: %s", path, exc)

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -42,7 +42,6 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -59,8 +58,13 @@ from fraisier.drain_restart import (
     send_restart,
     wait_for_deploys_to_drain,
 )
+from fraisier.self_upgrade_record import (
+    clear_self_upgrade_failure,
+    record_self_upgrade_failure,
+)
 from fraisier.service_managers.systemd import _call_via_socket
 from fraisier.versioning import detect_required_fraisier_version
+from fraisier.worker_logging import configure_worker_logging, open_worker_log
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
@@ -209,14 +213,13 @@ def maybe_self_upgrade(
 
 
 def _open_log_fd(project_name: str):
-    """Open a log file under :data:`_LOG_DIR`. Fall back to DEVNULL on failure."""
-    try:
-        _LOG_DIR.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
-        return (_LOG_DIR / f"{project_name}-{ts}.log").open("ab")
-    except OSError as exc:
-        log.warning("self-upgrade: could not open log file (%s); using DEVNULL", exc)
-        return subprocess.DEVNULL
+    """Open a log file under :data:`_LOG_DIR`. Fall back to DEVNULL on failure.
+
+    Reads the module-level :data:`_LOG_DIR` at call time so tests that
+    monkeypatch it keep working; the shared helper takes the directory as an
+    argument for exactly that reason.
+    """
+    return open_worker_log(_LOG_DIR, project_name)
 
 
 def _resolve_spawn_args() -> _SpawnArgs:
@@ -289,8 +292,14 @@ def _spawn_upgrade(required: str, project_name: str) -> None:
     )
 
 
-def _run_install(required: str) -> int:
-    """Run the install command, log failure, return rc."""
+def _run_install(required: str, *, lock_dir: Path | None = None) -> int:
+    """Run the install command, record and log any failure, return rc.
+
+    ``uv tool install --force`` removes before it verifies, so a non-zero rc can
+    mean the tool venv is now half-removed and every entrypoint dangling. The
+    record is what makes that visible: the log below reaches only this worker's
+    own file, which nothing surfaces (#351).
+    """
     cmd = _build_install_cmd(required)
     log.info("self-upgrade: running %s", " ".join(cmd))
     result = subprocess.run(cmd, check=False, capture_output=True, text=True)
@@ -300,7 +309,26 @@ def _run_install(required: str) -> int:
             result.returncode,
             result.stderr,
         )
+        if lock_dir is not None:
+            record_self_upgrade_failure(
+                lock_dir,
+                required=required,
+                installed=_installed_version(),
+                rc=result.returncode,
+                detail=(result.stderr or "").strip(),
+            )
+    elif lock_dir is not None:
+        # Cleared only on a landing, so a debt nobody paid stays on the books.
+        clear_self_upgrade_failure(lock_dir)
     return result.returncode
+
+
+def _installed_version() -> str:
+    """Best-effort: the version running right now, for the failure record."""
+    try:
+        return importlib_metadata.version("fraisier")
+    except Exception:  # pragma: no cover - metadata is present in practice
+        return "unknown"
 
 
 def _run_upgrade(
@@ -324,7 +352,7 @@ def _run_upgrade(
             "self-upgrade: lock_dir unresolved; running install + restart "
             "without drain coordination"
         )
-        rc = _run_install(required)
+        rc = _run_install(required, lock_dir=lock_dir)
         if rc != 0:
             return rc
         if not socket_path:
@@ -339,7 +367,7 @@ def _run_upgrade(
     # Flag covers install + drain so dispatch refuses new deploys for the
     # entire upgrade window, not just the drain tail.
     with _with_draining_flag(lock_dir):
-        rc = _run_install(required)
+        rc = _run_install(required, lock_dir=lock_dir)
         if rc != 0:
             return rc
         if not socket_path:
@@ -368,6 +396,7 @@ def _run_upgrade(
 
 
 def _main() -> None:
+    configure_worker_logging()
     parser = argparse.ArgumentParser(prog="fraisier.webhook_self_upgrade")
     parser.add_argument("--required", required=True)
     parser.add_argument("--service", required=True)

--- a/fraisier/webhook_self_upgrade.py
+++ b/fraisier/webhook_self_upgrade.py
@@ -60,6 +60,7 @@ from fraisier.drain_restart import (
 )
 from fraisier.self_upgrade_record import (
     clear_self_upgrade_failure,
+    read_self_upgrade_failure,
     record_self_upgrade_failure,
 )
 from fraisier.service_managers.systemd import _call_via_socket
@@ -74,6 +75,14 @@ log = logging.getLogger(__name__)
 # Webhook units run with ProtectSystem=strict and have /var/lib/fraisier in
 # ReadWritePaths, so a sibling directory is writable by the deploy user.
 _LOG_DIR = Path("/var/lib/fraisier/self-upgrade")
+
+#: Where the worker resolves its own unit's ``ExecStart=``. A module constant so
+#: tests can point it at a temporary tree.
+_UNIT_DIR = Path("/etc/systemd/system")
+
+#: The install ran but left the unit unable to start, so no restart was sent.
+#: Distinct from the install's own rc: the operator's next move is different.
+ENTRYPOINT_BROKEN_RC = 4
 
 # Re-exported under their historical private names: this module is where the
 # drain sequence was written, and its tests and callers still reach for these
@@ -331,6 +340,94 @@ def _installed_version() -> str:
         return "unknown"
 
 
+def _unit_entrypoint(service: str) -> str | None:
+    """The binary the installed unit names in ``ExecStart=``, or None.
+
+    None means *unknown*, not *fine*: the unit may be absent, unreadable, or
+    generated somewhere this worker cannot see. Callers treat that as abstention
+    (see :func:`_entrypoint_is_broken`).
+    """
+    from fraisier.doctor import _exec_start_binary
+
+    try:
+        text = (_UNIT_DIR / service).read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in text.splitlines():
+        binary = _exec_start_binary(line)
+        if binary is not None:
+            return binary
+    return None
+
+
+def _entrypoint_is_broken(service: str) -> str | None:
+    """The unresolvable entrypoint path, or None when it resolves or is unknown.
+
+    ``uv tool install --force`` removes before it verifies, so after any install
+    — successful or not — the binary this unit names may no longer exist. The
+    worst thing to do at that moment is request a restart: the running process
+    is the only working fraisier left on the host, and restarting it turns a
+    latent problem into an outage.
+
+    **Abstains when the unit cannot be read.** Blocking a restart on a guess
+    would strand the host in the other direction, and the ``unit_entrypoints``
+    doctor check reports the same condition without needing to be right here.
+    """
+    binary = _unit_entrypoint(service)
+    if binary is None:
+        return None
+    target = Path(binary)
+    # Existence first: os.access(X_OK) is permissive for root.
+    if target.exists() and os.access(binary, os.X_OK):
+        return None
+    return binary
+
+
+def _refuse_restart_for_broken_entrypoint(
+    service: str,
+    binary: str,
+    *,
+    required: str,
+    lock_dir: Path | None,
+    rc: int,
+) -> None:
+    """Log loudly and record that the venv did not survive the install."""
+    log.error(
+        "self-upgrade: NOT restarting %s — its ExecStart binary %s no longer "
+        "resolves. `uv tool install --force` removes before it verifies, so the "
+        "tool venv is half-removed and this unit would fail 203/EXEC. The "
+        "process running now is the only working fraisier on this host. "
+        "Recover with: sudo find ~/.local/share/uv/tools -name __pycache__ "
+        "! -user $(id -un) -type d -exec rm -rf {} + && "
+        "uv tool install --force fraisier==%s",
+        service,
+        binary,
+        required,
+    )
+    if lock_dir is None:
+        return
+    consequence = (
+        f"{service} ExecStart={binary} does not resolve after the install; "
+        "restart refused to avoid 203/EXEC"
+    )
+    # A failed install already recorded uv's own stderr. That is the *cause* and
+    # this is the *consequence*; an operator needs both, so the earlier detail is
+    # carried forward rather than overwritten by this second write.
+    previous = read_self_upgrade_failure(lock_dir)
+    detail = (
+        f"{previous.detail}\n\n{consequence}"
+        if previous is not None and previous.detail
+        else consequence
+    )
+    record_self_upgrade_failure(
+        lock_dir,
+        required=required,
+        installed=_installed_version(),
+        rc=rc,
+        detail=detail,
+    )
+
+
 def _run_upgrade(
     required: str,
     service: str,
@@ -353,6 +450,12 @@ def _run_upgrade(
             "without drain coordination"
         )
         rc = _run_install(required, lock_dir=lock_dir)
+        broken = _entrypoint_is_broken(service)
+        if broken is not None:
+            _refuse_restart_for_broken_entrypoint(
+                service, broken, required=required, lock_dir=lock_dir, rc=rc
+            )
+            return rc or ENTRYPOINT_BROKEN_RC
         if rc != 0:
             return rc
         if not socket_path:
@@ -368,6 +471,14 @@ def _run_upgrade(
     # entire upgrade window, not just the drain tail.
     with _with_draining_flag(lock_dir):
         rc = _run_install(required, lock_dir=lock_dir)
+        # Checked on both outcomes: --force removes before it verifies, so a
+        # non-zero rc and a zero rc can leave the same half-removed venv.
+        broken = _entrypoint_is_broken(service)
+        if broken is not None:
+            _refuse_restart_for_broken_entrypoint(
+                service, broken, required=required, lock_dir=lock_dir, rc=rc
+            )
+            return rc or ENTRYPOINT_BROKEN_RC
         if rc != 0:
             return rc
         if not socket_path:

--- a/fraisier/worker_logging.py
+++ b/fraisier/worker_logging.py
@@ -1,0 +1,68 @@
+"""One place a subprocess entrypoint configures logging (#351).
+
+fraisier spawns two kinds of child process that log for themselves: the four
+socket helpers, which systemd starts as their own units, and the two detached
+``python -m fraisier.<module>`` workers that outlive the process which spawned
+them.
+
+The helpers each carried an identical hand-copied ``basicConfig``. The two
+workers had none — and with no handler configured, Python falls back to
+:data:`logging.lastResort`, which is **WARNING level and writes to stderr**. So
+every ``log.info`` in a worker was dropped before it reached anything, including
+the line naming the command it was about to run. A self-upgrade that destroyed
+its own venv left a 200-byte log holding the failure and no record of what
+produced it.
+
+Copying the call a fifth and sixth time would have worked and drifted again, so
+it gets a name here and a guard in ``tests/test_worker_logging_seam.py``: every
+module discovered as a ``-m`` spawn target must route through this function.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+#: The format the four socket helpers already emitted. Kept byte-identical so
+#: adopting this seam does not change how any existing unit reads in the journal.
+WORKER_LOG_FORMAT = "%(levelname)s %(name)s: %(message)s"
+
+
+def configure_worker_logging(level: int = logging.INFO) -> None:
+    """Attach a root handler so a child process's own INFO output survives.
+
+    Idempotent, because :func:`logging.basicConfig` returns without doing
+    anything once the root logger has a handler — which is what makes this safe
+    to call from a ``_main`` that a test may invoke more than once.
+    """
+    logging.basicConfig(level=level, format=WORKER_LOG_FORMAT)
+
+
+def open_worker_log(log_dir: Path, stem: str):
+    """Open an append-mode file to hold a detached worker's stdout and stderr.
+
+    Configuring a handler is only half the job: a worker spawned with its output
+    on ``DEVNULL`` is exactly as silent as one with no handler at all. Callers
+    pass their own directory rather than reading a shared constant, so each
+    module keeps the module-level path its tests already monkeypatch.
+
+    Falls back to ``subprocess.DEVNULL`` when the directory cannot be opened —
+    losing the log is bad, but refusing to spawn the worker would leave the debt
+    unpaid *and* unexplained.
+    """
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+        return (log_dir / f"{stem}-{ts}.log").open("ab")
+    except OSError as exc:
+        log.warning(
+            "could not open a worker log under %s (%s); using DEVNULL", log_dir, exc
+        )
+        return subprocess.DEVNULL

--- a/tests/test_doctor_entrypoints.py
+++ b/tests/test_doctor_entrypoints.py
@@ -1,0 +1,200 @@
+"""Is the binary each installed unit names still there? (#351)
+
+A failed `uv tool install --force` can leave the tool venv half-removed — `bin/`
+gone, `lib/` intact — so every `~/.local/bin/fraisier*` symlink dangles,
+including the one the webhook unit names in `ExecStart=`.
+
+Nothing catches that today. The running process outlives its deleted binary, so
+`systemctl is-active`, the health check and the version endpoint all look
+normal; the failure surfaces only at the next restart, as 203/EXEC. This check
+asks the question directly, and it does not care *how* the host got there — a
+failed self-upgrade, a half-finished manual install, a pruned venv all read the
+same.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from fraisier.doctor import DOCTOR_CHECKS
+
+
+@pytest.fixture
+def unit_dir(tmp_path, monkeypatch):
+    d = tmp_path / "systemd"
+    d.mkdir()
+    monkeypatch.setattr("fraisier.doctor.SYSTEMD_UNIT_DIR", d)
+    return d
+
+
+@pytest.fixture
+def bindir(tmp_path):
+    d = tmp_path / "bin"
+    d.mkdir()
+    return d
+
+
+def _executable(bindir, name="fraisier-webhook"):
+    p = bindir / name
+    p.write_text("#!/bin/sh\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    return p
+
+
+def _unit(unit_dir, name, exec_start):
+    (unit_dir / name).write_text(
+        f"[Unit]\nDescription=x\n\n[Service]\nExecStart={exec_start}\n"
+    )
+
+
+def _run(config=None):
+    return DOCTOR_CHECKS["unit_entrypoints"].fn(config)
+
+
+def _config():
+    return SimpleNamespace(deployment=SimpleNamespace(lock_dir="/run/fraisier"))
+
+
+class TestItIsRegistered:
+    def test_the_check_exists(self):
+        assert "unit_entrypoints" in DOCTOR_CHECKS
+
+
+class TestAHealthyHost:
+    def test_a_resolvable_entrypoint_passes(self, unit_dir, bindir):
+        exe = _executable(bindir)
+        _unit(unit_dir, "fraisier-api-webhook.service", str(exe))
+        result = _run(_config())
+        assert result.status == "pass"
+
+    def test_arguments_after_the_binary_are_ignored(self, unit_dir, bindir):
+        exe = _executable(bindir, "fraisier-systemctl-helper")
+        _unit(
+            unit_dir, "fraisier-api-systemctl-helper.service", f"{exe} --deploy-user x"
+        )
+        assert _run(_config()).status == "pass"
+
+    @pytest.mark.parametrize("prefix", ["-", "@", "+", "!", "!!", ":"])
+    def test_systemd_exec_prefixes_are_stripped(self, unit_dir, bindir, prefix):
+        """systemd allows `-`, `@`, `+`, `!`, `!!` and `:` before the path."""
+        exe = _executable(bindir)
+        _unit(unit_dir, "fraisier-api-webhook.service", f"{prefix}{exe}")
+        assert _run(_config()).status == "pass"
+
+
+class TestTheHalfRemovedVenv:
+    def test_a_dangling_entrypoint_fails_and_names_it(self, unit_dir, bindir):
+        missing = bindir / "fraisier-webhook"  # never created
+        _unit(unit_dir, "fraisier-api-webhook.service", str(missing))
+        result = _run(_config())
+        assert result.status == "fail"
+        assert "fraisier-api-webhook.service" in result.detail
+        assert result.fix_hint
+
+    def test_a_present_but_non_executable_entrypoint_fails(self, unit_dir, bindir):
+        p = bindir / "fraisier-webhook"
+        p.write_text("#!/bin/sh\n")
+        p.chmod(p.stat().st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
+        _unit(unit_dir, "fraisier-api-webhook.service", str(p))
+        assert _run(_config()).status == "fail"
+
+    def test_a_dangling_symlink_fails(self, unit_dir, bindir):
+        link = bindir / "fraisier-webhook"
+        link.symlink_to(bindir / "gone")
+        _unit(unit_dir, "fraisier-api-webhook.service", str(link))
+        assert _run(_config()).status == "fail"
+
+    def test_every_broken_unit_is_reported_not_just_the_first(self, unit_dir, bindir):
+        _unit(
+            unit_dir, "fraisier-api-webhook.service", str(bindir / "fraisier-webhook")
+        )
+        _unit(unit_dir, "fraisier-api-mcp.service", str(bindir / "fraisier-mcp"))
+        result = _run(_config())
+        assert result.status == "fail"
+        assert "fraisier-api-webhook.service" in result.detail
+        assert "fraisier-api-mcp.service" in result.detail
+
+
+class TestScope:
+    def test_a_non_fraisier_binary_is_not_our_business(self, unit_dir):
+        _unit(unit_dir, "nginx.service", "/usr/sbin/nginx-does-not-exist")
+        assert _run(_config()).status == "skip"
+
+    def test_a_missing_unit_dir_skips(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("fraisier.doctor.SYSTEMD_UNIT_DIR", tmp_path / "nope")
+        assert _run(_config()).status == "skip"
+
+    def test_no_fraisier_units_is_skip_not_pass(self, unit_dir):
+        """A scan that matches nothing must not read as a clean bill of health.
+
+        v0.61.0's rule, applied to the check itself: `pass` here would be
+        indistinguishable from "checked, and everything resolved".
+        """
+        result = _run(_config())
+        assert result.status == "skip"
+        assert "no" in result.detail.lower()
+
+    def test_no_config_still_runs(self, unit_dir, bindir):
+        """This one does not need config — the units on disk are the input."""
+        _unit(
+            unit_dir, "fraisier-api-webhook.service", str(bindir / "fraisier-webhook")
+        )
+        assert _run(None).status == "fail"
+
+    def test_an_unparseable_unit_does_not_crash_the_check(self, unit_dir, bindir):
+        exe = _executable(bindir)
+        (unit_dir / "fraisier-broken.service").write_bytes(b"\xff\xfe not utf-8")
+        _unit(unit_dir, "fraisier-api-webhook.service", str(exe))
+        assert _run(_config()).status == "pass"
+
+
+class TestItIsDocumented:
+    def test_doctor_md_covers_the_check(self):
+        from pathlib import Path
+
+        doc = (
+            Path(__file__).resolve().parent.parent / "docs" / "doctor.md"
+        ).read_text()
+        assert "unit_entrypoints" in doc
+
+
+class TestTheHelperItself:
+    """The parser is the part that can silently match nothing."""
+
+    def test_it_finds_the_exec_start_binary(self):
+        from fraisier.doctor import _exec_start_binary
+
+        assert _exec_start_binary("ExecStart=/a/b/fraisier-webhook --x") == (
+            "/a/b/fraisier-webhook"
+        )
+
+    def test_it_ignores_other_directives(self):
+        from fraisier.doctor import _exec_start_binary
+
+        assert _exec_start_binary("ExecStop=/a/b/fraisier-webhook") is None
+        assert _exec_start_binary("Environment=X=1") is None
+
+    def test_it_tolerates_whitespace(self):
+        from fraisier.doctor import _exec_start_binary
+
+        assert _exec_start_binary("  ExecStart =  /a/fraisier ") == "/a/fraisier"
+
+    def test_an_empty_exec_start_is_not_a_binary(self):
+        from fraisier.doctor import _exec_start_binary
+
+        assert _exec_start_binary("ExecStart=") is None
+
+
+class TestOsAccessIsNotTheOnlyGate:
+    def test_running_as_root_does_not_mask_a_missing_file(self, unit_dir, bindir):
+        """`os.access(X_OK)` is permissive for root; existence is checked first."""
+        _unit(
+            unit_dir, "fraisier-api-webhook.service", str(bindir / "fraisier-webhook")
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "access", lambda *_a, **_k: True)
+            assert _run(_config()).status == "fail"

--- a/tests/test_self_upgrade_failure_record.py
+++ b/tests/test_self_upgrade_failure_record.py
@@ -1,0 +1,174 @@
+"""A failed self-upgrade has to leave state, not just a line in a file (#351).
+
+When ``uv tool install --force`` fails partway it leaves the tool venv
+half-removed — ``bin/`` gone, ``lib/`` intact — so every
+``~/.local/bin/fraisier*`` symlink dangles, including the one the webhook unit
+names in ``ExecStart=``. The running process outlives its deleted binary, so
+nothing looks wrong until the next restart fails 203/EXEC.
+
+The only record was a file under ``/var/lib/fraisier/self-upgrade/`` that
+nothing surfaces. This is the ledger ``doctor`` reads instead, in the same shape
+v0.63.0 gave deferred restarts: **the entry is cleared only when a later upgrade
+succeeds**, so a debt nobody paid stays visible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fraisier.self_upgrade_record import (
+    SELF_UPGRADE_FAILURE_FILE,
+    clear_self_upgrade_failure,
+    read_self_upgrade_failure,
+    record_self_upgrade_failure,
+)
+
+
+@pytest.fixture
+def lock_dir(tmp_path):
+    d = tmp_path / "run-fraisier"
+    d.mkdir()
+    return d
+
+
+class TestTheLedger:
+    def test_no_record_is_no_failure(self, lock_dir):
+        assert read_self_upgrade_failure(lock_dir) is None
+
+    def test_a_recorded_failure_reads_back(self, lock_dir):
+        record_self_upgrade_failure(
+            lock_dir,
+            required="0.62.0",
+            installed="0.61.0",
+            rc=2,
+            detail="failed to remove directory `.../lib`: Permission denied",
+        )
+        rec = read_self_upgrade_failure(lock_dir)
+        assert rec is not None
+        assert rec.required == "0.62.0"
+        assert rec.installed == "0.61.0"
+        assert rec.rc == 2
+        assert "Permission denied" in rec.detail
+
+    def test_it_is_dot_prefixed_like_its_neighbours(self):
+        """``count_held_deployment_locks`` globs ``*.lock`` in this directory.
+
+        ``.draining`` and ``.deferred-restarts`` are dot-prefixed for the same
+        reason: a stray file here changes the answer to "is a deploy in flight".
+        """
+        assert SELF_UPGRADE_FAILURE_FILE.startswith(".")
+        assert not SELF_UPGRADE_FAILURE_FILE.endswith(".lock")
+
+    def test_a_later_success_clears_it(self, lock_dir):
+        record_self_upgrade_failure(
+            lock_dir, required="0.62.0", installed="0.61.0", rc=2, detail="boom"
+        )
+        clear_self_upgrade_failure(lock_dir)
+        assert read_self_upgrade_failure(lock_dir) is None
+
+    def test_clearing_nothing_is_not_an_error(self, lock_dir):
+        clear_self_upgrade_failure(lock_dir)
+        assert read_self_upgrade_failure(lock_dir) is None
+
+    def test_a_corrupt_record_reads_as_no_record(self, lock_dir):
+        """A half-written record must not take `doctor` down with it."""
+        (lock_dir / SELF_UPGRADE_FAILURE_FILE).write_text("{not json")
+        assert read_self_upgrade_failure(lock_dir) is None
+
+    def test_an_unwritable_lock_dir_does_not_raise(self, tmp_path):
+        """Best-effort: recording a failure must never mask the failure itself."""
+        record_self_upgrade_failure(
+            tmp_path / "does-not-exist",
+            required="0.62.0",
+            installed="0.61.0",
+            rc=2,
+            detail="boom",
+        )
+
+    def test_a_second_failure_replaces_the_first(self, lock_dir):
+        record_self_upgrade_failure(
+            lock_dir, required="0.62.0", installed="0.61.0", rc=2, detail="first"
+        )
+        record_self_upgrade_failure(
+            lock_dir, required="0.63.0", installed="0.61.0", rc=9, detail="second"
+        )
+        rec = read_self_upgrade_failure(lock_dir)
+        assert rec is not None
+        assert rec.rc == 9
+        assert rec.detail == "second"
+
+    def test_the_detail_is_bounded(self, lock_dir):
+        """uv's stderr can be long; the ledger sits in a runtime dir."""
+        record_self_upgrade_failure(
+            lock_dir,
+            required="0.62.0",
+            installed="0.61.0",
+            rc=2,
+            detail="x" * 100_000,
+        )
+        rec = read_self_upgrade_failure(lock_dir)
+        assert rec is not None
+        assert len(rec.detail) < 10_000
+
+    def test_it_records_when_it_happened(self, lock_dir):
+        record_self_upgrade_failure(
+            lock_dir, required="0.62.0", installed="0.61.0", rc=2, detail="boom"
+        )
+        rec = read_self_upgrade_failure(lock_dir)
+        assert rec is not None
+        assert rec.recorded_at, "an operator needs to correlate this with a journal"
+
+
+class TestTheDoctorCheck:
+    """A debt nothing paid must be visible, per v0.63.0's own invariant."""
+
+    def _run(self, config):
+        from fraisier.doctor import DOCTOR_CHECKS
+
+        return DOCTOR_CHECKS["self_upgrade_failure"].fn(config)
+
+    def test_it_is_registered(self):
+        from fraisier.doctor import DOCTOR_CHECKS
+
+        assert "self_upgrade_failure" in DOCTOR_CHECKS
+
+    def test_no_config_skips(self):
+        assert self._run(None).status == "skip"
+
+    def test_clean_host_passes(self, lock_dir):
+        from types import SimpleNamespace
+
+        config = SimpleNamespace(deployment=SimpleNamespace(lock_dir=str(lock_dir)))
+        assert self._run(config).status == "pass"
+
+    def test_a_recorded_failure_warns_and_names_the_versions(self, lock_dir):
+        from types import SimpleNamespace
+
+        record_self_upgrade_failure(
+            lock_dir,
+            required="0.62.0",
+            installed="0.61.0",
+            rc=2,
+            detail="Permission denied",
+        )
+        config = SimpleNamespace(deployment=SimpleNamespace(lock_dir=str(lock_dir)))
+        result = self._run(config)
+        assert result.status == "warn"
+        assert "0.62.0" in result.detail
+        assert result.fix_hint
+
+    def test_no_lock_dir_configured_skips(self):
+        from types import SimpleNamespace
+
+        config = SimpleNamespace(deployment=SimpleNamespace(lock_dir=None))
+        assert self._run(config).status == "skip"
+
+
+class TestItIsDocumented:
+    def test_doctor_md_covers_the_check(self):
+        doc = (
+            Path(__file__).resolve().parent.parent / "docs" / "doctor.md"
+        ).read_text()
+        assert "self_upgrade_failure" in doc

--- a/tests/test_self_upgrade_verifies_result.py
+++ b/tests/test_self_upgrade_verifies_result.py
@@ -1,0 +1,207 @@
+"""The worker checks its own result before declaring success (#351).
+
+`uv tool install --force` removes before it verifies. When it fails partway the
+tool venv is left half-removed — `bin/` gone, `lib/` intact — and the binary the
+webhook unit names in `ExecStart=` no longer resolves.
+
+At that moment the *worst* thing the worker can do is request a restart: the
+running process is the only working fraisier left on the host, and restarting it
+turns a latent problem into an outage. So the worker resolves the unit's own
+entrypoint after the install and refuses the restart when it does not resolve,
+recording why.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from fraisier.self_upgrade_record import read_self_upgrade_failure
+from fraisier.webhook_self_upgrade import ENTRYPOINT_BROKEN_RC, _run_upgrade
+
+SERVICE = "fraisier-api-webhook.service"
+
+
+@pytest.fixture
+def lock_dir(tmp_path):
+    d = tmp_path / "run-fraisier"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def unit_dir(tmp_path, monkeypatch):
+    d = tmp_path / "systemd"
+    d.mkdir()
+    monkeypatch.setattr("fraisier.webhook_self_upgrade._UNIT_DIR", d)
+    return d
+
+
+def _install_entrypoint(bin_dir: Path, name: str = "fraisier-webhook") -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    p = bin_dir / name
+    p.write_text("#!/bin/sh\necho ok\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    return p
+
+
+def _write_unit(unit_dir: Path, target: Path) -> None:
+    (unit_dir / SERVICE).write_text(
+        f"[Unit]\nDescription=webhook\n\n[Service]\nExecStart={target}\n"
+    )
+
+
+class TestARealFailedInstall:
+    """Driven with a fake `uv` on PATH, not a stubbed `_run_install`.
+
+    The defect is what the worker does *after* the install, and an install that
+    is mocked out cannot leave the venv in the state that matters.
+    """
+
+    @pytest.fixture
+    def fake_uv(self, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "tools" / "bin"
+        entry = _install_entrypoint(bin_dir)
+        shim_dir = tmp_path / "shim"
+        shim_dir.mkdir()
+        uv = shim_dir / "uv"
+        # Exactly the #351 shape: bin/ is removed, then the install fails.
+        uv.write_text(
+            "#!/bin/sh\n"
+            f"rm -rf '{bin_dir}'\n"
+            "echo 'error: failed to remove directory ...: Permission denied' >&2\n"
+            "exit 2\n"
+        )
+        uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
+        monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+        return entry
+
+    def test_no_restart_is_requested_and_the_breakage_is_recorded(
+        self, lock_dir, unit_dir, fake_uv
+    ):
+        _write_unit(unit_dir, fake_uv)
+        with patch("fraisier.webhook_self_upgrade._send_restart") as send_restart:
+            rc = _run_upgrade(
+                "0.62.0",
+                SERVICE,
+                "/run/fraisier/systemctl.sock",
+                lock_dir=lock_dir,
+                drain_settle_s=0,
+            )
+
+        send_restart.assert_not_called()
+        assert rc != 0
+        record = read_self_upgrade_failure(lock_dir)
+        assert record is not None
+        assert record.required == "0.62.0"
+        assert "Permission denied" in record.detail
+
+    def test_the_entrypoint_really_is_gone(self, lock_dir, unit_dir, fake_uv):
+        """Guards the fixture: if `uv` stopped removing bin/, the tests above
+        would pass for the wrong reason."""
+        _write_unit(unit_dir, fake_uv)
+        assert fake_uv.exists()
+        with patch("fraisier.webhook_self_upgrade._send_restart"):
+            _run_upgrade(
+                "0.62.0",
+                SERVICE,
+                "/run/fraisier/systemctl.sock",
+                lock_dir=lock_dir,
+                drain_settle_s=0,
+            )
+        assert not fake_uv.exists()
+
+
+class TestASuccessfulInstallThatLeftNothingBehind:
+    """rc == 0 is not proof. The install can report success and still not resolve."""
+
+    def test_a_broken_entrypoint_blocks_the_restart(self, lock_dir, unit_dir, tmp_path):
+        missing = tmp_path / "tools" / "bin" / "fraisier-webhook"
+        _write_unit(unit_dir, missing)
+        with (
+            patch("fraisier.webhook_self_upgrade._run_install", return_value=0),
+            patch("fraisier.webhook_self_upgrade._send_restart") as send_restart,
+            patch("fraisier.webhook_self_upgrade._wait_for_deploys_to_drain") as drain,
+        ):
+            drain.return_value = type("R", (), {"drained": True, "held": []})()
+            rc = _run_upgrade(
+                "0.62.0",
+                SERVICE,
+                "/run/fraisier/systemctl.sock",
+                lock_dir=lock_dir,
+                drain_settle_s=0,
+            )
+
+        send_restart.assert_not_called()
+        assert rc == ENTRYPOINT_BROKEN_RC
+        assert read_self_upgrade_failure(lock_dir) is not None
+
+    def test_a_resolvable_entrypoint_still_restarts(self, lock_dir, unit_dir, tmp_path):
+        """The regression guard: the happy path must not become cautious."""
+        entry = _install_entrypoint(tmp_path / "tools" / "bin")
+        _write_unit(unit_dir, entry)
+        with (
+            patch("fraisier.webhook_self_upgrade._run_install", return_value=0),
+            patch(
+                "fraisier.webhook_self_upgrade._send_restart", return_value=0
+            ) as send_restart,
+            patch("fraisier.webhook_self_upgrade._wait_for_deploys_to_drain") as drain,
+        ):
+            drain.return_value = type("R", (), {"drained": True, "held": []})()
+            rc = _run_upgrade(
+                "0.62.0",
+                SERVICE,
+                "/run/fraisier/systemctl.sock",
+                lock_dir=lock_dir,
+                drain_settle_s=0,
+            )
+
+        send_restart.assert_called_once()
+        assert rc == 0
+
+
+class TestWhenTheUnitCannotBeRead:
+    """Abstaining is the safe direction: never block a restart on a guess."""
+
+    def test_an_absent_unit_file_does_not_block_the_restart(
+        self, lock_dir, unit_dir, tmp_path
+    ):
+        with (
+            patch("fraisier.webhook_self_upgrade._run_install", return_value=0),
+            patch(
+                "fraisier.webhook_self_upgrade._send_restart", return_value=0
+            ) as send_restart,
+            patch("fraisier.webhook_self_upgrade._wait_for_deploys_to_drain") as drain,
+        ):
+            drain.return_value = type("R", (), {"drained": True, "held": []})()
+            rc = _run_upgrade(
+                "0.62.0",
+                SERVICE,
+                "/run/fraisier/systemctl.sock",
+                lock_dir=lock_dir,
+                drain_settle_s=0,
+            )
+
+        send_restart.assert_called_once()
+        assert rc == 0
+
+
+class TestTheResolver:
+    def test_it_reads_the_units_exec_start(self, unit_dir, tmp_path):
+        from fraisier.webhook_self_upgrade import _unit_entrypoint
+
+        entry = _install_entrypoint(tmp_path / "bin")
+        _write_unit(unit_dir, entry)
+        assert _unit_entrypoint(SERVICE) == str(entry)
+
+    def test_an_unknown_unit_resolves_to_none(self, unit_dir):
+        from fraisier.webhook_self_upgrade import _unit_entrypoint
+
+        assert _unit_entrypoint("fraisier-nope.service") is None

--- a/tests/test_worker_logging_seam.py
+++ b/tests/test_worker_logging_seam.py
@@ -1,0 +1,176 @@
+"""A detached worker that cannot speak cannot report its own failure (#351).
+
+`maybe_self_upgrade` and `maybe_apply_deferred_restarts` both spawn a
+``python -m fraisier.<module>`` worker. Neither worker configured logging, and
+with no handler Python falls back to :data:`logging.lastResort` — **WARNING
+level, straight to stderr**. So every ``log.info`` was dropped outright,
+including the line naming the command about to run, and the deferred-restart
+worker fared worse still: it is spawned with stdout *and* stderr on ``DEVNULL``,
+so even its warnings were unrecoverable.
+
+The four socket helpers each carried an identical hand-copied ``basicConfig``.
+That is the seam these two drifted from, so it gets a name and a guard rather
+than a fifth and sixth copy.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from fraisier.worker_logging import WORKER_LOG_FORMAT, configure_worker_logging
+
+_FRAISIER_DIR = Path(__file__).resolve().parent.parent / "fraisier"
+
+#: Matches the argv fragment a spawn site uses: "-m", "fraisier.<module>".
+_SPAWNED_MODULE = re.compile(r'"-m",\s*"fraisier\.([a-z_]+)"', re.MULTILINE)
+
+
+def _modules_spawned_as_workers() -> set[str]:
+    """Every ``fraisier.X`` launched via ``python -m`` anywhere in the tree.
+
+    Discovered rather than listed, so a new worker is covered the day it is
+    written instead of the day someone remembers this file.
+    """
+    found: set[str] = set()
+    for path in _FRAISIER_DIR.rglob("*.py"):
+        found.update(_SPAWNED_MODULE.findall(path.read_text()))
+    return found
+
+
+class TestTheSeamItself:
+    def test_it_attaches_a_handler_to_the_root_logger(self):
+        """Without a handler, `log.info` falls through to lastResort and dies.
+
+        Asserted on the root logger rather than through ``caplog``, which
+        installs a handler of its own and would make this pass even against the
+        unconfigured code it exists to catch.
+        """
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        try:
+            root.handlers.clear()
+            configure_worker_logging()
+            assert root.handlers, (
+                "no root handler: every log.info in the worker would be dropped "
+                "by logging.lastResort, which is WARNING-level"
+            )
+            assert root.level <= logging.INFO
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+    def test_it_is_idempotent(self):
+        """`basicConfig` is a no-op once configured; calling twice must not raise."""
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers[:], root.level
+        try:
+            root.handlers.clear()
+            configure_worker_logging()
+            configure_worker_logging()
+            assert len(root.handlers) == 1
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+    def test_it_keeps_the_format_the_helpers_already_used(self):
+        """The four socket helpers' format, so journal output does not change."""
+        assert WORKER_LOG_FORMAT == "%(levelname)s %(name)s: %(message)s"
+
+
+class TestEveryDetachedWorkerRoutesThroughIt:
+    """The guard. A worker that skips the seam is the #351 defect returning."""
+
+    def test_the_scan_finds_the_workers_we_know_about(self):
+        """Meta-test: a tree scan that matches nothing looks exactly like a pass.
+
+        v0.61.0's rule. Without this, deleting the spawn sites — or breaking the
+        regex — would turn the guard below green rather than red.
+        """
+        found = _modules_spawned_as_workers()
+        assert {"webhook_self_upgrade", "deferred_restart"} <= found, (
+            f"the spawn-site scan is broken or the workers moved; found={found}"
+        )
+
+    @pytest.mark.parametrize("module", sorted(_modules_spawned_as_workers()))
+    def test_worker_configures_logging_before_it_works(self, module):
+        source = (_FRAISIER_DIR / f"{module}.py").read_text()
+        assert "configure_worker_logging()" in source, (
+            f"fraisier.{module} is spawned as a detached worker but never calls "
+            "configure_worker_logging(); its log.info output would be discarded "
+            "by logging.lastResort"
+        )
+
+    def test_the_guard_can_fail(self, tmp_path, monkeypatch):
+        """Meta-test: prove the assertion above is capable of going red."""
+        fake = tmp_path / "fraisier"
+        fake.mkdir()
+        (fake / "silent_worker.py").write_text(
+            'import logging\nlog = logging.getLogger(__name__)\n"-m", "x"\n'
+        )
+        source = (fake / "silent_worker.py").read_text()
+        assert "configure_worker_logging()" not in source
+
+
+class TestTheSpawnSiteKeepsTheOutput:
+    """Configuring logging is pointless if the spawn throws it away."""
+
+    @staticmethod
+    def _spawn(tmp_path, monkeypatch, *, log_dir):
+        from unittest.mock import patch
+
+        from fraisier.deferred_restart import (
+            DEFERRED_RESTART_FILE,
+            maybe_apply_deferred_restarts,
+        )
+
+        monkeypatch.setattr("fraisier.deferred_restart._LOG_DIR", log_dir)
+        lock_dir = tmp_path / "run-fraisier"
+        lock_dir.mkdir()
+        (lock_dir / DEFERRED_RESTART_FILE).write_text("a.service\n")
+        seen: dict = {}
+
+        class _FakeProc:
+            pid = 4321
+
+        def fake_popen(cmd, **kwargs):
+            seen.update(kwargs)
+            return _FakeProc()
+
+        with patch("fraisier.deferred_restart.subprocess.Popen", fake_popen):
+            maybe_apply_deferred_restarts(
+                lock_dir=lock_dir, socket_path="/run/fraisier/systemctl.sock"
+            )
+        return seen
+
+    def test_deferred_restart_worker_output_is_not_discarded(
+        self, tmp_path, monkeypatch
+    ):
+        import subprocess as sp
+
+        seen = self._spawn(tmp_path, monkeypatch, log_dir=tmp_path / "logs")
+
+        assert seen, "the deferred-restart worker was never spawned"
+        assert seen.get("stdout") is not sp.DEVNULL, (
+            "the worker's diagnostics are discarded — it is the only thing that "
+            "can say *why* a deferred restart went unpaid"
+        )
+        assert seen.get("stderr") == sp.STDOUT, "stderr must join the same log"
+        assert (tmp_path / "logs").is_dir()
+
+    def test_an_unwritable_log_dir_still_spawns_the_worker(self, tmp_path, monkeypatch):
+        """Losing the log is bad; leaving the debt unpaid *and* unexplained is worse.
+
+        This is the fallback the self-upgrade worker already had, and it is why
+        the test above must point `_LOG_DIR` somewhere writable — otherwise it
+        passes against DEVNULL for an unrelated reason.
+        """
+        import subprocess as sp
+
+        seen = self._spawn(tmp_path, monkeypatch, log_dir=Path("/dev/null/nope"))
+
+        assert seen, "an unwritable log dir must not stop the worker"
+        assert seen.get("stdout") is sp.DEVNULL


### PR DESCRIPTION
Closes #351. Folds into the **unreleased** v0.63.0 — the tag is held, so this
ships alongside #349 and #262 rather than as its own release.

`uv tool install --force` removes before it verifies. When it failed partway it
left the tool venv half-removed — `bin/` gone, `lib/` intact — so every
`~/.local/bin/fraisier*` symlink dangled, including the one the webhook unit
names in `ExecStart=`. The running process outlived its deleted binary, so
`systemctl is-active`, the health check and the version endpoint all looked
normal. The damage surfaced only at the next restart, as 203/EXEC — and on a
deploy host that restart is often what you are relying on to fix something else.

Where #349 was an install destroying the deploy that asked for it, this is
fraisier destroying *itself* and staying quiet about it. Same invariant, one
level up:

> **A tool that replaces itself must leave a working tool, and must say so.**

## Scope

Owner-set: **detect and report**. The privileged `__pycache__` sweep the issue
suggests is deliberately **not** here — see "what is not in scope" below.

## Three commits

**1. `bc0d4cc` — a detached worker's own log is evidence**

The near-silence had a mechanical cause, not a design one. Neither
`webhook_self_upgrade._main` nor `deferred_restart._main` configured logging, so
Python fell back to `logging.lastResort` — **WARNING level, straight to stderr**
— and every `log.info` was dropped before it reached anything, including the line
naming the command about to run. That is exactly why the reported log file held
the failure and no record of what produced it.

`deferred_restart` was worse: spawned with **stdout *and* stderr on `DEVNULL`**,
so even its warnings were unrecoverable. Its ledger records *that* a debt went
unpaid; only the log records *why*, and a drain that timed out reads nothing like
a unit the helper refused. It now writes to `/var/lib/fraisier/deferred-restart/`.

Both route through one seam (`fraisier/worker_logging.py`) rather than becoming a
fifth and sixth copy of the four socket helpers' hand-copied `basicConfig`.

Plus `fraisier/self_upgrade_record.py`: the failure ledger, in the shape v0.63.0
gave deferred restarts — **cleared only when a later upgrade lands** — and a
`self_upgrade_failure` doctor check that reads it.

**2. `998cf85` — a half-removed venv is detectable**

New `unit_entrypoints` doctor check: reads every `*.service` under
`/etc/systemd/system`, takes each `ExecStart=` binary, keeps the ones named
`fraisier*`, and asserts each still exists and is executable.

It takes **no config** — the units on disk are the input — so it still answers on
a host whose `fraises.yaml` will not load, which a broken install can itself
produce. `fail`, not `warn`: unlike a deferred restart the unit cannot start at
all. And finding no fraisier entrypoint reports **`skip`, not `pass`** — a scan
that matched nothing must not read as a clean bill of health.

**3. `c6d2053` — the worker verifies its own result before restarting**

The worker resolves its own unit's `ExecStart=` after the install and refuses the
restart when it does not resolve. Checked on a **zero rc as well as a non-zero
one**, because success is not proof — and the same half-removed venv arises from
a full disk or a killed worker as from root-owned bytecode.

It **abstains** when the unit cannot be read: `None` means *unknown*, not *fine*,
and blocking a restart on a guess would strand the host in the other direction.

## What is not in scope, and why

The issue's first suggestion — sweep foreign-owned `__pycache__` before
installing — **cannot be built as written**. `fraisier-webhook.service.j2:38` sets
`NoNewPrivileges=true`, inherited by every descendant, and `start_new_session=True`
changes the session, not the privilege posture. The detached worker cannot
`sudo find`. The sweep already exists at `install.sh.j2:573` in #303's
foreign-owner form; reaching it from here needs a new privileged action on a root
daemon.

It was dropped on its merits: `--force` removes before it verifies, so
`__pycache__` is one trigger of a failure with many. A blocked upgrade still
fails — it just stops being invisible, and the workaround in the issue stays the
repair.

Also worth recording: the issue's fourth suggestion is **already shipped**. Every
unit sets `Environment=PYTHONDONTWRITEBYTECODE=1`, and the two daemons named as
root writers have since v0.5.13 and since the unit was created. The residue's
source is still an open evidence question, asked on the issue.

## Verification

Each gate's own exit status read separately rather than through a pipe:

- ✅ `uv run pytest` — **5154 passed / 7 skipped in 92.2s**, exit 0
- ✅ **5161 collected** vs `main`'s **5105** (+56), compared in a detached
  worktree per the standing rule, never a stash
- ✅ `uv run ruff check .` / `ruff format --check .` — clean, 484 files, exit 0
- ✅ `uv run ty check` — All checks passed, exit 0, **zero diagnostics**

### Things asserted rather than assumed

- **The logging guard is mutation-tested.** Deleting `configure_worker_logging()`
  from `deferred_restart` turns
  `test_worker_configures_logging_before_it_works[deferred_restart]` red with the
  right message; restoring it turns it green. The spawn-site discovery is
  asserted too — a tree scan that silently matches nothing is indistinguishable
  from a passing one.
- **The headline test drives a real fake `uv` on `PATH`** that removes `bin/` and
  exits 2, reproducing #351's exact shape. A stubbed `_run_install` cannot leave
  the venv in the state that matters. A fixture guard asserts the fake `uv`
  really did remove the entrypoint, so the tests cannot pass because the fixture
  quietly stopped working.
- **Existence is checked before `os.access`**, since `os.access(X_OK)` is
  permissive for root; a test patches `os.access` to always return True and still
  expects a failure.
- **A regression guard** asserts the happy path still restarts.

### One bug this found in its own first implementation

The restart refusal originally *overwrote* the failure record, replacing uv's
`Permission denied` with the consequence. A test caught it, and it was fixed in
the code rather than by weakening the test: the earlier detail is now carried
forward, because the cause and the consequence are both things an operator needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
