### PR TITLE
release: v0.64.0 — an outcome nobody could receive (#356, #343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,10 @@ would have started failing outright.
   result off the socket, and then exec'd into `journalctl` *before* looking at
   it — exiting with journalctl's status, which says nothing about the deploy. It
   now reports the outcome first and follows the logs only for a deployment that
-  succeeded.
+  succeeded. It still exec's `journalctl` only once the recv loop has drained —
+  that is, once the deploy is already over — so it follows nothing live; that
+  second oddity is untouched here and tracked as
+  [#357](https://github.com/fraiseql/fraisier/issues/357).
 - **`min_tables_schema` is forwarded to confiture**
   ([#343](https://github.com/fraiseql/fraisier/issues/343)). It was defaulting to
   `public` while the count could describe any schema. The host that reported #356
@@ -107,7 +110,8 @@ would have started failing outright.
   data section restores a complete, empty schema and passes any count —
   `dbops/restore.py` has said so in its own docstring the whole time. Relation
   mtimes, which is how #356 was found, remain the check for stale-but-intact
-  data. That hole stays open and gets an issue of its own.
+  data. That hole stays open as
+  [#358](https://github.com/fraiseql/fraisier/issues/358).
 - **`doctor deploy_result_channel`** finds hosts that cannot answer (#356).
   Making `--wait` honest means every host whose deploy unit still runs a
   pre-v0.64.0 fraisier now fails `--wait` — and that skew is the *normal* upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,130 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-08-10
+
+**An outcome nobody could receive.**
+
+`trigger-deploy --wait` printed `ok Deployment triggered successfully` and exited
+0 in **7 seconds** for a nightly staging restore whose real runtime is ~33
+minutes. The wrapping systemd unit recorded a clean exit. Staging silently stayed
+a day stale, and it was found only by comparing relation-file mtimes — row counts
+on a stale database are correct.
+
+The reported defect was the `--wait` guard, and it is real. But reading the
+source turned up something larger and stranger: **the result channel has never
+existed.** `deploy-service.j2` sets `StandardInput=socket` under an `Accept=yes`
+socket, so fd 0 *is* the accepted client connection — and it also sets
+`StandardOutput=journal`, so the `print()` carrying the machine-readable result
+went to the journal instead. Those three lines have been unchanged since socket
+activation was implemented in April.
+
+So the 7-second incident is not a race that produced an empty response. It is the
+*only* response that transport could ever produce, observed on a run short enough
+for someone to notice. Every `--wait` deploy in this project's history — success,
+failure, crash, all of them — read an empty response and took the
+fire-and-forget branch.
+
+This is the sixth instance of v0.61.0–v0.63.0's heading — *work that could not
+fail visibly*. The previous five destroyed or omitted the reporter. This one is
+worse: the reporting channel was never connected. So the invariant, not the site:
+
+> **A caller that asked for an outcome receives one, or an error — never a report
+> of an outcome that could not have arrived.**
+
+[#343](https://github.com/fraiseql/fraisier/issues/343)'s restore half is the
+same invariant against a database, narrowed to what a table count can actually
+prove:
+
+> **A restore reports success against the schema the archive says it carries, not
+> against a floor nobody configured.**
+
+**Order matters here, and the phases exist to enforce it.** Making `--wait` refuse
+to invent an outcome is only an improvement once an outcome can reach it. Shipped
+alone against today's units, it would have turned *every* `--wait` deploy —
+including the successful ones — into an exit 1. Nightly units that currently lie
+would have started failing outright.
+
+### Fixed
+
+- **The daemon's result reaches the connection that asked for it**
+  ([#356](https://github.com/fraiseql/fraisier/issues/356)). `deploy_daemon`
+  writes its JSON result to the accepted socket on fd 0, and keeps writing it to
+  stdout as well, so the journal holds the record it has always held and the
+  documented `echo '{…}' | fraisier deploy-daemon` pipe form is untouched.
+  `StandardOutput=journal` stays — it is deliberate (#72 Bug 2: `systemd` 255
+  versus Debian 12's 252) and flipping it would have put Rich-styled prose on the
+  wire ahead of the JSON, trading an empty response for an unparseable one.
+- **All seven terminating paths report, not two.** Empty stdin, an exception
+  while reading stdin, an unparseable request, a project mismatch and an
+  exception out of `execute_deployment_request` each printed prose and exited 1
+  having written nothing machine-readable at all. #356 attributed the empty
+  response to #349 killing the unit; #349 was one trigger out of six, and the
+  other five are ordinary control flow. Each now names its own reason.
+- **A departed peer cannot change the outcome.** `deploy-checker` fires
+  `trigger-deploy` with no `--wait` and closes in milliseconds, so half an hour
+  later the daemon writes to a socket whose peer is long gone. Unhandled, that
+  `BrokenPipeError` would raise *after* a successful deployment and take the
+  unit's exit code with it — inverting the bug rather than fixing it. The write
+  is wrapped, logged, and cannot touch the exit code.
+- **`--wait` reports the outcome it received.** An empty response is an error
+  naming both causes and the remedy for each; an unparseable response is an error
+  too, where it used to print a yellow warning and then the success line — the
+  same lie in a quieter voice, since a warning is not an exit code. Without
+  `--wait`, nothing changes: the caller never asked.
+- **`--follow` is bound by the same invariant.** It implies `--wait`, drained the
+  result off the socket, and then exec'd into `journalctl` *before* looking at
+  it — exiting with journalctl's status, which says nothing about the deploy. It
+  now reports the outcome first and follows the logs only for a deployment that
+  succeeded.
+- **`min_tables_schema` is forwarded to confiture**
+  ([#343](https://github.com/fraiseql/fraisier/issues/343)). It was defaulting to
+  `public` while the count could describe any schema. The host that reported #356
+  keeps its heaps in `tenant`, so this is the half that makes an archive-derived
+  floor safe rather than a guaranteed false failure on a perfect restore.
+
+### Added
+
+- **A restore proves its schema arrived** (#343). `verify_archive` already ran
+  `pg_restore --list` and then discarded the table of contents; it now counts the
+  `TABLE DATA` entries **per schema** from output it already had in memory — no
+  second invocation. The count becomes the floor confiture enforces *before*
+  migrations, because the TOC describes the archive, so the database that must
+  satisfy it is the one before `migrate up`. A shortfall fails the restore.
+
+  This closes a hole `min_tables` only *declared*: it defaults to `0` and the
+  strategy's floor is `if cfg.min_tables > 0`, so in the default configuration
+  nothing counted anything and a near-empty restore exited 0 with a yellow note.
+
+  **What it does not do, stated plainly because the CHANGELOG must not imply
+  otherwise: it does not prove the data arrived.** A dump truncated inside its
+  data section restores a complete, empty schema and passes any count —
+  `dbops/restore.py` has said so in its own docstring the whole time. Relation
+  mtimes, which is how #356 was found, remain the check for stale-but-intact
+  data. That hole stays open and gets an issue of its own.
+- **`doctor deploy_result_channel`** finds hosts that cannot answer (#356).
+  Making `--wait` honest means every host whose deploy unit still runs a
+  pre-v0.64.0 fraisier now fails `--wait` — and that skew is the *normal* upgrade
+  order, not an edge case: the CLI replaces itself via self-upgrade while the
+  deploy unit's binary changes only when someone re-runs a scaffold install. The
+  check reads the **installed** units, finds every service whose `ExecStart=`
+  runs `deploy-daemon`, and asks that binary its version. Three-valued, following
+  `ArchiveCheck`: `fail` for a stale binary, `warn` for one it could not
+  interrogate — the deploy user's binary is routinely unreadable by whoever runs
+  `doctor`, and "I could not ask" is not "this host is broken" — and `skip` when
+  there was nothing to look at.
+
+### Upgrading
+
+Reinstall the deploy units on every host, or `--wait` will exit 1 there:
+
+```bash
+fraisier scaffold && sudo fraisier scaffold-install --yes
+fraisier doctor          # deploy_result_channel lists anything still stale
+```
+
+Hosts that never pass `--wait` are unaffected.
+
 ## [0.63.0] - 2026-08-09
 
 **An install that killed the deploy that asked for it.**

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -46,6 +46,7 @@ passed.
 | `webhook_hosted_trees_writable` | the installed webhook unit's `ReadWritePaths=` covers every tree it deploys | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` |
 | `deferred_restarts` | no unit is installed-and-daemon-reloaded while still running its previous version | no | `sudo systemctl restart <unit>` once no deploy is in flight — see [restarts a deploy defers](#restarts-a-deploy-defers) |
 | `sandbox_write_probe` | actually writes into the rendered unit's sandbox under `ProtectSystem=strict` | no | opt-in via `--probe-sandbox`; needs root, else `skip` |
+| `deploy_result_channel` | every installed deploy service runs a fraisier new enough to return a result to `--wait` | no | `fraisier scaffold && sudo fraisier scaffold-install --yes` — see [a deploy socket that cannot answer](#a-deploy-socket-that-cannot-answer) |
 
 The catalog above is **complete**, and a test asserts it: every name in
 `DOCTOR_CHECKS` appears here and vice versa. It had silently fallen six checks
@@ -155,6 +156,58 @@ a missing file executable.
 If no unit names a fraisier binary, the check reports `skip` and says so, rather
 than `pass`. A scan that matched nothing must not read as a clean bill of
 health.
+
+## A deploy socket that cannot answer
+
+`trigger-deploy --wait` exists so a caller can tell "done" from "started". Until
+v0.64.0 it could not: `deploy-service` sets `StandardInput=socket` under an
+`Accept=yes` socket, so fd 0 *is* the accepted client connection, but the
+daemon wrote its machine-readable result with `print()` — to fd 1, which
+`StandardOutput=journal` sends to the journal. The result never reached the
+client. Every `--wait` run read an empty response and reported
+`Deployment triggered successfully`, exit 0, whatever had actually happened.
+
+v0.64.0 fixes both halves: the daemon writes the result to the connection, and
+`--wait` treats a missing or unparseable result as a failure rather than
+inventing a success.
+
+That second half has a cost, and this check is how you pay it deliberately. A
+host whose deploy unit still runs a **pre-v0.64.0** fraisier cannot return a
+result at all, so every `--wait` deploy against it now exits 1. And that skew is
+the normal upgrade order rather than an edge case: the CLI replaces itself via
+self-upgrade, while the deploy unit's binary changes only when someone re-runs a
+scaffold install. A host can sit new-client/old-unit for weeks.
+
+`deploy_result_channel` reads the **installed** units — not the rendered ones —
+finds every service whose `ExecStart=` runs `deploy-daemon`, and asks that
+binary its version. The unit file itself is unchanged by the fix (the result
+goes to fd 0, which `StandardInput=socket` already provided), so the binary is
+the only thing that can answer the question.
+
+It takes no config: the units on disk are the input, so it still reports on a
+host whose `fraises.yaml` will not load. Deploy units on a host almost always
+share one binary, so it is asked once and the answer reused.
+
+Three verdicts, and the third is the point:
+
+- `fail` — a unit runs a fraisier older than 0.64.0. Named per unit, and the
+  unit name is the `(fraise, environment)` identity. Retrying will not help;
+  re-render and reinstall:
+
+  ```bash
+  fraisier scaffold && sudo fraisier scaffold-install --yes
+  ls -l ~/.local/bin/fraisier          # confirm the binary moved
+  ```
+
+- `warn` — the binary would not say what it is. Usually the deploy user's
+  `~/.local/bin/fraisier` is simply not readable by whoever ran `doctor`. This
+  is *unverifiable*, not broken, and follows `ArchiveCheck`'s three-valued
+  precedent: "I could not ask" is not "this host is broken". Ask it directly
+  with `sudo -u <deploy_user>`.
+
+- `skip` — no deploy services are installed here, or the unit directory could
+  not be read. As with `unit_entrypoints`, a scan that matched nothing reports
+  `skip` rather than `pass`.
 
 ## JSON output
 

--- a/docs/socket-deployment.md
+++ b/docs/socket-deployment.md
@@ -26,6 +26,42 @@ Socket activation allows web applications to trigger deployments by writing JSON
 /run/fraisier/api-staging/deploy.sock
 ```
 
+### The Result Channel
+
+The socket unit sets `Accept=yes` and the service sets `StandardInput=socket`, so
+systemd hands each connection to a fresh `<stem>@N.service` instance with **fd 0
+already connected to the client**. The daemon writes its JSON result there:
+
+```
+{"success": true, "status": "success", "version": "abc123",
+ "duration": 1987.4, "error": null, "message": "Deployment completed"}
+```
+
+Exactly one object per connection, on **every** terminating path — including the
+five that end before a deployment ever runs (empty stdin, unreadable stdin, an
+unparseable request, a project mismatch, and an exception out of the deployment
+itself). Each of those carries its own reason in `error`, because "failed" on its
+own names nothing.
+
+Three properties worth knowing:
+
+- **`StandardOutput=journal` is deliberate and stays.** Setting it to `socket`
+  would put Rich-styled human output on the wire ahead of the JSON, trading an
+  empty response for an unparseable one. The result goes to fd 0 explicitly
+  instead, and stdout keeps carrying a copy into the journal.
+- **The result is written to a duplicate of fd 0, never to fd 0 directly.**
+  `socket.socket(fileno=0)` takes ownership of the descriptor and closes it when
+  collected — stdin closed out from under a running deployment.
+- **A departed peer is normal, not an error.** `deploy-checker` triggers deploys
+  without `--wait` and closes immediately, so half an hour later the write fails
+  with `EPIPE`. That is logged and cannot affect the exit code, which belongs to
+  the deployment alone.
+
+Before v0.64.0 the daemon wrote its result to stdout only, which
+`StandardOutput=journal` sent to the journal — so no `--wait` client ever
+received one. See [`doctor`](doctor.md#a-deploy-socket-that-cannot-answer) for
+finding hosts whose deploy units still run an older fraisier.
+
 ### Security Model
 
 - **Socket permissions**: Owned by web user (www-data), readable/writable by web group

--- a/fraisier/cli/_deploy.py
+++ b/fraisier/cli/_deploy.py
@@ -301,9 +301,24 @@ def trigger_deploy(
             # socket_stem was derived from deploy_socket_name() above.
             unit_pattern = f"{socket_stem}@*.service"
             os.execvp("journalctl", ["journalctl", "-u", unit_pattern, "-f"])
-        elif wait and response_data:
-            # Parse and display result
+        elif wait:
+            # --wait asked for the outcome, so anything short of a result the
+            # daemon actually sent is an outcome we do not know — and an unknown
+            # outcome must never read as a success. Reporting one is how a
+            # nightly restore skipped a full day while the wrapping unit
+            # recorded a clean exit (#356).
             from fraisier._output import success
+
+            if not response_data:
+                console.print(
+                    "[red]Error:[/red] Deployment reported no result — the "
+                    "connection closed before the daemon sent one.\n"
+                    "[yellow]Hint:[/yellow] The deploy unit likely died mid-run. "
+                    "Check what it logged:\n"
+                    f"  journalctl -u '{socket_stem}@*.service' --since '-1h'"
+                )
+                sock.close()
+                raise SystemExit(1)
 
             try:
                 result = json.loads(response_data.decode("utf-8"))
@@ -324,9 +339,13 @@ def trigger_deploy(
                     raise SystemExit(1)
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
                 console.print(
-                    f"[yellow]Warning:[/yellow] Could not parse deployment result: {e}"
+                    f"[red]Error:[/red] Could not parse deployment result: {e}\n"
+                    "[yellow]Hint:[/yellow] The deploy ran, but its outcome is "
+                    "unknown. Check status: "
+                    f"fraisier deployment-status {fraise}"
                 )
-                success("Deployment triggered successfully")
+                sock.close()
+                raise SystemExit(1) from None
         else:
             from fraisier._output import success
 

--- a/fraisier/cli/_deploy.py
+++ b/fraisier/cli/_deploy.py
@@ -310,12 +310,23 @@ def trigger_deploy(
             from fraisier._output import success
 
             if not response_data:
+                # Two causes, and the first is the common one right after an
+                # upgrade: the CLI replaces itself via self-upgrade while the
+                # deploy unit only changes when someone re-runs a scaffold
+                # install, so a host can be new-client/old-unit for weeks. Such
+                # a unit has no result channel at all and retrying never helps.
                 console.print(
                     "[red]Error:[/red] Deployment reported no result — the "
                     "connection closed before the daemon sent one.\n"
-                    "[yellow]Hint:[/yellow] The deploy unit likely died mid-run. "
-                    "Check what it logged:\n"
-                    f"  journalctl -u '{socket_stem}@*.service' --since '-1h'"
+                    "[yellow]Hint:[/yellow] Two causes, likeliest first:\n"
+                    "  1. This host's deploy unit predates v0.64.0 and cannot "
+                    "return a result.\n"
+                    "     Re-render and reinstall it — retrying will not help:\n"
+                    "       fraisier scaffold && fraisier scaffold-install\n"
+                    "     fraisier doctor lists every deploy unit that cannot "
+                    "answer.\n"
+                    "  2. The deploy unit died mid-run. Check what it logged:\n"
+                    f"       journalctl -u '{socket_stem}@*.service' --since '-1h'"
                 )
                 sock.close()
                 raise SystemExit(1)

--- a/fraisier/cli/_deploy.py
+++ b/fraisier/cli/_deploy.py
@@ -173,7 +173,11 @@ def deploy_daemon(ctx: click.Context, project: str) -> None:  # noqa: ARG001
 @click.option(
     "--follow",
     is_flag=True,
-    help="Wait and stream live service logs via journalctl (implies --wait)",
+    help=(
+        "Wait, report the outcome, then stream live service logs via "
+        "journalctl (implies --wait; a failed deploy exits non-zero instead "
+        "of tailing)"
+    ),
 )
 @click.option(
     "--timeout", type=int, default=300, help="Timeout in seconds (default: 300)"
@@ -295,13 +299,13 @@ def trigger_deploy(
                 )
                 raise SystemExit(1) from None
 
-        # Handle wait/follow modes
-        if follow:
-            # Exec into journalctl to follow logs.
-            # socket_stem was derived from deploy_socket_name() above.
-            unit_pattern = f"{socket_stem}@*.service"
-            os.execvp("journalctl", ["journalctl", "-u", unit_pattern, "-f"])
-        elif wait:
+        # Handle wait/follow modes. --follow implies --wait, so it is a caller
+        # that asked for an outcome and is bound by the same invariant: it used
+        # to drain the result off the socket and exec into journalctl before
+        # looking at it, exiting with journalctl's status instead of the
+        # deploy's. The outcome is reported first now, and the logs are
+        # followed only for a deployment that actually succeeded.
+        if wait:
             # --wait asked for the outcome, so anything short of a result the
             # daemon actually sent is an outcome we do not know — and an unknown
             # outcome must never read as a success. Reporting one is how a
@@ -341,6 +345,12 @@ def trigger_deploy(
                     if result.get("duration"):
                         console.print(f"Duration: {result['duration']:.1f}s")
                     sock.close()
+                    if follow:
+                        # socket_stem was derived from deploy_socket_name().
+                        unit_pattern = f"{socket_stem}@*.service"
+                        os.execvp(
+                            "journalctl", ["journalctl", "-u", unit_pattern, "-f"]
+                        )
                     raise SystemExit(0)
                 else:
                     console.print(

--- a/fraisier/cli/_deploy.py
+++ b/fraisier/cli/_deploy.py
@@ -12,6 +12,67 @@ from ._helpers import console
 from .main import main
 
 
+def _failure_result(error: str) -> dict[str, object]:
+    """A machine-readable result for a path that never reached a deployment.
+
+    Same six keys as the success payload, so a client parses one shape whatever
+    happened. The reason goes in ``error`` verbatim: these are the paths an
+    operator most needs named, and "failed" on its own names nothing.
+    """
+    return {
+        "success": False,
+        "status": "failed",
+        "version": None,
+        "duration": None,
+        "error": error,
+        "message": None,
+    }
+
+
+def _write_to_accepted_connection(result_json: str) -> None:
+    """Write the result to the socket systemd accepted on fd 0, if there is one.
+
+    Under ``Accept=yes`` + ``StandardInput=socket`` fd 0 *is* the client
+    connection, so this is the only channel that reaches a waiting
+    ``trigger-deploy``. ``StandardOutput=journal`` is deliberate (#72 Bug 2),
+    which is why stdout cannot carry the result.
+
+    Never raises. ``deploy-checker.service.j2`` triggers deploys *without*
+    ``--wait`` and closes at once, so half an hour later the peer is normally
+    gone — a departed client must not turn a successful deployment into a
+    failed unit.
+    """
+    import socket
+    import stat
+
+    try:
+        if not stat.S_ISSOCK(os.fstat(0).st_mode):
+            return  # the documented pipe form; stdout already carried it
+    except OSError:
+        return  # fd 0 is closed — there is nobody to answer
+
+    try:
+        # os.dup(0), never socket.socket(fileno=0): the latter *owns* fd 0 and
+        # closes it when collected, out from under a deployment reading stdin.
+        with socket.socket(fileno=os.dup(0)) as conn:
+            conn.sendall(result_json.encode("utf-8"))
+    except OSError as e:
+        console.print(f"[yellow]Note:[/yellow] no client received the result: {e}")
+
+
+def _emit_result(payload: dict[str, object]) -> None:
+    """Send the deployment result everywhere it is owed.
+
+    stdout keeps the record the journal has always held; the accepted
+    connection is what a ``--wait`` client reads.
+    """
+    import json
+
+    result_json = json.dumps(payload)
+    print(result_json)  # print() not console.print(): machine-readable output
+    _write_to_accepted_connection(result_json)
+
+
 @main.command()
 @click.option("--project", required=True, help="Project name to deploy")
 @click.pass_context
@@ -30,42 +91,48 @@ def deploy_daemon(ctx: click.Context, project: str) -> None:  # noqa: ARG001
 
     from fraisier.daemon import execute_deployment_request, parse_deployment_request
 
-    # Read JSON from stdin
+    # Read JSON from stdin. Every terminating path below reports a result on
+    # the connection first — a caller that asked for an outcome gets one, and
+    # these five are the paths that used to answer with nothing at all (#356).
     try:
         json_input = sys.stdin.read().strip()
-        if not json_input:
-            console.print("[red]Error:[/red] No input received on stdin")
-            raise SystemExit(1)
     except Exception as e:
+        _emit_result(_failure_result(f"Error reading stdin: {e}"))
         console.print(f"[red]Error reading stdin:[/red] {e}")
         raise SystemExit(1) from None
+
+    if not json_input:
+        _emit_result(_failure_result("No input received on stdin"))
+        console.print("[red]Error:[/red] No input received on stdin")
+        raise SystemExit(1)
 
     # Parse and validate request
     try:
         request = parse_deployment_request(json_input)
     except ValueError as e:
+        _emit_result(_failure_result(f"Error parsing request: {e}"))
         console.print(f"[red]Error parsing request:[/red] {e}")
         raise SystemExit(1) from None
 
     # Validate project matches
     if request.project != project:
-        console.print(
-            f"[red]Error:[/red] Project mismatch: requested '{request.project}' "
+        mismatch = (
+            f"Project mismatch: requested '{request.project}' "
             f"but daemon configured for '{project}'"
         )
+        _emit_result(_failure_result(mismatch))
+        console.print(f"[red]Error:[/red] {mismatch}")
         raise SystemExit(1)
 
     # Execute deployment
     try:
         result = execute_deployment_request(request)
     except Exception as e:
+        _emit_result(_failure_result(f"Error executing deployment: {e}"))
         console.print(f"[red]Error executing deployment:[/red] {e}")
         raise SystemExit(1) from None
 
-    # Write JSON result to stdout (for socket clients)
-    import json
-
-    result_json = json.dumps(
+    _emit_result(
         {
             "success": result.success,
             "status": result.status,
@@ -75,7 +142,6 @@ def deploy_daemon(ctx: click.Context, project: str) -> None:  # noqa: ARG001
             "message": result.message,
         }
     )
-    print(result_json)  # Use print() not console.print() for machine-readable output
 
     # Also write human-readable output to stderr for systemd logs
     if result.success:

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -715,11 +715,36 @@ def db_restore(
             # console rather than the log because `fraisier` only configures
             # logging under -v, and the generated timer unit passes no flags —
             # an INFO line would reach neither the terminal nor the journal.
-            if int(restore_cfg.get("min_tables", 0)) <= 0:
+            # The archive can state its own floor now (#343), so "not checked"
+            # stopped being true whenever it does. What must not creep in is the
+            # opposite claim: a table count proves the schema arrived and says
+            # nothing about the data, which `dbops/restore.py` documents.
+            schema_floor = getattr(result, "schema_floor", None)
+            if schema_floor is not None:
+                floor_schema, floor_tables = schema_floor
+                console.print(
+                    f"  Schema floor: {floor_tables} base table(s) required in "
+                    f"'{floor_schema}', from the archive's own table of "
+                    "contents — met."
+                )
+                unchecked = getattr(result, "unchecked_schemas", ())
+                if unchecked:
+                    console.print(
+                        "  [yellow]Not checked:[/yellow] "
+                        f"{', '.join(unchecked)} also carry table data in this "
+                        "archive; the floor covers the largest schema only."
+                    )
+                console.print(
+                    "  [dim]This checks the schema arrived, not the data — a "
+                    "dump truncated inside its data section restores a "
+                    "complete, empty schema.[/dim]"
+                )
+            elif int(restore_cfg.get("min_tables", 0)) <= 0:
                 console.print(
                     "  [yellow]Note:[/yellow] no table-count floor configured "
-                    "(database.restore.min_tables); the restored database was "
-                    "not checked for emptiness."
+                    "(database.restore.min_tables) and the archive stated none "
+                    "(--schema-only, or pg_restore unavailable); the restored "
+                    "database was not checked for emptiness."
                 )
             if result.total_duration_seconds > 0:
                 console.print(

--- a/fraisier/dbops/archive.py
+++ b/fraisier/dbops/archive.py
@@ -85,6 +85,39 @@ class ArchiveCheck:
         """
         return self.verdict is ArchiveVerdict.INVALID
 
+    @property
+    def schema_floor(self) -> tuple[str, int] | None:
+        """The principal data schema and how many base tables it carries.
+
+        ``None`` when the archive states no floor: ``UNVERIFIABLE``,
+        ``INVALID``, or a ``--schema-only`` dump carrying no ``TABLE DATA``
+        entries at all. A caller must report that as *not checked*, never as
+        checked and passed — three routes to the same silence, and only one of
+        them was ever guarded.
+
+        One schema, because the counter that enforces it takes one. The
+        principal schema is the one carrying the most table data, ties broken
+        by name so the choice is deterministic across runs.
+        """
+        if not self.table_data_by_schema:
+            return None
+        schema = min(
+            self.table_data_by_schema,
+            key=lambda s: (-self.table_data_by_schema[s], s),
+        )
+        return schema, self.table_data_by_schema[schema]
+
+    @property
+    def unchecked_schemas(self) -> tuple[str, ...]:
+        """Schemas the archive carries that the derived floor does not cover.
+
+        Named rather than folded into a sum. Summing them would restore exactly
+        the mismatch this per-schema counting exists to avoid.
+        """
+        floor = self.schema_floor
+        covered = {floor[0]} if floor else set()
+        return tuple(sorted(set(self.table_data_by_schema) - covered))
+
 
 #: Fields of a TOC entry once the ``dumpId;`` prefix is removed:
 #: ``catalogId oid TAG SCHEMA NAME OWNER``. The tag begins at index 2.

--- a/fraisier/dbops/archive.py
+++ b/fraisier/dbops/archive.py
@@ -24,7 +24,7 @@ second on the corpus that matters.
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
@@ -56,6 +56,20 @@ class ArchiveCheck:
     verdict: ArchiveVerdict
     detail: str
 
+    table_data_by_schema: dict[str, int] = field(default_factory=dict)
+    """``TABLE DATA`` entries in the table of contents, counted per schema.
+
+    Empty unless the verdict is ``VALID``, and empty for a ``--schema-only``
+    dump, which carries none. **An empty mapping is "nothing was learned", not
+    "a floor of zero"** — the same rule as ``UNVERIFIABLE``. A caller deriving
+    a floor must say it did not check rather than that it checked and passed.
+
+    Per schema, never summed: entries span every schema in the archive while
+    the counters that verify a restore look at one. A whole-archive floor
+    compared against a single schema's count is a guaranteed false failure on a
+    host whose tables live outside ``public``.
+    """
+
     @property
     def is_valid(self) -> bool:
         """The archive was read successfully."""
@@ -70,6 +84,43 @@ class ArchiveCheck:
         that would have cleared it.
         """
         return self.verdict is ArchiveVerdict.INVALID
+
+
+#: Fields of a TOC entry once the ``dumpId;`` prefix is removed:
+#: ``catalogId oid TAG SCHEMA NAME OWNER``. The tag begins at index 2.
+_TAG_INDEX = 2
+#: An entry needs a schema and a name after a two-word tag to be counted.
+_MIN_ENTRY_FIELDS = 6
+
+
+def _table_data_counts(toc: str) -> dict[str, int]:
+    """Count ``TABLE DATA`` entries per schema in a ``pg_restore --list`` TOC.
+
+    ``relkind='r'`` is what this is apples-to-apples with: pg_dump emits one
+    ``TABLE DATA`` entry per dumped base table whatever its row count, emits
+    ``MATERIALIZED VIEW DATA`` for matviews, emits nothing for views, and
+    attaches partition data to the leaf partitions rather than to the parent.
+
+    The tag is read **positionally**, not by substring. Header and comment
+    lines share the stream, tags are multi-word, and a table *named*
+    ``my TABLE DATA table`` would otherwise be counted as an entry it is not.
+    """
+    counts: dict[str, int] = {}
+    for raw in toc.splitlines():
+        line = raw.strip()
+        if not line or line.startswith(";"):
+            continue  # header or comment
+        dump_id, sep, rest = line.partition(";")
+        if not sep or not dump_id.strip().isdigit():
+            continue
+        fields = rest.split()
+        if len(fields) < _MIN_ENTRY_FIELDS:
+            continue
+        if fields[_TAG_INDEX : _TAG_INDEX + 2] != ["TABLE", "DATA"]:
+            continue
+        schema = fields[_TAG_INDEX + 2]
+        counts[schema] = counts.get(schema, 0) + 1
+    return counts
 
 
 def _list_command(path: Path) -> list[str]:
@@ -127,4 +178,6 @@ def verify_archive(path: Path | str) -> ArchiveCheck:
             or f"pg_restore --list exited with code {result.returncode}",
         )
 
-    return ArchiveCheck(ArchiveVerdict.VALID, "")
+    return ArchiveCheck(
+        ArchiveVerdict.VALID, "", _table_data_counts(result.stdout or "")
+    )

--- a/fraisier/dbops/restore.py
+++ b/fraisier/dbops/restore.py
@@ -115,6 +115,7 @@ def restore_backup(
     db_owner: str | None = None,
     jobs: int = 1,
     min_tables: int = 0,
+    min_tables_schema: str = "public",
 ) -> RestoreResult:
     """Restore a pg_dump backup into *db_name* via confiture's three-phase restore.
 
@@ -161,6 +162,12 @@ def restore_backup(
         # at their own point — confiture's before migrations, the strategy's
         # after, where a floor can account for tables migrations create.
         min_tables=min_tables,
+        # Forwarded too, and this is the half that makes a derived floor safe
+        # (#343). It defaulted to confiture's `public` while the caller's count
+        # could describe any schema — and #356's own host keeps its heaps in
+        # `tenant`, so a floor derived from one schema and asserted against
+        # another is a guaranteed false failure on a perfectly good restore.
+        min_tables_schema=min_tables_schema,
     )
     # confiture emits an explicit -h/-p; only override its RestoreOptions
     # defaults for the parts the URL actually carries (a socket URL with no

--- a/fraisier/doctor.py
+++ b/fraisier/doctor.py
@@ -22,6 +22,7 @@ Security
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1169,4 +1170,145 @@ def _check_self_upgrade_failure(config: FraisierConfig | None) -> CheckResult:
             f"  uv tool install --force fraisier=={failure.required}\n"
             f"Recorded cause: {failure.detail[:300]}"
         ),
+    )
+
+
+#: The release in which ``deploy_daemon`` began writing its result to the
+#: accepted connection (#356). Before it, the result went to the journal via
+#: ``print()`` and no ``--wait`` client could ever receive one.
+RESULT_CHANNEL_SINCE = (0, 64, 0)
+
+_VERSION_IN_OUTPUT = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+def _binary_semver(binary: str) -> tuple[int, int, int] | None:
+    """Ask a fraisier binary its version. None when it will not say.
+
+    None is *unverifiable*, not old: the deploy user's binary is frequently
+    unreadable by whoever runs ``doctor``, and "I could not ask" must not read
+    as "this host is broken".
+    """
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    match = _VERSION_IN_OUTPUT.search(proc.stdout or "")
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _installed_deploy_entrypoints() -> dict[str, str] | None:
+    """Map each installed deploy service to the fraisier binary it runs.
+
+    Deploy services are identified by what they execute — ``deploy-daemon`` —
+    rather than by unit name, so a hand-written or renamed unit is found too.
+    None when the unit directory cannot be read at all.
+    """
+    try:
+        unit_files = sorted(SYSTEMD_UNIT_DIR.glob("*.service"))
+    except OSError:
+        return None
+
+    entrypoints: dict[str, str] = {}
+    for unit in unit_files:
+        try:
+            text = unit.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in text.splitlines():
+            binary = _exec_start_binary(line)
+            if binary is None or "deploy-daemon" not in line:
+                continue
+            entrypoints[unit.name] = binary
+    return entrypoints
+
+
+@register_check("deploy_result_channel")
+def _check_deploy_result_channel(_config: FraisierConfig | None) -> CheckResult:
+    """Every installed deploy service can return a result to ``--wait`` (#356).
+
+    ``trigger-deploy --wait`` now exits 1 when no result arrives, because
+    reporting an outcome that never came is how a nightly staging restore
+    skipped a full day while systemd recorded a clean exit. The cost is that a
+    host whose deploy unit still runs a pre-v0.64.0 fraisier fails every
+    ``--wait`` deploy until it is reinstalled — and that skew is the *normal*
+    upgrade order: the CLI replaces itself via self-upgrade, while the deploy
+    unit's binary changes only when someone re-runs a scaffold install.
+
+    This is what finds those hosts before their next nightly does. The unit
+    file is unchanged by the fix — the result goes to fd 0, which
+    ``StandardInput=socket`` already provided — so the discriminator is the
+    version of the binary the *installed* unit names in ``ExecStart=``.
+
+    Takes no config: the units on disk are the input, so it still answers on a
+    host whose ``fraises.yaml`` will not load.
+    """
+    name = "deploy_result_channel"
+
+    entrypoints = _installed_deploy_entrypoints()
+    if entrypoints is None:
+        return CheckResult(name, "skip", f"could not read {SYSTEMD_UNIT_DIR}")
+    if not entrypoints:
+        # Distinct from "pass" on purpose: a scan that matched nothing must not
+        # read as a clean bill of health.
+        return CheckResult(
+            name, "skip", f"no deploy services installed under {SYSTEMD_UNIT_DIR}"
+        )
+
+    # Deploy units on a host almost always share one binary; ask each once.
+    versions = {binary: _binary_semver(binary) for binary in set(entrypoints.values())}
+
+    stale: list[str] = []
+    unknown: list[str] = []
+    for unit_name, binary in sorted(entrypoints.items()):
+        semver = versions[binary]
+        if semver is None:
+            unknown.append(f"{unit_name} -> {binary}")
+        elif semver < RESULT_CHANNEL_SINCE:
+            stale.append(f"{unit_name} -> {'.'.join(str(p) for p in semver)}")
+
+    since = ".".join(str(p) for p in RESULT_CHANNEL_SINCE)
+    if stale:
+        return CheckResult(
+            name,
+            "fail",
+            f"{len(stale)} of {len(entrypoints)} deploy service(s) run a fraisier "
+            f"older than {since} and cannot return a result to --wait: "
+            f"{'; '.join(stale)}",
+            fix_hint=(
+                "every `trigger-deploy --wait` against these exits 1 until the "
+                "unit runs a newer fraisier — retrying does not help. Re-render "
+                "and reinstall:\n"
+                "  fraisier scaffold && fraisier scaffold-install\n"
+                "then confirm the deploy user's binary moved: "
+                "`ls -l ~/.local/bin/fraisier`"
+            ),
+        )
+    if unknown:
+        return CheckResult(
+            name,
+            "warn",
+            f"could not determine the fraisier version behind "
+            f"{len(unknown)} of {len(entrypoints)} deploy service(s): "
+            f"{'; '.join(unknown)}",
+            fix_hint=(
+                "this is unverifiable, not broken — the deploy user's binary is "
+                "usually not readable by whoever runs doctor. Ask it directly: "
+                "`sudo -u <deploy_user> ~<deploy_user>/.local/bin/fraisier "
+                "--version`"
+            ),
+        )
+    return CheckResult(
+        name,
+        "pass",
+        f"{len(entrypoints)} deploy service(s) run fraisier {since} or newer",
     )

--- a/fraisier/strategies/_base.py
+++ b/fraisier/strategies/_base.py
@@ -19,6 +19,17 @@ class StrategyResult:
     migration_duration_seconds: float = 0.0
     total_duration_seconds: float = 0.0
 
+    schema_floor: tuple[str, int] | None = None
+    """``(schema, tables)`` the archive's own TOC required, or None if none was.
+
+    None is *not checked* — an unverifiable archive or a ``--schema-only`` dump
+    — and a caller reporting it must not say the restore was checked and
+    passed. It proves the **schema** arrived; it cannot prove the data did.
+    """
+
+    unchecked_schemas: tuple[str, ...] = ()
+    """Schemas in the archive the derived floor did not cover."""
+
 
 @dataclass
 class ValidationResult:

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -363,13 +363,22 @@ class RestoreMigrateStrategy(Strategy):
                     f"Table count validation failed: {count} < {cfg.min_tables}",
                 )
             log.info("Table count validation passed: %d >= %d", count, cfg.min_tables)
+        elif derived is not None:
+            log.info(
+                "No operator floor configured (restore.min_tables); the "
+                "archive's own floor of %d base table(s) in schema %s was "
+                "enforced before migrations",
+                derived[1],
+                derived[0],
+            )
         else:
             # Said, not assumed (#343). The absence of a floor used to be
             # covered by a comment claiming this step enforced one. An operator
             # reading "Restore complete" should learn whether anything counted.
             log.info(
-                "No table-count floor configured (restore.min_tables); the "
-                "restored database was not checked for emptiness"
+                "No table-count floor configured (restore.min_tables) and the "
+                "archive stated none; the restored database was not checked "
+                "for emptiness"
             )
 
         # Step 11: Start service

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -260,6 +260,23 @@ class RestoreMigrateStrategy(Strategy):
             )
         log.info("Recreated database %s", cfg.db_name)
 
+        # The archive states the floor it can satisfy, so nobody has to invent
+        # a number (#343). confiture's pre-migration counter is the instrument:
+        # `pg_class WHERE relkind='r'` in a parameterised schema, which is
+        # apples-to-apples with the TOC's TABLE DATA entries. Pre-migration is
+        # the right checkpoint too — the TOC describes the archive, so the
+        # database that must satisfy it is the one before `migrate up`; applied
+        # after, any migration that drops or renames a table false-fails.
+        #
+        # None means the archive stated nothing — UNVERIFIABLE, or a
+        # --schema-only dump with no TABLE DATA entries. That falls back to the
+        # operator's floor and is reported as unchecked, never as a floor of 0.
+        derived = check.schema_floor
+        if derived is not None:
+            floor_schema, floor_tables = derived
+        else:
+            floor_schema, floor_tables = "public", cfg.min_tables
+
         # Step 6 + 7: pg_restore (with optional ownership fix)
         t_total = time.monotonic()
         restore_result = restore_backup(
@@ -268,7 +285,8 @@ class RestoreMigrateStrategy(Strategy):
             db_owner=cfg.target_owner,
             connection_url=self._admin_url,
             jobs=cfg.jobs,
-            min_tables=cfg.min_tables,
+            min_tables=floor_tables,
+            min_tables_schema=floor_schema,
         )
         restore_secs = restore_result.duration_seconds
         if not restore_result.success:
@@ -386,6 +404,8 @@ class RestoreMigrateStrategy(Strategy):
             restore_duration_seconds=restore_secs,
             migration_duration_seconds=migration_secs,
             total_duration_seconds=total_secs,
+            schema_floor=derived,
+            unchecked_schemas=check.unchecked_schemas,
         )
 
     def rollback(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.63.0"
+version = "0.64.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/test_cli_db.py
+++ b/tests/test_cli_db.py
@@ -365,6 +365,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -456,6 +461,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -503,6 +513,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -533,6 +548,11 @@ class TestDbRestore:
             restore_duration_seconds=45.3,
             migration_duration_seconds=12.7,
             total_duration_seconds=58.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). This case states no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -557,6 +577,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -629,6 +654,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -660,6 +690,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -693,6 +728,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -724,6 +764,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),
@@ -758,6 +803,11 @@ class TestDbRestore:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit: a bare MagicMock auto-creates this as a truthy mock
+            # and `db restore` branches on it to report the archive-derived
+            # schema floor (#343). These cases state no floor.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch("fraisier.dbops.guard.is_external_db", return_value=False),

--- a/tests/test_cli_trigger_deploy.py
+++ b/tests/test_cli_trigger_deploy.py
@@ -332,3 +332,142 @@ class TestTriggerDeployEstimate:
         assert result.exit_code == 0, result.output
         assert "Deployment triggered successfully" in result.output
         mock_sock.sendall.assert_called_once()
+
+
+class TestTriggerDeployWaitOutcomeIsKnown:
+    """--wait must not report success for an outcome it never received.
+
+    A deploy unit whose socket is restarted under it dies without writing a
+    result (#349). The connection then closes empty, which is indistinguishable
+    from fire-and-forget unless --wait treats "no result" as a failure — the
+    gap that let a nightly staging restore skip while systemd recorded
+    ExecMainStatus=0.
+    """
+
+    @staticmethod
+    def _wire(mock_get_config, mock_path_class, mock_socket_class):
+        """Set up config, socket path and socket mocks; return the socket mock."""
+        config = MagicMock()
+        config.project_name = "myproject"
+        config.get_fraise_environment.return_value = {"type": "api"}
+        mock_get_config.return_value = config
+
+        mock_path = MagicMock()
+        mock_path_class.return_value = mock_path
+        mock_socket_path = MagicMock()
+        mock_path.__truediv__.return_value = mock_socket_path
+        mock_socket_path.__str__.return_value = (
+            "/run/fraisier/myproject-prod/deploy.sock"
+        )
+
+        mock_sock = MagicMock()
+        mock_socket_class.return_value = mock_sock
+        mock_sock.connect.return_value = None
+        mock_sock.sendall.return_value = None
+        mock_sock.shutdown.return_value = None
+        return mock_sock
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_wait_fails_when_no_result_arrives(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """An empty response under --wait exits non-zero, not 'triggered'."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        mock_sock.recv.return_value = b""
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--wait"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "no result" in result.output
+        assert "triggered successfully" not in result.output
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_wait_fails_on_unparseable_result(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """Garbage on the wire is an unknown outcome, so it exits non-zero."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        mock_sock.recv.side_effect = [b"not json at all", b""]
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--wait"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "triggered successfully" not in result.output
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_wait_reports_a_failed_deployment(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """A result saying success=False still exits non-zero."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        payload = json.dumps({"success": False, "error": "migrations failed"}).encode()
+        mock_sock.recv.side_effect = [payload, b""]
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--wait"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "migrations failed" in result.output
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_wait_reports_a_successful_deployment(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """The success path is untouched: a real result still exits 0."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        payload = json.dumps(
+            {"success": True, "message": "done", "version": "abc123", "duration": 4.2}
+        ).encode()
+        mock_sock.recv.side_effect = [payload, b""]
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--wait"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Deployment successful" in result.output
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_without_wait_an_empty_response_is_still_fire_and_forget(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """Without --wait the caller never asked for an outcome, so this is 0."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        mock_sock.recv.return_value = b""
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Deployment triggered successfully" in result.output

--- a/tests/test_cli_trigger_deploy.py
+++ b/tests/test_cli_trigger_deploy.py
@@ -471,3 +471,31 @@ class TestTriggerDeployWaitOutcomeIsKnown:
 
         assert result.exit_code == 0, result.output
         assert "Deployment triggered successfully" in result.output
+
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_empty_result_names_the_version_skew_remedy(
+        self, mock_get_config, mock_path_class, mock_socket_class
+    ):
+        """The CLI upgrades itself long before the units are re-rendered.
+
+        A deploy service older than v0.64.0 has no result channel at all, so
+        every `--wait` on that host exits 1 until it is reinstalled. Telling
+        the operator to retry would be telling them to wait forever; the
+        message has to name the reinstall and the command that finds every
+        affected unit.
+        """
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        mock_sock.recv.return_value = b""
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--wait"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "scaffold-install" in result.output
+        assert "doctor" in result.output

--- a/tests/test_cli_trigger_deploy.py
+++ b/tests/test_cli_trigger_deploy.py
@@ -162,7 +162,13 @@ class TestTriggerDeployWait:
     def test_trigger_deploy_follow_execs_journalctl(
         self, mock_get_config, mock_path_class, mock_socket_class, mock_execvp
     ):
-        """Test trigger-deploy --follow execs into journalctl."""
+        """Test trigger-deploy --follow execs into journalctl.
+
+        The result is supplied because `--follow` implies `--wait`: since #356
+        the logs are followed only once a real success has been reported. The
+        empty-response case is covered by
+        `TestFollowIsBoundByTheSameInvariant`, where it exits 1 instead.
+        """
         runner = CliRunner()
 
         # Mock config
@@ -180,13 +186,16 @@ class TestTriggerDeployWait:
             "/run/fraisier/myproject-prod/deploy.sock"
         )
 
-        # Mock socket — recv must return empty bytes to break the read loop
+        # Mock socket — a successful result, then empty bytes to break the loop
         mock_sock = MagicMock()
         mock_socket_class.return_value = mock_sock
         mock_sock.connect.return_value = None
         mock_sock.sendall.return_value = None
         mock_sock.shutdown.return_value = None
-        mock_sock.recv.return_value = b""
+        mock_sock.recv.side_effect = [
+            json.dumps({"success": True, "message": "done"}).encode(),
+            b"",
+        ]
 
         runner.invoke(
             main,
@@ -499,3 +508,93 @@ class TestTriggerDeployWaitOutcomeIsKnown:
         assert result.exit_code == 1, result.output
         assert "scaffold-install" in result.output
         assert "doctor" in result.output
+
+
+class TestFollowIsBoundByTheSameInvariant:
+    """`--follow` implies `--wait`, so it is a caller that asked for an outcome.
+
+    It drained the result off the socket and then discarded it: the exec into
+    journalctl happened before the result was looked at, so the process exited
+    with journalctl's status, which says nothing about the deploy. A flag that
+    implies `--wait` and then ignores the invariant is the next issue in this
+    series.
+    """
+
+    @staticmethod
+    def _wire(mock_get_config, mock_path_class, mock_socket_class):
+        return TestTriggerDeployWaitOutcomeIsKnown._wire(
+            mock_get_config, mock_path_class, mock_socket_class
+        )
+
+    @patch("fraisier.cli._deploy.os.execvp")
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_follow_does_not_tail_logs_for_a_failed_deployment(
+        self, mock_get_config, mock_path_class, mock_socket_class, mock_execvp
+    ):
+        """A failed deploy exits 1 rather than handing the shell to journalctl."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        payload = json.dumps({"success": False, "error": "migrations failed"}).encode()
+        mock_sock.recv.side_effect = [payload, b""]
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--follow"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "migrations failed" in result.output
+        mock_execvp.assert_not_called()
+
+    @patch("fraisier.cli._deploy.os.execvp")
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_follow_does_not_tail_logs_when_no_result_arrives(
+        self, mock_get_config, mock_path_class, mock_socket_class, mock_execvp
+    ):
+        """An unknown outcome under --follow is still an unknown outcome."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        mock_sock.recv.return_value = b""
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--follow"],
+            obj={"skip_health": False},
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "triggered successfully" not in result.output
+        mock_execvp.assert_not_called()
+
+    @patch("fraisier.cli._deploy.os.execvp")
+    @patch("socket.socket")
+    @patch("fraisier.cli._deploy.Path")
+    @patch("fraisier.cli.main.get_config")
+    def test_follow_reports_the_outcome_then_tails_the_logs(
+        self, mock_get_config, mock_path_class, mock_socket_class, mock_execvp
+    ):
+        """On success the summary is printed first — exec would erase it."""
+        runner = CliRunner()
+        mock_sock = self._wire(mock_get_config, mock_path_class, mock_socket_class)
+        payload = json.dumps(
+            {"success": True, "message": "done", "version": "abc123", "duration": 4.2}
+        ).encode()
+        mock_sock.recv.side_effect = [payload, b""]
+
+        result = runner.invoke(
+            main,
+            ["trigger-deploy", "api", "prod", "--follow"],
+            obj={"skip_health": False},
+        )
+
+        assert "Deployment successful" in result.output
+        mock_execvp.assert_called_once()
+        argv = mock_execvp.call_args[0][1]
+        assert argv[:2] == ["journalctl", "-u"]
+        assert argv[2] == "fraisier-api-prod@*.service"
+        assert argv[3] == "-f"

--- a/tests/test_dbops_archive.py
+++ b/tests/test_dbops_archive.py
@@ -215,3 +215,115 @@ class TestVerifyArchiveCommand:
             )
             check = verify_archive(str(dump))
         assert check.verdict is ArchiveVerdict.VALID
+
+
+#: A faithful `pg_restore --list` table of contents: header comments, a SCHEMA
+#: entry whose schema field is `-`, base tables in two schemas, a matview (whose
+#: data tag is MATERIALIZED VIEW DATA, not TABLE DATA), a view (no data entry at
+#: all), and a quoted table name that *contains* the words TABLE DATA.
+_TOC = """;
+; Archive created at 2026-08-09 02:00:00 UTC
+;     dbname: printoptim
+;     TOC Entries: 12
+;     Format: CUSTOM
+;     Dumped by pg_dump version: 16.3
+;
+;
+; Selected TOC Entries:
+;
+5; 2615 16385 SCHEMA - tenant postgres
+216; 1259 16456 TABLE tenant tb_order postgres
+217; 1259 16460 TABLE tenant tb_customer postgres
+218; 1259 16470 TABLE public flyway_schema_history postgres
+219; 1259 16480 VIEW public v_orders postgres
+220; 1259 16490 MATERIALIZED VIEW public mv_daily postgres
+221; 1259 16495 TABLE public my TABLE DATA table postgres
+4102; 0 16456 TABLE DATA tenant tb_order postgres
+4103; 0 16460 TABLE DATA tenant tb_customer postgres
+4104; 0 16470 TABLE DATA public flyway_schema_history postgres
+4105; 0 16490 MATERIALIZED VIEW DATA public mv_daily postgres
+"""
+
+
+def _valid_with_toc(tmp_path: Path, toc: str):
+    dump = tmp_path / "proddb_full.dump"
+    dump.write_bytes(_PGDUMP_MAGIC + b"\x00" * 64)
+    with patch("fraisier.dbops.archive.subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=toc, stderr=""
+        )
+        return verify_archive(dump)
+
+
+class TestTheArchiveStatesItsSchemaFloor:
+    """The TOC is already in `result.stdout` and was being thrown away (#343).
+
+    Counting it costs one pass over a string held in memory; no second
+    `pg_restore` invocation is needed.
+    """
+
+    def test_table_data_is_counted_per_schema(self, tmp_path: Path):
+        check = _valid_with_toc(tmp_path, _TOC)
+
+        assert check.verdict is ArchiveVerdict.VALID
+        assert check.table_data_by_schema == {"tenant": 2, "public": 1}
+
+    def test_schemas_are_never_summed(self, tmp_path: Path):
+        """A whole-TOC floor against a single schema's count false-fails.
+
+        #356's own host keeps its heaps in `tenant`; a floor of 3 derived from
+        the whole TOC and compared against `public` would fail a perfect
+        restore.
+        """
+        check = _valid_with_toc(tmp_path, _TOC)
+
+        assert sum(check.table_data_by_schema.values()) == 3
+        assert check.table_data_by_schema["tenant"] == 2
+        assert check.table_data_by_schema["public"] == 1
+
+    def test_matview_data_is_not_table_data(self, tmp_path: Path):
+        """pg_dump emits MATERIALIZED VIEW DATA for matviews, and it is not it."""
+        check = _valid_with_toc(tmp_path, _TOC)
+
+        assert check.table_data_by_schema.get("public") == 1
+
+    def test_the_tag_is_read_positionally_not_by_substring(self, tmp_path: Path):
+        """A table *named* `my TABLE DATA table` must not count as an entry.
+
+        `"TABLE DATA" in line` counts it; reading the tag field positionally
+        does not. Header and comment lines share the same stream.
+        """
+        one_liner = "221; 1259 16495 TABLE public my TABLE DATA table postgres\n"
+        check = _valid_with_toc(tmp_path, one_liner)
+
+        assert check.table_data_by_schema == {}
+
+    def test_a_schema_only_dump_has_no_floor_to_state(self, tmp_path: Path):
+        """`--schema-only` produces zero TABLE DATA entries — a VALID archive."""
+        schema_only = (
+            ";\n; Selected TOC Entries:\n;\n"
+            "216; 1259 16456 TABLE tenant tb_order postgres\n"
+        )
+        check = _valid_with_toc(tmp_path, schema_only)
+
+        assert check.verdict is ArchiveVerdict.VALID
+        assert check.table_data_by_schema == {}
+
+    def test_an_unverifiable_archive_states_no_counts(self, tmp_path: Path):
+        """Absence of a tool is not a floor of zero."""
+        check = verify_archive(tmp_path / "gone.dump")
+
+        assert check.verdict is ArchiveVerdict.UNVERIFIABLE
+        assert check.table_data_by_schema == {}
+
+    def test_an_invalid_archive_states_no_counts(self, tmp_path: Path):
+        dump = tmp_path / "truncated.dump"
+        dump.write_bytes(_PGDUMP_MAGIC + b"\x00" * 8)
+        with patch("fraisier.dbops.archive.subprocess.run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="unexpected end of file"
+            )
+            check = verify_archive(dump)
+
+        assert check.verdict is ArchiveVerdict.INVALID
+        assert check.table_data_by_schema == {}

--- a/tests/test_deploy_daemon_result_channel.py
+++ b/tests/test_deploy_daemon_result_channel.py
@@ -224,3 +224,124 @@ class TestEveryErrorPathReportsItsReason:
         payload = json.loads(wire.decode("utf-8"))
         assert payload["success"] is False
         assert "git fetch: host key mismatch" in payload["error"]
+
+
+class TestADepartedPeerCannotChangeTheOutcome:
+    """`deploy-checker.service.j2:24` runs trigger-deploy with no ``--wait``.
+
+    That client sends, shuts down its write half, skips the recv loop and
+    closes — in milliseconds. Half an hour later the daemon writes its result
+    to a socket whose peer is long gone. Unhandled, the `BrokenPipeError` would
+    raise *after* a successful deployment and take the unit's exit code with
+    it, inverting the very bug this phase fixes.
+
+    Each test asserts the note, which is only printed from the `except OSError`
+    branch — so a guard that stopped being exercised fails the test rather than
+    passing it quietly.
+    """
+
+    def test_success_survives_a_peer_that_already_left(self) -> None:
+        with accepted_connection() as client:
+            client.close()  # what every deploy-checker fire does
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result()
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+
+        assert run.exit_code == 0, run.output
+        assert "no client received the result" in run.output
+        assert run.exception is None or isinstance(run.exception, SystemExit)
+
+    def test_failure_still_exits_one_when_the_peer_already_left(self) -> None:
+        """The exit code is the deployment's, in both directions."""
+        with accepted_connection() as client:
+            client.close()
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result(
+                    success=False, status="failed", error_message="migration failed"
+                )
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+
+        assert run.exit_code == 1
+        assert "no client received the result" in run.output
+
+    def test_a_closed_fd_zero_is_not_an_error(self) -> None:
+        """`os.fstat(0)` raises EBADF rather than reporting "not a socket"."""
+        saved_stdin = os.dup(0)
+        try:
+            os.close(0)
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result()
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+        finally:
+            os.dup2(saved_stdin, 0)
+            os.close(saved_stdin)
+
+        assert run.exit_code == 0, run.output
+
+
+class TestThePipeFormIsUntouched:
+    """`echo '{…}' | fraisier deploy-daemon --project=api` is documented.
+
+    fd 0 there is a pipe, not a socket, so the result keeps going to stdout —
+    which is also what keeps `StandardOutput=journal` carrying the record it
+    has always carried under socket activation.
+    """
+
+    def test_result_json_still_goes_to_stdout(self) -> None:
+        with patch("fraisier.daemon.execute_deployment_request") as execute:
+            execute.return_value = deployment_result()
+            run = CliRunner().invoke(
+                main, ["deploy-daemon", "--project", "api"], input=REQUEST
+            )
+
+        assert run.exit_code == 0
+        json_lines = [
+            line for line in run.output.splitlines() if line.strip().startswith("{")
+        ]
+        assert len(json_lines) == 1, run.output
+        payload = json.loads(json_lines[0])
+        assert payload["success"] is True
+        assert payload["version"] == "abc123"
+
+    def test_journal_prose_is_unchanged(self) -> None:
+        """The human lines the journal has always shown, still shown."""
+        with patch("fraisier.daemon.execute_deployment_request") as execute:
+            execute.return_value = deployment_result()
+            run = CliRunner().invoke(
+                main, ["deploy-daemon", "--project", "api"], input=REQUEST
+            )
+
+        assert "Deployment successful - Deployment completed" in run.output
+        assert "Version: abc123" in run.output
+
+
+class TestAnOlderClientStillParsesTheResult:
+    """v0.63.0 guards the result path with `elif wait and response_data:`.
+
+    A 0.63.0 CLI against a v0.64.0 daemon is the safe direction of the skew:
+    the guard it already has now sees a non-empty response and parses it. This
+    replays that guard's shape rather than installing 0.63.0.
+    """
+
+    def test_the_old_guard_shape_reads_the_new_payload(self) -> None:
+        with accepted_connection() as client:
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result()
+                CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+            response_data = read_result(client)
+
+        wait = True
+        assert wait and response_data  # the v0.63.0 guard, verbatim
+        result = json.loads(response_data.decode("utf-8"))
+        assert result["success"] is True
+        assert result.get("message") == "Deployment completed"
+        assert result.get("version") == "abc123"
+        assert result.get("duration") == 45.5

--- a/tests/test_deploy_daemon_result_channel.py
+++ b/tests/test_deploy_daemon_result_channel.py
@@ -145,3 +145,82 @@ class TestOutcomeReachesTheConnection:
         text = wire.decode("utf-8")
         _, consumed = json.JSONDecoder().raw_decode(text)
         assert text[consumed:].strip() == "", f"trailing bytes on the wire: {text!r}"
+
+
+class TestEveryErrorPathReportsItsReason:
+    """The five paths that terminate before a deployment result exists.
+
+    Each used to print prose to the journal and exit 1 having written nothing
+    machine-readable at all. #356 attributed the empty response to #349 killing
+    the unit; #349 was one trigger out of six, and these five are ordinary
+    control flow rather than races.
+    """
+
+    def test_empty_stdin_says_so_on_the_wire(self) -> None:
+        with accepted_connection() as client:
+            run = CliRunner().invoke(
+                main, ["deploy-daemon", "--project", "api"], input=""
+            )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert payload["error"] == "No input received on stdin"
+
+    def test_undecodable_stdin_says_so_on_the_wire(self) -> None:
+        """A client writing non-UTF-8 makes ``sys.stdin.read()`` itself raise."""
+        with accepted_connection() as client:
+            run = CliRunner().invoke(
+                main, ["deploy-daemon", "--project", "api"], input=b"\xff\xfe\x00binary"
+            )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert payload["error"].startswith("Error reading stdin:")
+
+    def test_unparseable_request_says_so_on_the_wire(self) -> None:
+        with accepted_connection() as client:
+            run = CliRunner().invoke(
+                main, ["deploy-daemon", "--project", "api"], input="not-valid-json"
+            )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert payload["error"].startswith("Error parsing request:")
+
+    def test_project_mismatch_says_which_projects_on_the_wire(self) -> None:
+        mismatched = json.loads(REQUEST)
+        mismatched["project"] = "other"
+
+        with accepted_connection() as client:
+            run = CliRunner().invoke(
+                main,
+                ["deploy-daemon", "--project", "api"],
+                input=json.dumps(mismatched),
+            )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert "requested 'other'" in payload["error"]
+        assert "configured for 'api'" in payload["error"]
+
+    def test_execution_raising_says_so_on_the_wire(self) -> None:
+        with accepted_connection() as client:
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.side_effect = RuntimeError("git fetch: host key mismatch")
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert "git fetch: host key mismatch" in payload["error"]

--- a/tests/test_deploy_daemon_result_channel.py
+++ b/tests/test_deploy_daemon_result_channel.py
@@ -285,6 +285,25 @@ class TestADepartedPeerCannotChangeTheOutcome:
         assert run.exit_code == 0, run.output
 
 
+class TestTheWriteDoesNotStealFdZero:
+    """`socket.socket(fileno=0)` *owns* fd 0 and closes it when collected.
+
+    Built early and dropped, that closes stdin out from under a running
+    deployment. `os.dup(0)` gives the socket object an fd of its own to close.
+    """
+
+    def test_fd_zero_is_still_open_after_the_result_is_written(self) -> None:
+        import gc
+
+        from fraisier.cli._deploy import _write_to_accepted_connection
+
+        with accepted_connection() as client:
+            _write_to_accepted_connection('{"success": true}')
+            gc.collect()
+            os.fstat(0)  # OSError(EBADF) here means fd 0 was taken and closed
+            assert client.recv(65536) == b'{"success": true}'
+
+
 class TestThePipeFormIsUntouched:
     """`echo '{…}' | fraisier deploy-daemon --project=api` is documented.
 

--- a/tests/test_deploy_daemon_result_channel.py
+++ b/tests/test_deploy_daemon_result_channel.py
@@ -1,0 +1,147 @@
+"""The daemon's JSON result reaches the client that asked for it (#356).
+
+``deploy-service.j2`` sets ``StandardInput=socket`` under a socket unit with
+``Accept=yes``, so fd 0 *is* the accepted connection. It also sets
+``StandardOutput=journal``, so the ``print()`` that carried the machine-readable
+result sent it to the journal instead — never to the client. Every ``--wait``
+run in this project's history therefore read an empty response.
+
+These tests drive a real ``socketpair`` on fd 0 rather than mocking the write:
+what the daemon puts on the wire is the whole subject.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from fraisier.cli.main import main
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+REQUEST = json.dumps(
+    {
+        "version": 1,
+        "project": "api",
+        "environment": "staging",
+        "branch": "main",
+        "timestamp": "2026-08-09T02:00:00Z",
+        "triggered_by": "cli",
+        "options": {"force": False, "no_cache": False, "dry_run": False},
+        "metadata": {"cli_user": "deploy"},
+    }
+)
+
+
+@contextmanager
+def accepted_connection() -> Iterator[socket.socket]:
+    """Put a real AF_UNIX stream socket on fd 0, as systemd's Accept=yes does.
+
+    Yields the client end — the side ``trigger-deploy`` holds. fd 0 is restored
+    unconditionally on the way out, so a failing test cannot poison the ones
+    after it.
+    """
+    server, client = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+    saved_stdin = os.dup(0)
+    try:
+        os.dup2(server.fileno(), 0)
+        yield client
+    finally:
+        os.dup2(saved_stdin, 0)
+        os.close(saved_stdin)
+        server.close()
+        client.close()
+
+
+def read_result(client: socket.socket) -> bytes:
+    """Read what the daemon wrote, without waiting for a close it may not do.
+
+    The daemon writes synchronously before exiting, so by the time
+    ``CliRunner.invoke`` has returned the bytes are already in the buffer. A
+    short timeout keeps an empty channel from hanging the suite for minutes.
+    """
+    client.settimeout(2)
+    try:
+        return client.recv(65536)
+    except TimeoutError:
+        return b""
+
+
+def deployment_result(**overrides: object) -> MagicMock:
+    """A DeploymentResult stand-in whose attributes are JSON-serialisable."""
+    result = MagicMock()
+    result.success = True
+    result.status = "success"
+    result.message = "Deployment completed"
+    result.deployed_version = "abc123"
+    result.duration_seconds = 45.5
+    result.error_message = None
+    for name, value in overrides.items():
+        setattr(result, name, value)
+    return result
+
+
+class TestOutcomeReachesTheConnection:
+    """The two terminating paths at the end of deploy_daemon."""
+
+    def test_successful_deployment_writes_its_result_to_the_socket(self) -> None:
+        with accepted_connection() as client:
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result()
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+            wire = read_result(client)
+
+        assert run.exit_code == 0
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is True
+        assert payload["status"] == "success"
+        assert payload["version"] == "abc123"
+        assert payload["duration"] == 45.5
+
+    def test_failed_deployment_writes_its_result_to_the_socket(self) -> None:
+        with accepted_connection() as client:
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result(
+                    success=False,
+                    status="failed",
+                    message=None,
+                    deployed_version=None,
+                    error_message="migration failed",
+                )
+                run = CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+            wire = read_result(client)
+
+        assert run.exit_code == 1
+        payload = json.loads(wire.decode("utf-8"))
+        assert payload["success"] is False
+        assert payload["error"] == "migration failed"
+
+    def test_exactly_one_json_object_is_written(self) -> None:
+        """One result per connection — a second would break the client's parse.
+
+        The client reads the whole stream and hands it to ``json.loads``, which
+        rejects two concatenated objects. ``raw_decode`` is what distinguishes
+        "one object" from "one object followed by more".
+        """
+        with accepted_connection() as client:
+            with patch("fraisier.daemon.execute_deployment_request") as execute:
+                execute.return_value = deployment_result()
+                CliRunner().invoke(
+                    main, ["deploy-daemon", "--project", "api"], input=REQUEST
+                )
+            wire = read_result(client)
+
+        text = wire.decode("utf-8")
+        _, consumed = json.JSONDecoder().raw_decode(text)
+        assert text[consumed:].strip() == "", f"trailing bytes on the wire: {text!r}"

--- a/tests/test_doctor_deploy_result_channel.py
+++ b/tests/test_doctor_deploy_result_channel.py
@@ -1,0 +1,174 @@
+"""Can each installed deploy service actually answer a `--wait` client? (#356)
+
+Phase 1 gave `deploy_daemon` a result channel, and Phase 2 made `--wait` exit 1
+when no result arrives. Together those turn a host whose deploy unit still runs
+a pre-v0.64.0 fraisier into a host where every `--wait` deploy fails — and that
+is the *normal* upgrade order, not an edge case: the CLI replaces itself via
+self-upgrade while the deploy unit's binary only changes when someone re-runs a
+scaffold install.
+
+The unit file itself is unchanged by the fix (the result goes to fd 0, which
+`StandardInput=socket` already provided), so the discriminator is the version of
+the fraisier binary the installed unit names in `ExecStart=`. This check reads
+the installed unit and asks that binary.
+"""
+
+from __future__ import annotations
+
+import stat
+
+import pytest
+
+from fraisier.doctor import DOCTOR_CHECKS
+
+DEPLOY_UNIT = "fraisier-api-staging@.service"
+
+
+@pytest.fixture
+def unit_dir(tmp_path, monkeypatch):
+    d = tmp_path / "systemd"
+    d.mkdir()
+    monkeypatch.setattr("fraisier.doctor.SYSTEMD_UNIT_DIR", d)
+    return d
+
+
+@pytest.fixture
+def bindir(tmp_path):
+    d = tmp_path / "bin"
+    d.mkdir()
+    return d
+
+
+def _fraisier_reporting(bindir, version, *, name="fraisier"):
+    """A stand-in binary that answers `--version` the way fraisier does."""
+    p = bindir / name
+    p.write_text(f"#!/bin/sh\necho 'fraisier, version {version}'\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    return p
+
+
+def _fraisier_refusing(bindir, *, name="fraisier"):
+    """A binary that is there but will not say what it is."""
+    p = bindir / name
+    p.write_text("#!/bin/sh\necho 'boom' >&2\nexit 1\n")
+    p.chmod(p.stat().st_mode | stat.S_IXUSR)
+    return p
+
+
+def _deploy_unit(unit_dir, binary, *, name=DEPLOY_UNIT, project="api"):
+    (unit_dir / name).write_text(
+        "[Unit]\nDescription=Fraisier Deploy Service\n\n"
+        "[Service]\nType=simple\n"
+        f"ExecStart={binary} deploy-daemon --project={project}\n"
+        "StandardInput=socket\nStandardOutput=journal\n"
+    )
+
+
+def _run(config=None):
+    return DOCTOR_CHECKS["deploy_result_channel"].fn(config)
+
+
+class TestAnOldDeployUnitIsFound:
+    def test_a_pre_v0_64_binary_cannot_answer(self, unit_dir, bindir):
+        _deploy_unit(unit_dir, _fraisier_reporting(bindir, "0.63.0"))
+
+        result = _run()
+
+        assert result.status == "fail"
+        assert DEPLOY_UNIT in result.detail
+        assert "0.63.0" in result.detail
+        assert result.fix_hint is not None
+        assert "scaffold-install" in result.fix_hint
+
+    def test_a_v0_64_binary_can_answer(self, unit_dir, bindir):
+        _deploy_unit(unit_dir, _fraisier_reporting(bindir, "0.64.0"))
+
+        result = _run()
+
+        assert result.status == "pass"
+
+    def test_a_later_binary_can_answer(self, unit_dir, bindir):
+        _deploy_unit(unit_dir, _fraisier_reporting(bindir, "1.2.3"))
+
+        result = _run()
+
+        assert result.status == "pass"
+
+
+class TestItReportsPerFraiseAndEnvironment:
+    """v0.59.0's scoping: the unit name is the (fraise, environment) identity."""
+
+    def test_only_the_stale_unit_is_named(self, unit_dir, bindir):
+        old = _fraisier_reporting(bindir, "0.61.0", name="fraisier-old")
+        new = _fraisier_reporting(bindir, "0.64.0", name="fraisier-new")
+        _deploy_unit(unit_dir, old, name="fraisier-api-staging@.service")
+        _deploy_unit(unit_dir, new, name="fraisier-api-production@.service")
+
+        result = _run()
+
+        assert result.status == "fail"
+        assert "fraisier-api-staging@.service" in result.detail
+        assert "fraisier-api-production@.service" not in result.detail
+
+
+class TestUnverifiableIsNotBad:
+    """`ArchiveCheck`'s three-valued precedent: cannot-read is not broken."""
+
+    def test_a_binary_that_will_not_report_its_version_is_a_warning(
+        self, unit_dir, bindir
+    ):
+        _deploy_unit(unit_dir, _fraisier_refusing(bindir))
+
+        result = _run()
+
+        assert result.status == "warn"
+        assert result.status != "fail"
+
+    def test_a_missing_binary_is_a_warning(self, unit_dir, bindir):
+        _deploy_unit(unit_dir, bindir / "not-installed")
+
+        result = _run()
+
+        assert result.status == "warn"
+
+    def test_an_unreadable_unit_directory_is_skipped(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("fraisier.doctor.SYSTEMD_UNIT_DIR", tmp_path / "nope")
+
+        result = _run()
+
+        assert result.status == "skip"
+
+
+class TestAScanThatMatchedNothingIsNotAPass:
+    """A tree-scanner that silently matches nothing looks exactly like a pass.
+
+    That mistake has cost this project four times, so it is pinned rather than
+    trusted: the check must be *able* to fail, and must say so when it had
+    nothing to look at.
+    """
+
+    def test_no_deploy_units_installed_is_skip_not_pass(self, unit_dir, bindir):
+        binary = _fraisier_reporting(bindir, "0.63.0")
+        # A webhook unit names a fraisier binary but is not a deploy service:
+        # if it were counted, this stale binary would produce a false failure.
+        (unit_dir / "fraisier-proj-webhook.service").write_text(
+            f"[Service]\nExecStart={binary} webhook-server\n"
+        )
+
+        result = _run()
+
+        assert result.status == "skip"
+        assert result.status not in {"pass", "fail"}
+
+    def test_an_empty_unit_directory_is_skip_not_pass(self, unit_dir):
+        result = _run()
+
+        assert result.status == "skip"
+
+    def test_the_check_can_fail_on_the_same_tree_that_passes(self, unit_dir, bindir):
+        """Same scanner, same tree shape, opposite verdicts — so it is looking."""
+        _deploy_unit(unit_dir, _fraisier_reporting(bindir, "0.64.0", name="new"))
+        assert _run().status == "pass"
+
+        _deploy_unit(unit_dir, _fraisier_reporting(bindir, "0.63.0", name="old"))
+        assert _run().status == "fail"

--- a/tests/test_doctor_deploy_result_channel.py
+++ b/tests/test_doctor_deploy_result_channel.py
@@ -1,11 +1,10 @@
 """Can each installed deploy service actually answer a `--wait` client? (#356)
 
-Phase 1 gave `deploy_daemon` a result channel, and Phase 2 made `--wait` exit 1
-when no result arrives. Together those turn a host whose deploy unit still runs
-a pre-v0.64.0 fraisier into a host where every `--wait` deploy fails — and that
-is the *normal* upgrade order, not an edge case: the CLI replaces itself via
-self-upgrade while the deploy unit's binary only changes when someone re-runs a
-scaffold install.
+v0.64.0 gave `deploy_daemon` a result channel and made `--wait` exit 1 when no
+result arrives. Together those turn a host whose deploy unit still runs an older
+fraisier into a host where every `--wait` deploy fails — and that is the *normal*
+upgrade order, not an edge case: the CLI replaces itself via self-upgrade while
+the deploy unit's binary only changes when someone re-runs a scaffold install.
 
 The unit file itself is unchanged by the fix (the result goes to fd 0, which
 `StandardInput=socket` already provided), so the discriminator is the version of

--- a/tests/test_restore_derived_schema_floor.py
+++ b/tests/test_restore_derived_schema_floor.py
@@ -349,3 +349,81 @@ class TestWhatWasCheckedIsStated:
 
         assert res.exit_code == 0, res.output
         assert "no table-count floor" in res.output.lower()
+
+
+class TestAShortfallFailsTheRestore:
+    """Report-only is what v0.61.0 already shipped, and it was not enough.
+
+    confiture's counter returns `success=False` when the count is under the
+    floor; `restore_backup` turns that into a failed `RestoreResult` and the
+    strategy raises. Pinned because "derive a floor and then warn about it" is
+    the shape this issue exists to stop.
+    """
+
+    def test_confitures_shortfall_becomes_a_restore_failure(self):
+        restorer = MagicMock()
+        restorer.return_value.restore.return_value = MagicMock(
+            success=False,
+            errors=["Table count 3 is below minimum 240 in schema 'tenant'"],
+        )
+        with patch("fraisier.dbops.restore.DatabaseRestorer", restorer):
+            result = restore_backup(
+                backup_path="/backup/production/db.dump",
+                db_name="staging_db",
+                connection_url=_ADMIN_URL,
+                min_tables=240,
+                min_tables_schema="tenant",
+            )
+
+        assert result.success is False
+        assert "below minimum 240" in result.error
+
+    def test_the_strategy_raises_rather_than_reporting_success(self):
+        from fraisier.errors import DatabaseError
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "fraisier.dbops.restore.find_latest_backup",
+                    return_value=Path("/backup/production/db.dump"),
+                )
+            )
+            stack.enter_context(
+                patch("fraisier.dbops.restore.validate_backup_age", return_value=True)
+            )
+            stack.enter_context(
+                patch(
+                    "fraisier.dbops.archive.verify_archive",
+                    return_value=ArchiveCheck(
+                        ArchiveVerdict.VALID, "", {"tenant": 240}
+                    ),
+                )
+            )
+            for target, value in (
+                ("fraisier.dbops.operations.drop_db", (0, "", "")),
+                ("fraisier.dbops.operations.create_db", (0, "", "")),
+                ("fraisier.dbops.operations.terminate_backends", None),
+            ):
+                stack.enter_context(patch(target, return_value=value))
+            stack.enter_context(
+                patch(
+                    "fraisier.dbops.restore.restore_backup",
+                    return_value=RestoreResult(
+                        success=False, error="Table count 3 is below minimum 240"
+                    ),
+                )
+            )
+            strategy = RestoreMigrateStrategy(
+                RestoreConfig(
+                    db_name="staging_db",
+                    backup_dir=Path("/backup/production"),
+                    preflight=PreflightConfig(enabled=False),
+                ),
+                admin_url=_ADMIN_URL,
+            )
+            try:
+                strategy.execute(Path("confiture.yaml"))
+            except DatabaseError as exc:
+                assert "below minimum 240" in str(exc)
+            else:
+                raise AssertionError("a schema shortfall must not report success")

--- a/tests/test_restore_derived_schema_floor.py
+++ b/tests/test_restore_derived_schema_floor.py
@@ -1,0 +1,232 @@
+"""The archive's own table of contents states the floor the restore must meet.
+
+`min_tables` defaults to `0`, and `restore.py`'s floor is `if cfg.min_tables >
+0`, so on a default configuration nothing counted anything: a restore that
+produced almost nothing exited 0 with a yellow note. v0.61.0 made that state
+*said* rather than enforced; this makes it enforced without asking an operator
+to invent a number.
+
+Two things this deliberately does not do:
+
+- It does not sum schemas. TOC entries span every schema in the archive while
+  the counter that verifies a restore takes one, so a whole-archive floor
+  compared against a single schema's count is a guaranteed false failure —
+  #356's own host keeps its heaps in `tenant`.
+- It does not prove the data arrived. A dump truncated inside its data section
+  restores a complete, empty schema and passes any count; `dbops/restore.py`
+  says so in its own docstring. That hole stays open.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fraisier.config.schema import PreflightConfig
+from fraisier.dbops.archive import ArchiveCheck, ArchiveVerdict
+from fraisier.dbops.confiture import MigrationResult
+from fraisier.dbops.restore import RestoreResult, restore_backup
+from fraisier.strategies import RestoreConfig, RestoreMigrateStrategy
+
+_ADMIN_URL = "postgresql://postgres@localhost:5432/postgres"
+
+
+def _restorer_returning_success():
+    restorer = MagicMock()
+    restorer.return_value.restore.return_value = MagicMock(
+        success=True,
+        errors=[],
+        matviews_deferred=None,
+        matviews_refreshed=0,
+        analyze_ran=False,
+    )
+    return restorer
+
+
+def _execute(check: ArchiveCheck, *, min_tables: int = 0):
+    """Drive the strategy to completion and hand back the restore_backup mock."""
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "fraisier.dbops.restore.find_latest_backup",
+                return_value=Path("/backup/production/db.dump"),
+            )
+        )
+        stack.enter_context(
+            patch("fraisier.dbops.restore.validate_backup_age", return_value=True)
+        )
+        stack.enter_context(
+            patch("fraisier.dbops.archive.verify_archive", return_value=check)
+        )
+        for target, value in (
+            ("fraisier.dbops.operations.drop_db", (0, "", "")),
+            ("fraisier.dbops.operations.create_db", (0, "", "")),
+            ("fraisier.dbops.operations.terminate_backends", None),
+        ):
+            stack.enter_context(patch(target, return_value=value))
+        restore = stack.enter_context(
+            patch(
+                "fraisier.dbops.restore.restore_backup",
+                return_value=RestoreResult(success=True, duration_seconds=0.1),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "fraisier.strategies._restore.migrate_up",
+                return_value=MigrationResult(success=True, steps_applied=0),
+            )
+        )
+        counted = stack.enter_context(
+            patch(
+                "fraisier.dbops.restore.validate_table_count", return_value=(True, 120)
+            )
+        )
+        strategy = RestoreMigrateStrategy(
+            RestoreConfig(
+                db_name="staging_db",
+                backup_dir=Path("/backup/production"),
+                preflight=PreflightConfig(enabled=False),
+                min_tables=min_tables,
+            ),
+            admin_url=_ADMIN_URL,
+        )
+        result = strategy.execute(Path("confiture.yaml"))
+    return restore, result, counted
+
+
+class TestTheArchivePicksItsPrincipalSchema:
+    def test_the_schema_carrying_the_most_table_data_is_the_one_enforced(self):
+        check = ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 1, "tenant": 240})
+
+        assert check.schema_floor == ("tenant", 240)
+
+    def test_the_other_schemas_are_named_unchecked_not_summed(self):
+        check = ArchiveCheck(
+            ArchiveVerdict.VALID, "", {"public": 1, "tenant": 240, "audit": 3}
+        )
+
+        assert check.schema_floor == ("tenant", 240)
+        assert check.unchecked_schemas == ("audit", "public")
+
+    def test_a_tie_is_broken_deterministically(self):
+        check = ArchiveCheck(ArchiveVerdict.VALID, "", {"beta": 7, "alpha": 7})
+
+        assert check.schema_floor == ("alpha", 7)
+
+    def test_a_schema_only_archive_states_no_floor(self):
+        check = ArchiveCheck(ArchiveVerdict.VALID, "", {})
+
+        assert check.schema_floor is None
+
+    def test_an_unverifiable_archive_states_no_floor(self):
+        check = ArchiveCheck(ArchiveVerdict.UNVERIFIABLE, "no pg_restore")
+
+        assert check.schema_floor is None
+
+
+class TestTheFloorReachesConfituresCounter:
+    """confiture counts `pg_class WHERE relkind='r'` in a parameterised schema.
+
+    That is apples-to-apples with `TABLE DATA`. fraisier's own counter
+    (`information_schema.tables`, schema hardcoded to `public`) counts views and
+    misses matviews, so it is wrong in both directions and is not used here.
+    """
+
+    def test_restore_backup_forwards_the_schema(self):
+        restorer = _restorer_returning_success()
+        with patch("fraisier.dbops.restore.DatabaseRestorer", restorer):
+            restore_backup(
+                backup_path="/backup/production/db.dump",
+                db_name="staging_db",
+                connection_url=_ADMIN_URL,
+                min_tables=240,
+                min_tables_schema="tenant",
+            )
+        options = restorer.return_value.restore.call_args[0][0]
+        assert options.min_tables == 240
+        assert options.min_tables_schema == "tenant"
+
+    def test_restore_backup_defaults_to_public(self):
+        restorer = _restorer_returning_success()
+        with patch("fraisier.dbops.restore.DatabaseRestorer", restorer):
+            restore_backup(
+                backup_path="/backup/production/db.dump",
+                db_name="staging_db",
+                connection_url=_ADMIN_URL,
+            )
+        options = restorer.return_value.restore.call_args[0][0]
+        assert options.min_tables_schema == "public"
+
+
+class TestTheStrategyDerivesAndForwards:
+    def test_the_derived_floor_and_schema_are_passed_through(self):
+        restore, _, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 1, "tenant": 240})
+        )
+
+        assert restore.call_args.kwargs["min_tables"] == 240
+        assert restore.call_args.kwargs["min_tables_schema"] == "tenant"
+
+    def test_the_floor_is_never_the_sum_of_the_schemas(self):
+        """241 against a `tenant`-only count is the false failure to avoid."""
+        restore, _, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 1, "tenant": 240})
+        )
+
+        assert restore.call_args.kwargs["min_tables"] != 241
+
+    def test_a_schema_only_archive_falls_back_to_the_configured_floor(self):
+        restore, _, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {}), min_tables=50
+        )
+
+        assert restore.call_args.kwargs["min_tables"] == 50
+        assert restore.call_args.kwargs["min_tables_schema"] == "public"
+
+    def test_an_unverifiable_archive_falls_back_to_the_configured_floor(self):
+        restore, _, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.UNVERIFIABLE, "no pg_restore"), min_tables=50
+        )
+
+        assert restore.call_args.kwargs["min_tables"] == 50
+
+    def test_an_unverifiable_archive_does_not_become_a_floor_of_zero_silently(self):
+        _, result, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.UNVERIFIABLE, "no pg_restore")
+        )
+
+        assert result.schema_floor is None
+
+    def test_the_result_carries_what_was_checked(self):
+        _, result, _counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 1, "tenant": 240})
+        )
+
+        assert result.schema_floor == ("tenant", 240)
+        assert result.unchecked_schemas == ("public",)
+
+
+class TestTheOperatorFloorKeepsItsOwnCheckpoint:
+    """`min_tables` is post-migration; the derived floor is pre-migration.
+
+    The two are not interchangeable: applied after migrations, an
+    archive-derived floor false-fails on any migration that drops or renames a
+    table. Applied before, an operator's floor cannot account for tables the
+    migrations create.
+    """
+
+    def test_a_configured_floor_still_runs_after_migrate_up(self):
+        _, _result, counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {"tenant": 240}), min_tables=50
+        )
+
+        assert counted.call_args.kwargs["min_threshold"] == 50
+
+    def test_the_derived_floor_does_not_become_the_post_migration_floor(self):
+        """240 tables in `tenant` must not be asserted against `public` later."""
+        _, _result, counted = _execute(
+            ArchiveCheck(ArchiveVerdict.VALID, "", {"tenant": 240})
+        )
+
+        assert counted.call_count == 0  # no operator floor configured

--- a/tests/test_restore_derived_schema_floor.py
+++ b/tests/test_restore_derived_schema_floor.py
@@ -230,3 +230,122 @@ class TestTheOperatorFloorKeepsItsOwnCheckpoint:
         )
 
         assert counted.call_count == 0  # no operator floor configured
+
+
+class TestWhatWasCheckedIsStated:
+    """A floor nobody can read is the same silence in a different place.
+
+    `fraisier` configures logging only under `-v`, and the generated timer unit
+    passes no flags, so an INFO line reaches neither the terminal nor the
+    journal. The declaration goes through the console, whose stdout systemd
+    captures.
+    """
+
+    @staticmethod
+    def _config(min_tables: int | None):
+        restore: dict = {
+            "backup_dir": "/backup/production",
+            "backup_pattern": "*.dump",
+            "max_age_hours": 48.0,
+        }
+        if min_tables is not None:
+            restore["min_tables"] = min_tables
+        config = MagicMock()
+        config.get_fraise.return_value = {"type": "api"}
+        config.get_fraise_environment.return_value = {
+            "type": "api",
+            "app_path": "/var/www/api",
+            "systemd_service": "api.staging.service",
+            "database": {
+                "name": "mydb_staging",
+                "strategy": "restore_migrate",
+                "admin_url": _ADMIN_URL,
+                "confiture_config": "confiture.yaml",
+                "restore": restore,
+            },
+        }
+        config._config = {"backup": {}}
+        config.deployment = MagicMock()
+        config.deployment.get_strategy.return_value = "restore_migrate"
+        config.list_fraises_detailed.return_value = []
+        return config
+
+    def _invoke(
+        self,
+        *,
+        min_tables: int | None = None,
+        schema_floor: tuple[str, int] | None = None,
+        unchecked_schemas: tuple[str, ...] = (),
+    ):
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        result_mock = MagicMock(
+            success=True,
+            migrations_applied=0,
+            total_duration_seconds=0.0,
+            restore_duration_seconds=0.0,
+            migration_duration_seconds=0.0,
+            schema_floor=schema_floor,
+            unchecked_schemas=unchecked_schemas,
+        )
+        with (
+            patch(
+                "fraisier.cli.main.get_config", return_value=self._config(min_tables)
+            ),
+            patch("fraisier.locking.deployment_lock", MagicMock()),
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch(
+                "fraisier.strategies.RestoreMigrateStrategy.execute",
+                return_value=result_mock,
+            ),
+            patch("fraisier.systemd.SystemdServiceManager"),
+            patch(
+                "fraisier.dbops.restore.find_latest_backup",
+                return_value="/backup/production/x.dump",
+            ),
+            patch("fraisier.dbops.restore.validate_backup_age"),
+            patch(
+                "fraisier.post_migrate.run_configured_post_migrate", return_value=None
+            ),
+        ):
+            return CliRunner().invoke(main, ["db", "restore", "api", "staging"])
+
+    def test_a_derived_floor_names_the_schema_and_the_count(self):
+        res = self._invoke(schema_floor=("tenant", 240))
+
+        assert res.exit_code == 0, res.output
+        assert "240" in res.output
+        assert "tenant" in res.output
+
+    def test_a_derived_floor_is_not_reported_as_unchecked(self):
+        res = self._invoke(schema_floor=("tenant", 240))
+
+        assert "not checked for emptiness" not in res.output.lower()
+
+    def test_the_schemas_outside_the_floor_are_named(self):
+        res = self._invoke(
+            schema_floor=("tenant", 240), unchecked_schemas=("audit", "public")
+        )
+
+        assert "audit" in res.output
+        assert "public" in res.output
+
+    def test_it_does_not_claim_the_data_was_checked(self):
+        """A truncated data section restores a complete, empty schema.
+
+        The repository's own docstring says a table count cannot catch that, so
+        the operator-facing line must not imply otherwise.
+        """
+        res = self._invoke(schema_floor=("tenant", 240))
+        lowered = res.output.lower()
+
+        assert "schema" in lowered
+        assert "not the data" in lowered or "not that the data" in lowered
+
+    def test_an_archive_stating_no_floor_still_says_nothing_was_checked(self):
+        res = self._invoke(schema_floor=None)
+
+        assert res.exit_code == 0, res.output
+        assert "no table-count floor" in res.output.lower()

--- a/tests/test_restore_min_tables_handoff.py
+++ b/tests/test_restore_min_tables_handoff.py
@@ -272,6 +272,12 @@ class TestTheCliSaysIt:
             total_duration_seconds=0.0,
             restore_duration_seconds=0.0,
             migration_duration_seconds=0.0,
+            # Explicit, because a bare MagicMock auto-creates this attribute as
+            # a truthy mock and the CLI branches on it (#343). These cases are
+            # "the archive stated no floor"; the derived-floor cases live in
+            # test_restore_derived_schema_floor.py.
+            schema_floor=None,
+            unchecked_schemas=(),
         )
         with (
             patch(

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -792,6 +792,11 @@ class TestRestoreMigrateStrategy:
             # and step 10 is `if cfg.min_tables > 0` over a default of 0, so
             # neither side checked. Both check now, at their own point.
             min_tables=300,
+            # This archive states no floor of its own (the verify_archive stub
+            # carries no TOC counts), so the operator's floor is what confiture
+            # gets, in confiture's own default schema. When an archive *does*
+            # state one, both values come from it instead — #343.
+            min_tables_schema="public",
         )
         mock_table.assert_called_once_with(
             "staging_db", min_threshold=300, connection_url=_ADMIN_URL

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.63.0"
+version = "0.64.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
`trigger-deploy --wait` printed `ok Deployment triggered successfully` and exited
0 in **7 seconds** for a nightly staging restore whose real runtime is ~33
minutes. The wrapping systemd unit recorded a clean exit. Staging silently stayed
a day stale, found only by comparing relation-file mtimes — row counts on a stale
database are correct.

The reported defect is the `--wait` guard, and it is real. Reading the source
turned up something larger: **the result channel has never existed.**
`deploy-service.j2` sets `StandardInput=socket` under an `Accept=yes` socket, so
fd 0 *is* the accepted client connection — and it also sets
`StandardOutput=journal`, so the `print()` carrying the machine-readable result
went to the journal instead. Those three lines have been unchanged since socket
activation shipped in April.

So the 7-second incident is not a race that produced an empty response. It is the
*only* response that transport could ever produce, observed on a run short enough
for someone to notice. Every `--wait` deploy in this project's history — success,
failure, crash — read an empty response and took the fire-and-forget branch.

Sixth instance of the v0.61.0–v0.63.0 heading, *work that could not fail visibly*.
The previous five destroyed or omitted the reporter; this one never connected it.
Hence the invariant rather than the site:

> **A caller that asked for an outcome receives one, or an error — never a report
> of an outcome that could not have arrived.**

## Order matters, and the commits enforce it

Making `--wait` refuse to invent an outcome is only an improvement once an
outcome can reach it. Shipped alone against today's units it would have turned
*every* `--wait` deploy — including the successful ones — into an exit 1. The
channel is connected first (phase 01), then `--wait` is made honest (phase 02),
then `doctor` learns to find hosts that still cannot answer (phase 03).

## What ships

- **The daemon's result reaches the connection that asked for it.** Written to
  the accepted socket on fd 0, and still to stdout, so the journal keeps the
  record it has always held and the documented `echo '{…}' | fraisier
  deploy-daemon` pipe form is untouched. `StandardOutput=journal` stays — it is
  deliberate (#72 Bug 2) and flipping it would put Rich-styled prose on the wire
  ahead of the JSON, trading an empty response for an unparseable one.
- **All seven terminating paths report, not two.** #356 attributed the empty
  response to #349 killing the unit; #349 was one trigger out of six, and the
  other five are ordinary control flow.
- **A departed peer cannot change the outcome.** `deploy-checker` fires without
  `--wait` and closes in milliseconds; unhandled, the resulting `BrokenPipeError`
  would raise *after* a successful deployment and take the unit's exit code with
  it — inverting the bug rather than fixing it.
- **`--wait` reports the outcome it received.** Empty → an error naming both
  causes and each remedy. Unparseable → an error, where it used to print a yellow
  warning and *then* the success line — the same lie in a quieter voice, since a
  warning is not an exit code. Without `--wait`, nothing changes.
- **`--follow` is bound by the same invariant** — outcome first, logs only for a
  deployment that succeeded.
- **A restore proves its schema arrived** (#343 half). `verify_archive` counts
  `TABLE DATA` entries **per schema** from `pg_restore --list` output it already
  held, and that count becomes the floor confiture enforces *before* migrations.
  A shortfall fails the restore. Closes a hole `min_tables` only *declared*: it
  defaults to `0` and the check is `if cfg.min_tables > 0`, so by default nothing
  counted anything.
- **`min_tables_schema` is forwarded to confiture.** It defaulted to `public`
  while the count can describe any schema — without this, the floor above would
  false-fail every perfect restore on a host whose heaps live elsewhere.
- **`doctor deploy_result_channel`** finds hosts that cannot answer. Three-valued
  following `ArchiveCheck`: `fail` for a stale binary, `warn` for one it could
  not interrogate — the deploy user's binary is routinely unreadable by whoever
  runs `doctor`, and "I could not ask" is not "this host is broken" — `skip` when
  there was nothing to look at.

## ⚠️ Upgrade impact — read before merging

Making `--wait` honest means **every host whose deploy unit still runs a
pre-0.64.0 fraisier will start FAILING `--wait` deploys** where it previously
succeeded falsely. That skew is the *normal* upgrade order: the CLI replaces
itself via self-upgrade while the deploy unit's binary changes only when someone
re-runs a scaffold install.

```bash
fraisier scaffold && sudo fraisier scaffold-install --yes
fraisier doctor        # deploy_result_channel lists every affected unit
```

Hosts that never pass `--wait` are unaffected.

## Issue disposition — deliberate

Closes #356.

**#343 stays OPEN, on purpose.** The restore work here shipped on its own merit —
the default floor of `0` is a real hole regardless of what #343's journals say —
and **not** as a diagnosis of that reporter's three runs. Which unit those runs
used is still unknown, and until their `systemctl cat` arrives the third-defect
question is unanswered. `Closes #A, #B` only closes `#A` in any case; the omission
here is intentional either way.

Two gaps found and deliberately left unfixed, now tracked:

- **#357** — `--follow` execs `journalctl` only after the recv loop has drained,
  i.e. after the deploy is over, so it follows nothing live. v0.64.0 fixed which
  exit code it reports; the timing is untouched.
- **#358** — a table-count floor cannot detect a dump truncated inside its data
  section: the schema restores complete and empty and any count passes. The
  archive-derived floor proves schema arrived, **not** data. Relation-file mtimes
  remain the only known check.

## Verification

- `uv run pytest` → **5217 passed, 7 skipped** (main's baseline: 5154/7)
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → 487 files, clean
- `uv run ty check` → exit 0, zero diagnostics

Not verifiable here, and requested of the owner separately: one live
`trigger-deploy --wait` against a real socket-activated host, confirming the
result now arrives while `StandardOutput=journal` still holds. Confirmation
rather than a gate — systemd.exec(5) plus POSIX already settle it.

**Merge with rebase, not squash** — release-PR precedent for this repo.
