### PR TITLE
release: v0.65.0 — counting harder cannot see a restore that never ran (#358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,22 @@ heap was written *this run*.
   drift. It needs no migration and no cleanup — the next restore's DROP+CREATE
   takes it with everything else.
 
+  The receipt also records **which schema the run derived its floor for**
+  (`floor_schema`). That is knowable at exactly one moment: `min_tables_schema`
+  comes off the archive's table of contents during the restore and is configured
+  nowhere, so a caller arriving the next morning has no archive and no key to
+  read it from. Recording it is what lets the mtime cross-check ask about
+  `tenant` on a host whose heaps are in `tenant`. NULL when the archive stated
+  no floor — the reader falls back to `public`, the writer does not invent.
+
+- **`database.restore.max_actuation_age_hours`** — how recently a restore must
+  have rewritten the database, defaulting to 26h. Deliberately *not*
+  `max_age_hours`, which answers a different question: how old the backup *file*
+  may be. A 48h tolerance is reasonable for an input and uselessly loose for an
+  outcome — on a nightly cadence it passes a staging database whose restore
+  stopped running yesterday, which is the exact failure the receipt exists to
+  catch. Two questions, two knobs.
+
 - **`fraisier db receipt <fraise> <env>`** asks a database when a restore last
   rewrote it. This is the half that actually catches the reported failure: the
   pipeline's own read-back runs inside the process that did the writing, which
@@ -92,12 +108,35 @@ heap was written *this run*.
   and the heap says last week" is something an operator wants told, not
   something the tool should settle silently.
 
+  It inspects the schema the receipt names, so `--heap-schema` is an override
+  rather than a thing the operator must remember. Defaulting it to `public` on
+  a host whose heaps are in `tenant` would find no base tables and return
+  UNVERIFIABLE — silence, precisely where the check is most wanted, and the same
+  `public`-vs-`tenant` mismatch v0.64.0 removed from the floor.
+
 ### Fixed
 
 - `_pg_cmd` accepts stdin, so `psql`'s `:'var'` binding is usable at all. `-c`
   hands its string to the server unread, so the variables were never
   substituted; only input psql lexes itself gets them. Found by a test that put
   a quote in a backup path.
+
+- **The tests carrying this release's guarantee did not run in CI.** The
+  integration harness discovered PostgreSQL over a unix socket only; every
+  workflow provides one as a service container over TCP with no socket shared
+  into the runner. So the fixture skipped, and the nine tests proving a
+  truncated dump fails the restore and the nine proving the receipt round-trips
+  through real SQL reported green without executing — a check that could not
+  fail visibly, one layer above the code this release is about. Discovery now
+  takes `FRAISIER_TEST_PG_URL` first and builds per-database DSNs over either
+  transport, and the discovery itself is pinned by unit tests that always run.
+
+- **The receipt write is one transaction.** Its script deletes the standing
+  receipt before inserting the new one; run as separate statements, a failure
+  between the two committed the delete and left the table present and empty —
+  which reads as `MISSING`, a database claiming no run has ever written it.
+  Worse than the truth, and now impossible: `psql -1`, with `ON_ERROR_STOP=1`
+  still deciding that a failure is a failure.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,109 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.0] - 2026-08-10
+
+**Counting harder cannot see a restore that never ran.**
+
+[#358](https://github.com/fraiseql/fraisier/issues/358) was filed against
+v0.64.0's schema floor with a correct observation — a dump truncated inside its
+data section restores a complete, empty schema, so no table-count floor of any
+derivation can see it — and reached for row counts as the answer. Before
+building that, we measured. The measurement changed the work.
+
+The issue conflates two failures:
+
+- **Partial data.** The schema arrived, the rows did not.
+- **Non-actuation.** The pipeline never ran; staging keeps yesterday's database.
+  Counts, floors and `pg_restore`'s exit are all *correct*, because nothing
+  about the content is wrong. It is only old.
+
+**Partial data turned out to already be caught, on both restore paths.** Against
+a real PostgreSQL, a `-Fc` dump cut at 50%, 90% and 98% fails the restore every
+time: `pg_restore` cannot read past the cut, writes a `pg_restore: error:` line
+and exits non-zero, and confiture fails the section. That holds for `jobs > 1`
+too, where `exit_on_error` is off — tolerating a non-zero *exit* is not the same
+as tolerating an *error line*. The premise still holds exactly as #358 states it
+(the table of contents parses, `verify_archive` returns VALID, the derived floor
+is satisfied by an empty schema); it is the restore, not the checks around it,
+that refuses. That is now pinned by a test rather than believed.
+
+So the row-count manifest #358 asks for was **not built**. It exists only to
+close the half that is already closed, it is the most expensive option on the
+table — a producer, a consumer, snapshot skew against `pg_dump`'s own snapshot,
+a tolerance band, and a three-valued case for every dump predating it — and it
+would not have caught the failure that was actually reported.
+
+**Non-actuation is the residual, and it is the #343 signature** ("success in 21s,
+staging a day stale"). It is unreachable by counting: the cure is evidence the
+heap was written *this run*.
+
+### Added
+
+- **A restore leaves a receipt proving it ran** (#358). The pipeline mints a
+  token per run and writes it, with the backup's path and size, into a
+  `fraisier.restore_receipt` table in the database it just restored — then reads
+  it straight back and compares. A round trip through the database, not a
+  variable the pipeline set and then trusted.
+
+  The token is the whole mechanism. A restore that never ran leaves the
+  *previous* run's receipt in place, so "a receipt exists" matches every time
+  and proves nothing; `verify_actuation` therefore refuses to answer without a
+  criterion — a run id, or a freshness window.
+
+  Four-valued, following `ArchiveCheck`: `ACTUATED` is the only proof, `STALE`
+  the only conviction, and `MISSING` (restored by hand, or by an older fraisier)
+  and `UNVERIFIABLE` (no `psql`, no connection) say nothing in either direction.
+  A receipt that could not be written **does not fail the restore** — it is
+  bookkeeping written after every real check has already passed, and it is
+  reported as *not verified*, never as verified.
+
+  The table lives in a dedicated `fraisier` schema, not `public`: both floors
+  guarding a restore count `relkind='r'` in one schema, so a bookkeeping table
+  in `public` would quietly raise them, and a schema comparison would read it as
+  drift. It needs no migration and no cleanup — the next restore's DROP+CREATE
+  takes it with everything else.
+
+- **`fraisier db receipt <fraise> <env>`** asks a database when a restore last
+  rewrote it. This is the half that actually catches the reported failure: the
+  pipeline's own read-back runs inside the process that did the writing, which
+  proves the write landed but cannot prove a run happened — when the run does
+  not happen, that code does not execute either. The durable row is what an
+  independent caller interrogates the next morning.
+
+  Three answers, three exit codes, so a monitoring timer can tell them apart:
+  `0` rewritten inside the window, `1` stale, and **`3` not checked**. Not `0`,
+  because a host that cannot check must not report what a host that checked and
+  passed reports — that is `min_tables=0`'s silent hole moved into monitoring.
+  Not `1`, because a missing `psql` should not page the way a stale staging
+  database does.
+
+- **`--check-heap`** reports relation-file mtimes, the check #358 names. Opt-in
+  and advisory: it needs superuser or `pg_read_server_files`, which managed
+  PostgreSQL commonly refuses, and autovacuum moves mtimes after a no-op — a
+  false *pass*, never a false fail. It corroborates the receipt and never moves
+  the exit code. When the two disagree both are printed; "the receipt says today
+  and the heap says last week" is something an operator wants told, not
+  something the tool should settle silently.
+
+### Fixed
+
+- `_pg_cmd` accepts stdin, so `psql`'s `:'var'` binding is usable at all. `-c`
+  hands its string to the server unread, so the variables were never
+  substituted; only input psql lexes itself gets them. Found by a test that put
+  a quote in a backup path.
+
+### Notes
+
+- **The docstrings that were wrong are corrected.** `dbops/restore.py` and
+  v0.64.0's CHANGELOG both said a truncated dump was an open hole. The floor
+  cannot see one — that part was right — but the restore fails on it anyway.
+- **The rollback template carries no receipt.** It is taken before `migrate up`
+  and the receipt is written after, so a database rolled back onto it reads
+  `MISSING`. That is correct: after a rollback it is not the state any completed
+  run produced, and `MISSING` says *not proven* rather than *stale*.
+- No confiture change and no version floor: the receipt is entirely fraisier's.
+
 ## [0.64.0] - 2026-08-10
 
 **An outcome nobody could receive.**
@@ -112,6 +215,11 @@ would have started failing outright.
   mtimes, which is how #356 was found, remain the check for stale-but-intact
   data. That hole stays open as
   [#358](https://github.com/fraiseql/fraisier/issues/358).
+
+  *Corrected in v0.65.0: the floor indeed cannot see a truncation, but the
+  restore fails on one regardless — `pg_restore` errors and exits non-zero, on
+  both the serial and parallel paths. The hole #358 really leaves open is a
+  restore that never ran, which v0.65.0 closes with an actuation receipt.*
 - **`doctor deploy_result_channel`** finds hosts that cannot answer (#356).
   Making `--wait` honest means every host whose deploy unit still runs a
   pre-v0.64.0 fraisier now fails `--wait` — and that skew is the *normal* upgrade

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ fraisier version bump patch|minor|major          Bump version number
 ```
 fraisier db migrate <fraise> -e <env>            Run migrations only
 fraisier db restore <fraise> -e <env>            Restore from backup (drains connections, force-drops on PG 13+)
+fraisier db receipt <fraise> <env>               When did a restore last rewrite this database? (0 fresh, 1 stale, 3 unknown)
 fraisier db reset <fraise> -e <env>              Reset database (development)
 fraisier backup <fraise> -e <env>                Create database backup
 fraisier backup prune --env <env>                Prune a corpus this host receives

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1224,6 +1224,23 @@ Stale: mydb_staging was last rewritten 31.2h ago by run 1a9b…, which is older
 than the 26.0h window
 ```
 
+The window has its own key, because it answers its own question:
+
+```yaml
+restore:
+  max_age_hours: 48                 # how old the backup *file* may be
+  max_actuation_age_hours: 26       # how long ago a restore must have run
+```
+
+They are not the same number and must not be shared. `max_age_hours` bounds an
+input: how stale an archive the restore is willing to load, where 48h is a
+comfortable tolerance. `max_actuation_age_hours` bounds an outcome: how long ago
+a restore last rewrote this database. On a nightly cadence, a 48h answer to that
+second question passes a staging database whose restore stopped running
+yesterday — the failure the receipt exists to catch. It defaults to 26h: a
+couple of hours of slack on a nightly, and no more. `--max-age-hours` overrides
+it for one run.
+
 The token matters more than the row. A restore that never ran leaves the
 *previous* run's receipt behind, so the mere presence of a receipt matches every
 time and proves nothing — the check is always against something: a run id, or a
@@ -1249,6 +1266,12 @@ because it needs superuser or `pg_read_server_files`, which managed PostgreSQL
 commonly refuses, and it never changes the exit code: autovacuum moves mtimes
 after a restore that did nothing, so it can pass a database the receipt
 correctly calls stale. When the two disagree, both are printed.
+
+It inspects one schema, never summed across schemas — the same rule the
+table-count floor follows. Which schema is not asked of the operator: the
+restore derived it from the archive's table of contents and recorded it in the
+receipt, so a host whose heaps live in `tenant` is checked against `tenant`.
+`--heap-schema` overrides it; a receipt naming none falls back to `public`.
 
 ---
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1194,7 +1194,61 @@ Restore complete: 4 migration(s) applied
 Set it if you know roughly how many tables the database should have. But do not
 mistake it for protection against a truncated dump: a dump truncated inside its
 *data* section restores its schema completely, so the tables all exist and are
-empty, and any count passes. The archive check above is what catches that.
+empty, and any count passes.
+
+What catches a truncated dump is `pg_restore` itself — it cannot read past the
+cut, so it errors and exits non-zero and the restore fails, on both the serial
+and the parallel path. The floor never sees it, and does not need to.
+
+#### The one thing no count can see: a restore that never ran
+
+A staging database nobody rewrote holds yesterday's data, and yesterday's data
+has entirely correct counts. That is the failure behind #343 and #356 — a
+nightly restore reporting success while staging silently stayed a day stale —
+and it is invisible to every check above, because nothing about the *content* is
+wrong. It is only old.
+
+So each restore leaves a receipt: a token minted for that run, written into the
+database it just restored along with the backup's path and size. The run reads
+it straight back; a later caller reads it whenever it wants to know:
+
+```
+$ fraisier db receipt api staging
+Actuated: mydb_staging was rewritten 2.4h ago by run 7f3c9e21…
+  From backup: /backup/production/db_full_20260810_lz4.dump
+```
+
+```
+$ fraisier db receipt api staging --max-age-hours 26
+Stale: mydb_staging was last rewritten 31.2h ago by run 1a9b…, which is older
+than the 26.0h window
+```
+
+The token matters more than the row. A restore that never ran leaves the
+*previous* run's receipt behind, so the mere presence of a receipt matches every
+time and proves nothing — the check is always against something: a run id, or a
+freshness window.
+
+Exit codes, so a monitoring timer can act on it:
+
+| code | meaning |
+|------|---------|
+| `0`  | a restore rewrote the database inside the window |
+| `1`  | the last restore is older than the window — staging is stale |
+| `3`  | no receipt, or the check could not run. **Not checked, not passed.** |
+
+`3` is deliberately not `0`: a host that cannot check must not report what a host
+that checked and passed reports. It is deliberately not `1` either — a missing
+`psql` should not page anyone the way a stale staging database should.
+
+A database restored by hand, or by a fraisier older than v0.65.0, has no receipt
+and reads as `MISSING` (exit 3). That is *not proven*, not *stale*.
+
+`--check-heap` adds relation-file mtimes as a second opinion. It is opt-in
+because it needs superuser or `pg_read_server_files`, which managed PostgreSQL
+commonly refuses, and it never changes the exit code: autovacuum moves mtimes
+after a restore that did nothing, so it can pass a database the receipt
+correctly calls stale. When the two disagree, both are printed.
 
 ---
 

--- a/fraises.example.yaml
+++ b/fraises.example.yaml
@@ -87,6 +87,7 @@ fraises:
             backup_dir: /backup/production
             backup_pattern: "*.dump"          # glob for finding backups
             max_age_hours: 48                 # reject backups older than this
+            max_actuation_age_hours: 26       # `db receipt`: how recently a restore must have run
             target_owner: myapp_user          # fix ownership after restore
             create_template: true             # create rollback template before migrating
             template_name: myapp_staging_template

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -40,6 +40,36 @@ def _get_db_config(
     return fraise, env_config
 
 
+def _report_actuation(actuation) -> None:
+    """Print what proved — or did not prove — that this run rewrote the database.
+
+    Three outcomes, three different lines, on purpose. The one failure this
+    exists to catch is a restore that reports success while staging keeps
+    yesterday's data (#343, #356), so a run that could not obtain the proof must
+    not print anything a reader could mistake for having obtained it.
+
+    ``None`` means the strategy predates the receipt — say nothing rather than
+    invent a verdict for it.
+    """
+    from fraisier.dbops.receipt import ActuationVerdict
+
+    if actuation is None:
+        return
+    if actuation.verdict is ActuationVerdict.ACTUATED and actuation.receipt:
+        receipt = actuation.receipt
+        console.print(
+            f"  Actuation: run {receipt.run_id} wrote this database, read back "
+            f"out of it — the restore ran, it did not merely report success."
+        )
+    elif actuation.verdict is ActuationVerdict.STALE:
+        console.print(f"  [red]Actuation failed:[/red] {actuation.detail}")
+    else:
+        console.print(
+            f"  [yellow]Actuation not verified:[/yellow] {actuation.detail}. "
+            "This says nothing either way — it is not a passed check."
+        )
+
+
 @db.command(name="exec")
 @click.argument("fraise")
 @click.option("--env", "-e", required=True, help="Target environment")
@@ -746,6 +776,16 @@ def db_restore(
                     "(--schema-only, or pg_restore unavailable); the restored "
                     "database was not checked for emptiness."
                 )
+
+            # What the floor above cannot tell anyone: that a restore happened
+            # at all (#358). A staging database nobody rewrote holds correct
+            # counts of yesterday's data, so the evidence has to be a token this
+            # run minted and then read back out of the database. Reported here
+            # in the same voice as the floor — including when it could not be
+            # obtained, because "not verified" and "verified" must not look
+            # alike to someone skimming a nightly log.
+            _report_actuation(getattr(result, "actuation", None))
+
             if result.total_duration_seconds > 0:
                 console.print(
                     f"  Restore: {result.restore_duration_seconds:.1f}s"
@@ -793,6 +833,175 @@ def db_restore(
             "`fraisier setup`; after a reboot it appears when the webhook starts."
         )
         raise SystemExit(1) from exc
+
+
+#: ``db receipt`` exits 3 when it could not reach a verdict. Not 0: a host that
+#: cannot check must not report what a host that checked and passed reports —
+#: that is the ``min_tables=0`` silent hole (#343) moved into monitoring. Not 1
+#: either, because a monitoring timer that pages on a stale staging database
+#: should not page on a host missing ``psql``.
+_RECEIPT_EXIT_UNKNOWN = 3
+
+
+@db.command(name="receipt")
+@click.argument("fraise")
+@click.argument("environment")
+@click.option(
+    "--max-age-hours",
+    type=float,
+    default=None,
+    help=(
+        "How recently a restore must have rewritten the database. "
+        "Defaults to the fraise's database.restore.max_age_hours."
+    ),
+)
+@click.option(
+    "--check-heap",
+    is_flag=True,
+    help=(
+        "Also report relation-file mtimes. Needs superuser or "
+        "pg_read_server_files; corroborates the receipt, never overrides it."
+    ),
+)
+@click.option(
+    "--heap-schema",
+    default="public",
+    show_default=True,
+    help="Schema whose base tables --check-heap inspects. One schema, never summed.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the verdict as JSON")
+@click.pass_context
+def db_receipt(
+    ctx: click.Context,
+    fraise: str,
+    environment: str,
+    max_age_hours: float | None,
+    check_heap: bool,
+    heap_schema: str,
+    as_json: bool,
+) -> None:
+    """Ask a database when a fraisier restore last rewrote it.
+
+    Every count taken on a stale database is correct — that is what makes a
+    nightly restore that silently stopped running so hard to notice (#343,
+    #356). Each restore leaves a token behind; this reads it back and reports
+    how long ago the run that left it finished.
+
+    \b
+    Exit codes:
+      0  a restore rewrote this database inside the window
+      1  the last restore is older than the window — staging is stale
+      3  no receipt, or the check could not run. Not checked, not passed.
+
+    \b
+    Examples:
+        fraisier db receipt api staging
+        fraisier db receipt api staging --max-age-hours 26 --json
+    """
+    from fraisier.dbops.guard import is_external_db
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
+
+    config = ctx.obj["config"]
+    fraise_cfg, env_config = _get_db_config(config, fraise, environment)
+    if not fraise_cfg or not env_config:
+        console.print(
+            f"[red]Error:[/red] Fraise '{fraise}' environment '{environment}' not found"
+        )
+        raise SystemExit(1)
+
+    if is_external_db(fraise_cfg):
+        console.print(f"[yellow]Skipping '{fraise}': external_db is true[/yellow]")
+        return
+
+    db_cfg = env_config.get("database", {})
+    db_name = db_cfg.get("name", fraise)
+    admin_url = db_cfg.get("admin_url")
+    if not admin_url:
+        console.print(
+            f"[red]Error:[/red] Fraise '{fraise}' env '{environment}' has no "
+            "admin_url; set database.admin_url in fraise/env/*.yaml"
+        )
+        raise SystemExit(1)
+
+    # The restore path's own notion of how stale an input may be, reused as the
+    # notion of how stale an output may be.
+    window = max_age_hours
+    if window is None:
+        window = float((db_cfg.get("restore") or {}).get("max_age_hours", 48.0))
+
+    check = verify_actuation(db_name, connection_url=admin_url, max_age_hours=window)
+    receipt = check.receipt
+
+    # Opt-in, and reported as a line rather than folded into the verdict. It
+    # answers a related but weaker question — mtimes move for autovacuum too, so
+    # it can pass a database the receipt correctly calls stale — and it needs a
+    # privilege most managed PostgreSQL will not grant, which would otherwise
+    # print "could not read" on every run. When the two disagree both are shown:
+    # "the receipt says today and the heap says last week" is something an
+    # operator wants told, not something this should settle silently.
+    heap = None
+    if check_heap:
+        from fraisier.dbops.receipt import relation_freshness
+
+        heap = relation_freshness(
+            db_name,
+            schema=heap_schema,
+            connection_url=admin_url,
+            within_hours=window,
+        )
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "database": db_name,
+                    "verdict": check.verdict.value,
+                    "detail": check.detail,
+                    "max_age_hours": window,
+                    "run_id": receipt.run_id if receipt else None,
+                    "backup_path": receipt.backup_path if receipt else None,
+                    "backup_bytes": receipt.backup_bytes if receipt else None,
+                    "restored_at": receipt.restored_at.isoformat() if receipt else None,
+                    "age_hours": receipt.age_hours if receipt else None,
+                    "heap": (
+                        {"verdict": heap.verdict.value, "detail": heap.detail}
+                        if heap
+                        else None
+                    ),
+                },
+                indent=2,
+            )
+        )
+    elif check.verdict is ActuationVerdict.ACTUATED and receipt:
+        console.print(
+            f"[green]Actuated:[/green] {db_name} was rewritten "
+            f"{receipt.age_hours:.1f}h ago by run {receipt.run_id}"
+        )
+        console.print(f"  From backup: {receipt.backup_path}")
+    elif check.verdict is ActuationVerdict.STALE:
+        console.print(f"[red]Stale:[/red] {check.detail}")
+        if receipt:
+            console.print(f"  Last backup restored: {receipt.backup_path}")
+    else:
+        console.print(f"[yellow]Not checked:[/yellow] {check.detail}")
+        console.print(
+            "  This says nothing either way about the database — it is not a "
+            "passed check and not a failed one."
+        )
+
+    if heap is not None and not as_json:
+        colour = {
+            ActuationVerdict.ACTUATED: "green",
+            ActuationVerdict.STALE: "red",
+        }.get(heap.verdict, "yellow")
+        console.print(f"  [{colour}]Heap mtimes:[/{colour}] {heap.detail}")
+
+    # The receipt decides. The heap check corroborates and does not vote: it
+    # passes a stale database whose autovacuum happened to run, so letting it
+    # move the exit code would trade a reliable signal for an unreliable one.
+    if check.verdict is ActuationVerdict.ACTUATED:
+        return
+    raise SystemExit(1 if check.is_bad else _RECEIPT_EXIT_UNKNOWN)
 
 
 class _BackupGroup(click.Group):

--- a/fraisier/cli/db.py
+++ b/fraisier/cli/db.py
@@ -842,6 +842,14 @@ def db_restore(
 #: should not page on a host missing ``psql``.
 _RECEIPT_EXIT_UNKNOWN = 3
 
+#: How recently a restore must have rewritten the database, when nothing says
+#: otherwise. Deliberately *not* ``database.restore.max_age_hours``, which asks a
+#: different question — how old the backup *file* may be. A 48h tolerance for an
+#: input is a reasonable thing to configure and a uselessly loose window for "did
+#: last night's restore run": a nightly that stopped a day ago would still pass.
+#: 26h suits a nightly cadence — a couple of hours of slack, and no more.
+_DEFAULT_ACTUATION_WINDOW_HOURS = 26.0
+
 
 @db.command(name="receipt")
 @click.argument("fraise")
@@ -851,8 +859,9 @@ _RECEIPT_EXIT_UNKNOWN = 3
     type=float,
     default=None,
     help=(
-        "How recently a restore must have rewritten the database. "
-        "Defaults to the fraise's database.restore.max_age_hours."
+        "How recently a restore must have rewritten the database. Defaults to "
+        "the fraise's database.restore.max_actuation_age_hours "
+        f"(default {_DEFAULT_ACTUATION_WINDOW_HOURS:g}h)."
     ),
 )
 @click.option(
@@ -865,9 +874,12 @@ _RECEIPT_EXIT_UNKNOWN = 3
 )
 @click.option(
     "--heap-schema",
-    default="public",
-    show_default=True,
-    help="Schema whose base tables --check-heap inspects. One schema, never summed.",
+    default=None,
+    help=(
+        "Schema whose base tables --check-heap inspects. One schema, never "
+        "summed. Defaults to the schema the restore derived its floor for, as "
+        "recorded in the receipt, and to 'public' when the receipt names none."
+    ),
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit the verdict as JSON")
 @click.pass_context
@@ -877,7 +889,7 @@ def db_receipt(
     environment: str,
     max_age_hours: float | None,
     check_heap: bool,
-    heap_schema: str,
+    heap_schema: str | None,
     as_json: bool,
 ) -> None:
     """Ask a database when a fraisier restore last rewrote it.
@@ -896,7 +908,7 @@ def db_receipt(
     \b
     Examples:
         fraisier db receipt api staging
-        fraisier db receipt api staging --max-age-hours 26 --json
+        fraisier db receipt api staging --max-age-hours 12 --json
     """
     from fraisier.dbops.guard import is_external_db
     from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
@@ -923,14 +935,30 @@ def db_receipt(
         )
         raise SystemExit(1)
 
-    # The restore path's own notion of how stale an input may be, reused as the
-    # notion of how stale an output may be.
+    # Its own key, not the restore's `max_age_hours`. That one bounds the age of
+    # the backup *file* the restore is allowed to load; this one bounds how long
+    # ago a restore last ran. On a nightly cadence they are different numbers,
+    # and borrowing the input tolerance for the output question makes the window
+    # far too loose to notice the failure it exists to catch.
     window = max_age_hours
     if window is None:
-        window = float((db_cfg.get("restore") or {}).get("max_age_hours", 48.0))
+        window = float(
+            (db_cfg.get("restore") or {}).get(
+                "max_actuation_age_hours", _DEFAULT_ACTUATION_WINDOW_HOURS
+            )
+        )
 
     check = verify_actuation(db_name, connection_url=admin_url, max_age_hours=window)
     receipt = check.receipt
+
+    # The receipt names where this database's heaps actually live, because the
+    # restore derived it from the archive and nothing else can. Guessing
+    # `public` on a host whose tables are in `tenant` finds no base tables and
+    # returns UNVERIFIABLE — silence, precisely where the cross-check is most
+    # wanted. That is the mismatch the v0.64.0 floor fix removed, and it is not
+    # being reintroduced one command over. Resolved unconditionally so the JSON
+    # can report which schema was looked in.
+    schema = heap_schema or (receipt.floor_schema if receipt else None) or "public"
 
     # Opt-in, and reported as a line rather than folded into the verdict. It
     # answers a related but weaker question — mtimes move for autovacuum too, so
@@ -945,7 +973,7 @@ def db_receipt(
 
         heap = relation_freshness(
             db_name,
-            schema=heap_schema,
+            schema=schema,
             connection_url=admin_url,
             within_hours=window,
         )
@@ -963,8 +991,16 @@ def db_receipt(
                     "backup_bytes": receipt.backup_bytes if receipt else None,
                     "restored_at": receipt.restored_at.isoformat() if receipt else None,
                     "age_hours": receipt.age_hours if receipt else None,
+                    "floor_schema": receipt.floor_schema if receipt else None,
+                    # The schema is reported alongside the verdict because it is
+                    # resolved rather than given: an operator reading
+                    # UNVERIFIABLE needs to see which schema was looked in.
                     "heap": (
-                        {"verdict": heap.verdict.value, "detail": heap.detail}
+                        {
+                            "verdict": heap.verdict.value,
+                            "detail": heap.detail,
+                            "schema": schema,
+                        }
                         if heap
                         else None
                     ),

--- a/fraisier/dbops/operations.py
+++ b/fraisier/dbops/operations.py
@@ -57,6 +57,7 @@ def _pg_cmd(
     cmd: list[str],
     *,
     connection_url: str,
+    input_text: str | None = None,
 ) -> tuple[int, str, str]:
     """Run a PostgreSQL CLI command against *connection_url*.
 
@@ -66,6 +67,12 @@ def _pg_cmd(
     The database path from the URL is also forwarded when the caller has
     not already specified one: ``-d`` for psql/pg_restore,
     ``--maintenance-db`` for createdb/dropdb.
+
+    *input_text* is written to the process's stdin. It exists for ``psql -f -``,
+    which is the only way to get psql's ``:'var'`` binding: ``-c`` hands its
+    string straight to the server, so psql never sees the variables and never
+    substitutes them. A caller with values to bind pipes the script instead of
+    quoting into it.
 
     Returns (exit_code, stdout, stderr).
     """
@@ -87,6 +94,7 @@ def _pg_cmd(
         text=True,
         check=False,
         env=run_env,
+        input=input_text,
     )
     return result.returncode, result.stdout, result.stderr
 

--- a/fraisier/dbops/receipt.py
+++ b/fraisier/dbops/receipt.py
@@ -64,17 +64,29 @@ RECEIPT_TABLE = f"{RECEIPT_SCHEMA}.restore_receipt"
 
 _SECONDS_PER_HOUR = 3600.0
 
+#: ``floor_schema`` is the schema the restore derived its table-count floor for,
+#: recorded because that is the only moment it is knowable: it comes off the
+#: archive's table of contents during the restore and is configured nowhere, so
+#: a caller reading the receipt the next morning has no archive to derive it
+#: from. NULL means the archive stated no floor — the reader falls back, the
+#: writer does not invent.
 _WRITE_SQL = f"""
 CREATE SCHEMA IF NOT EXISTS {RECEIPT_SCHEMA};
 CREATE TABLE IF NOT EXISTS {RECEIPT_TABLE} (
     run_id       text        PRIMARY KEY,
     backup_path  text        NOT NULL,
     backup_bytes bigint      NOT NULL,
-    restored_at  timestamptz NOT NULL DEFAULT now()
+    restored_at  timestamptz NOT NULL DEFAULT now(),
+    floor_schema text
 );
 DELETE FROM {RECEIPT_TABLE};
-INSERT INTO {RECEIPT_TABLE} (run_id, backup_path, backup_bytes)
-VALUES (:'run_id', :'backup_path', :'backup_bytes'::bigint);
+INSERT INTO {RECEIPT_TABLE} (run_id, backup_path, backup_bytes, floor_schema)
+VALUES (
+    :'run_id',
+    :'backup_path',
+    :'backup_bytes'::bigint,
+    NULLIF(:'floor_schema', '')
+);
 """
 
 #: Does the receipt table exist at all? Asked separately, and by ``to_regclass``
@@ -84,14 +96,17 @@ _PROBE_SQL = f"SELECT to_regclass('{RECEIPT_TABLE}') IS NOT NULL"
 
 #: ``age_seconds`` is computed by the server, from the server's own clock, so a
 #: host whose clock has drifted cannot make a stale restore look fresh.
+#:
+#: ``t.*`` rather than a column list, because the table above is created with
+#: ``CREATE TABLE IF NOT EXISTS`` and therefore never migrated: naming a column
+#: added later would turn a readable receipt written by an earlier fraisier into
+#: UNVERIFIABLE. Whatever columns are there arrive as JSON keys, and
+#: :func:`_parse_receipt` treats the ones it does not find as absent.
 _READ_SQL = f"""
 SELECT to_json(r) FROM (
-    SELECT run_id,
-           backup_path,
-           backup_bytes,
-           restored_at,
+    SELECT t.*,
            extract(epoch FROM (now() - restored_at)) AS age_seconds
-    FROM {RECEIPT_TABLE}
+    FROM {RECEIPT_TABLE} t
     ORDER BY restored_at DESC
     LIMIT 1
 ) r
@@ -166,6 +181,15 @@ class RestoreReceipt:
     age_seconds: float
     """How long ago that was, measured by the server rather than the client."""
 
+    floor_schema: str | None = None
+    """The schema that run derived its table-count floor for, if it derived one.
+
+    Where this database's heaps actually live, recorded by the only party that
+    can know: the restore, from the archive's table of contents. ``None`` means
+    the archive stated no floor, or the receipt predates this column — in both
+    cases a reader falls back rather than believing ``public``.
+    """
+
     @property
     def age_hours(self) -> float:
         return self.age_seconds / _SECONDS_PER_HOUR
@@ -200,7 +224,14 @@ class ActuationCheck:
         return self.verdict is ActuationVerdict.STALE
 
 
-def _psql(db_name: str, sql: str, *, connection_url: str, bind: dict[str, str]):
+def _psql(
+    db_name: str,
+    sql: str,
+    *,
+    connection_url: str,
+    bind: dict[str, str],
+    single_transaction: bool = False,
+):
     """Run *sql* against *db_name*, binding *bind* as psql variables.
 
     Values go in through ``-v name=value`` and are read back in the SQL as
@@ -215,8 +246,16 @@ def _psql(db_name: str, sql: str, *, connection_url: str, bind: dict[str, str]):
     ``ON_ERROR_STOP=1`` matters more than it looks: without it psql exits 0 on a
     statement that failed, so a caller checking the exit code would read a
     failed write as a successful one.
+
+    *single_transaction* adds ``-1``, for a script whose statements are only
+    meaningful together. It is the write's: that script deletes the standing
+    receipt before inserting the new one, so a failure between the two would
+    otherwise commit the delete and leave a present-but-empty table, which reads
+    as MISSING — a database claiming no run ever wrote it.
     """
     cmd = ["psql", "-d", db_name, "-t", "-A", "-v", "ON_ERROR_STOP=1"]
+    if single_transaction:
+        cmd.append("-1")
     for name, value in bind.items():
         cmd += ["-v", f"{name}={value}"]
     cmd += ["-f", "-"]
@@ -249,7 +288,11 @@ def write_receipt(
                 "run_id": receipt.run_id,
                 "backup_path": receipt.backup_path,
                 "backup_bytes": str(receipt.backup_bytes),
+                # Bound like every other value: a schema name is data here, not
+                # an identifier position, and NULLIF turns "" back into NULL.
+                "floor_schema": receipt.floor_schema or "",
             },
+            single_transaction=True,
         )
     except FileNotFoundError:
         return "psql not found on PATH — the restore receipt was not written"
@@ -264,15 +307,22 @@ def write_receipt(
 
 
 def _parse_receipt(payload: str) -> RestoreReceipt | None:
-    """Parse one ``to_json`` row, or None if it is not one."""
+    """Parse one ``to_json`` row, or None if it is not one.
+
+    ``floor_schema`` is read with ``.get``: a receipt written before that column
+    existed is a complete receipt missing one optional fact, not an unreadable
+    one, and the table it lives in is never migrated.
+    """
     try:
         row = json.loads(payload)
+        floor_schema = row.get("floor_schema")
         return RestoreReceipt(
             run_id=str(row["run_id"]),
             backup_path=str(row["backup_path"]),
             backup_bytes=int(row["backup_bytes"]),
             restored_at=datetime.fromisoformat(row["restored_at"]),
             age_seconds=float(row["age_seconds"]),
+            floor_schema=str(floor_schema) if floor_schema else None,
         )
     except (ValueError, TypeError, KeyError):
         return None

--- a/fraisier/dbops/receipt.py
+++ b/fraisier/dbops/receipt.py
@@ -1,0 +1,472 @@
+"""Did this restore actually run? (#358)
+
+A table-count floor proves the schema arrived. A row-count floor would prove how
+much data arrived. Neither can see the failure #343 reported and #356 was filed
+against: a nightly staging restore that reports success in 21 seconds while
+staging keeps yesterday's database. Nothing about that database's *content* is
+wrong — every count is correct — it is only old. Counting harder cannot see it,
+because the pipeline that would have changed the counts never ran.
+
+What can see it is evidence that the heap was written *this run*. fraisier owns
+the whole restore pipeline, so it leaves a receipt: a token minted per run and
+written into the freshly restored database, which an independent caller reads
+back later and compares against what it expected.
+
+The token is the point. A no-op leaves the *previous* run's receipt in place, so
+"a receipt exists" always matches and proves nothing — which is why
+:func:`verify_actuation` refuses to answer without a criterion to check the
+receipt against.
+
+The verdict is **four-valued**, and only one value is proof:
+
+- ``ACTUATED``    — a run rewrote this database and the receipt satisfies the
+                    criterion asked of it.
+- ``STALE``       — a receipt is present and does not. The known-bad verdict, and
+                    the only one :attr:`ActuationCheck.is_bad` convicts.
+- ``MISSING``     — no receipt. **Not bad.** A database restored by hand or by a
+                    fraisier older than this feature has none, and convicting it
+                    would make the check unusable on the hosts that need it first.
+- ``UNVERIFIABLE``— the check could not run. Says nothing about the database.
+
+That split is the same rule :class:`~fraisier.dbops.archive.ArchiveCheck` already
+applies, and for the same reason: an unevaluable condition is never silently
+resolved in either direction. A check that reads as a pass when it could not run
+is how ``min_tables=0`` was a silent hole for a year (#343).
+
+Storage is a single row in a dedicated ``fraisier`` schema, created inside the
+restored database. Outside ``public`` deliberately — both floors that guard a
+restore count ``relkind='r'`` in one schema, so a bookkeeping table in ``public``
+would quietly raise them, and a schema comparison would read it as drift. It
+needs no migration and no cleanup: the next restore's DROP+CREATE takes it with
+everything else.
+
+Access is ``psql``, like the ownership reassignment in
+:mod:`fraisier.dbops.restore`, over the admin URL the restore already holds. No
+new dependency, no new configuration, no new privilege.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from fraisier.dbops._validation import validate_pg_identifier
+from fraisier.dbops.operations import _pg_cmd
+
+#: Dedicated schema, never ``public`` — see the module docstring.
+RECEIPT_SCHEMA = "fraisier"
+
+#: Schema-qualified receipt table. A constant, so no caller-supplied value ever
+#: reaches an identifier position in the SQL below.
+RECEIPT_TABLE = f"{RECEIPT_SCHEMA}.restore_receipt"
+
+_SECONDS_PER_HOUR = 3600.0
+
+_WRITE_SQL = f"""
+CREATE SCHEMA IF NOT EXISTS {RECEIPT_SCHEMA};
+CREATE TABLE IF NOT EXISTS {RECEIPT_TABLE} (
+    run_id       text        PRIMARY KEY,
+    backup_path  text        NOT NULL,
+    backup_bytes bigint      NOT NULL,
+    restored_at  timestamptz NOT NULL DEFAULT now()
+);
+DELETE FROM {RECEIPT_TABLE};
+INSERT INTO {RECEIPT_TABLE} (run_id, backup_path, backup_bytes)
+VALUES (:'run_id', :'backup_path', :'backup_bytes'::bigint);
+"""
+
+#: Does the receipt table exist at all? Asked separately, and by ``to_regclass``
+#: rather than by matching ``psql``'s error text: PostgreSQL localises its
+#: messages, so "relation does not exist" is not a string a check may rely on.
+_PROBE_SQL = f"SELECT to_regclass('{RECEIPT_TABLE}') IS NOT NULL"
+
+#: ``age_seconds`` is computed by the server, from the server's own clock, so a
+#: host whose clock has drifted cannot make a stale restore look fresh.
+_READ_SQL = f"""
+SELECT to_json(r) FROM (
+    SELECT run_id,
+           backup_path,
+           backup_bytes,
+           restored_at,
+           extract(epoch FROM (now() - restored_at)) AS age_seconds
+    FROM {RECEIPT_TABLE}
+    ORDER BY restored_at DESC
+    LIMIT 1
+) r
+"""
+
+
+#: Relation-file mtimes, per schema and never summed — the rule the archive
+#: floor already follows. ``pg_stat_file`` raises rather than returning NULL when
+#: the role may not read server files, so a denial arrives as a non-zero exit and
+#: is classified UNVERIFIABLE by the caller.
+_FRESHNESS_SQL = """
+SELECT to_json(r) FROM (
+    SELECT count(*) AS total,
+           count(*) FILTER (
+               WHERE m IS NOT NULL
+                 AND m >= now() - (:'within_hours' || ' hours')::interval
+           ) AS fresh,
+           extract(epoch FROM (now() - min(m))) / 3600 AS oldest_age_hours
+    FROM (
+        SELECT (pg_stat_file(pg_relation_filepath(c.oid))).modification AS m
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'r' AND n.nspname = :'schema'
+    ) s
+) r
+"""
+
+
+class ActuationVerdict(Enum):
+    """What was learned about the last run to rewrite a database."""
+
+    ACTUATED = "actuated"
+    """A run rewrote this database and its receipt met the criterion."""
+
+    STALE = "stale"
+    """A receipt is present and does not meet the criterion.
+
+    Either it names a different run than the caller expected, or it is older
+    than the caller's window. This is the failure #343 reported.
+    """
+
+    MISSING = "missing"
+    """No receipt table, or no row in it.
+
+    Says nothing about the database: one restored by hand, or by a fraisier
+    predating this check, carries none. Callers must not treat it as STALE.
+    """
+
+    UNVERIFIABLE = "unverifiable"
+    """The check could not run: no ``psql``, no connection, unreadable output.
+
+    Says nothing about the database. Callers must not act as though it does.
+    """
+
+
+@dataclass(frozen=True)
+class RestoreReceipt:
+    """What one restore run recorded about itself."""
+
+    run_id: str
+    """The token that run minted. Unique per run — presence is not proof."""
+
+    backup_path: str
+    """The archive that run claims to have loaded."""
+
+    backup_bytes: int
+    """Its size, so a receipt names *which* backup and not merely a path."""
+
+    restored_at: datetime
+    """When the run finished, by the database server's clock."""
+
+    age_seconds: float
+    """How long ago that was, measured by the server rather than the client."""
+
+    @property
+    def age_hours(self) -> float:
+        return self.age_seconds / _SECONDS_PER_HOUR
+
+
+@dataclass(frozen=True)
+class ActuationCheck:
+    """A verdict, why it was reached, and the receipt behind it if there is one."""
+
+    verdict: ActuationVerdict
+    detail: str
+    receipt: RestoreReceipt | None = None
+    """The row that was read, carried even when it *fails* the criterion.
+
+    A caller reporting STALE should be able to say whose run the database is
+    still holding, and from which backup.
+    """
+
+    @property
+    def is_actuated(self) -> bool:
+        """A run rewrote this database and proved it. The only proof verdict."""
+        return self.verdict is ActuationVerdict.ACTUATED
+
+    @property
+    def is_bad(self) -> bool:
+        """The database is known not to have been rewritten as expected.
+
+        ``MISSING`` and ``UNVERIFIABLE`` are **not** bad. Branch on this rather
+        than on ``verdict is not ACTUATED``, which convicts a database for the
+        absence of the evidence that would have cleared it.
+        """
+        return self.verdict is ActuationVerdict.STALE
+
+
+def _psql(db_name: str, sql: str, *, connection_url: str, bind: dict[str, str]):
+    """Run *sql* against *db_name*, binding *bind* as psql variables.
+
+    Values go in through ``-v name=value`` and are read back in the SQL as
+    ``:'name'``, which psql quotes and escapes as a string literal. Nothing is
+    interpolated into the statement text.
+
+    The script goes in on **stdin** (``-f -``) rather than in ``-c``. That is
+    not a style choice: ``-c`` hands its string to the server unread, so psql
+    never sees ``:'run_id'`` and the server rejects it as a syntax error. Only
+    input psql lexes itself — a file, or stdin — gets variable substitution.
+
+    ``ON_ERROR_STOP=1`` matters more than it looks: without it psql exits 0 on a
+    statement that failed, so a caller checking the exit code would read a
+    failed write as a successful one.
+    """
+    cmd = ["psql", "-d", db_name, "-t", "-A", "-v", "ON_ERROR_STOP=1"]
+    for name, value in bind.items():
+        cmd += ["-v", f"{name}={value}"]
+    cmd += ["-f", "-"]
+    return _pg_cmd(cmd, connection_url=connection_url, input_text=sql)
+
+
+def write_receipt(
+    db_name: str,
+    *,
+    connection_url: str,
+    receipt: RestoreReceipt,
+) -> str | None:
+    """Record *receipt* as the one receipt of *db_name*.
+
+    Returns ``None`` when the receipt was written, or a detail string saying why
+    it was not. It never raises for an unreachable database or a missing
+    ``psql``: the caller is a restore that has already passed every check it
+    has, and failing an otherwise-good restore over a bookkeeping row would be
+    worse than the problem this row exists to solve.
+
+    One row, not an append log — "what wrote this database" has one answer.
+    """
+    validate_pg_identifier(db_name, "database name")
+    try:
+        code, _, stderr = _psql(
+            db_name,
+            _WRITE_SQL,
+            connection_url=connection_url,
+            bind={
+                "run_id": receipt.run_id,
+                "backup_path": receipt.backup_path,
+                "backup_bytes": str(receipt.backup_bytes),
+            },
+        )
+    except FileNotFoundError:
+        return "psql not found on PATH — the restore receipt was not written"
+    except OSError as exc:  # pragma: no cover - defensive
+        return f"could not run psql to write the restore receipt: {exc}"
+    if code != 0:
+        return (
+            f"writing the restore receipt to {db_name} failed: "
+            f"{stderr.strip() or f'psql exited with code {code}'}"
+        )
+    return None
+
+
+def _parse_receipt(payload: str) -> RestoreReceipt | None:
+    """Parse one ``to_json`` row, or None if it is not one."""
+    try:
+        row = json.loads(payload)
+        return RestoreReceipt(
+            run_id=str(row["run_id"]),
+            backup_path=str(row["backup_path"]),
+            backup_bytes=int(row["backup_bytes"]),
+            restored_at=datetime.fromisoformat(row["restored_at"]),
+            age_seconds=float(row["age_seconds"]),
+        )
+    except (ValueError, TypeError, KeyError):
+        return None
+
+
+def read_receipt(db_name: str, *, connection_url: str) -> ActuationCheck:
+    """Read *db_name*'s receipt without judging it.
+
+    Returns MISSING or UNVERIFIABLE as appropriate, or — when a row was read —
+    an ``ACTUATED`` check whose only claim is that a receipt exists. **That is
+    not proof the database is fresh**; a no-op leaves the previous run's receipt
+    in place. Callers deciding anything use :func:`verify_actuation`, which
+    requires a criterion. This exists for reporting what is there.
+    """
+    validate_pg_identifier(db_name, "database name")
+    try:
+        code, stdout, stderr = _psql(
+            db_name, _PROBE_SQL, connection_url=connection_url, bind={}
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not run psql to read the restore receipt: {exc}",
+        )
+    if code != 0:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not reach {db_name} to read its restore receipt: "
+            f"{stderr.strip() or f'psql exited with code {code}'}",
+        )
+    if stdout.strip() != "t":
+        return ActuationCheck(
+            ActuationVerdict.MISSING,
+            f"{db_name} has no {RECEIPT_TABLE} — it has not been restored by a "
+            "fraisier that writes one. This is not evidence either way.",
+        )
+
+    code, stdout, stderr = _psql(
+        db_name, _READ_SQL, connection_url=connection_url, bind={}
+    )
+    if code != 0:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not read {RECEIPT_TABLE} in {db_name}: "
+            f"{stderr.strip() or f'psql exited with code {code}'}",
+        )
+    payload = stdout.strip()
+    if not payload:
+        return ActuationCheck(
+            ActuationVerdict.MISSING,
+            f"{RECEIPT_TABLE} exists in {db_name} but holds no row",
+        )
+    receipt = _parse_receipt(payload)
+    if receipt is None:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not parse the receipt read from {db_name}",
+        )
+    return ActuationCheck(
+        ActuationVerdict.ACTUATED,
+        f"run {receipt.run_id} restored {db_name} from {receipt.backup_path} "
+        f"{receipt.age_hours:.1f}h ago",
+        receipt,
+    )
+
+
+def relation_freshness(
+    db_name: str,
+    *,
+    schema: str,
+    connection_url: str,
+    within_hours: float,
+) -> ActuationCheck:
+    """Were *schema*'s base tables written to disk within *within_hours*?
+
+    #358's own suggestion, and a genuine cross-check where fraisier is not the
+    only thing that writes a database — a hand-run ``psql`` restore leaves no
+    receipt but does move every heap file.
+
+    It is **secondary** to the receipt for two reasons this code cannot fix:
+
+    - ``pg_stat_file`` needs superuser or ``pg_read_server_files``, which many
+      managed PostgreSQL deployments refuse. A denial is UNVERIFIABLE. It is not
+      a pass, and the check does not ask for the privilege — a check that only
+      runs where it is least needed is worse than no check.
+    - Autovacuum and HOT pruning touch heap files, so an mtime can move after a
+      restore that did nothing. That is a false *pass*, never a false fail. Safe
+      to corroborate with, unsafe to rely on alone.
+
+    One schema, never summed across schemas — the rule the archive-derived floor
+    already follows.
+    """
+    validate_pg_identifier(db_name, "database name")
+    try:
+        code, stdout, stderr = _psql(
+            db_name,
+            _FRESHNESS_SQL,
+            connection_url=connection_url,
+            bind={"schema": schema, "within_hours": str(within_hours)},
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not run psql to read relation mtimes: {exc}",
+        )
+    if code != 0:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not read relation mtimes in {db_name}: "
+            f"{stderr.strip() or f'psql exited with code {code}'} — this needs "
+            "superuser or pg_read_server_files, which many managed PostgreSQL "
+            "deployments do not grant. Nothing was learned either way.",
+        )
+    try:
+        row = json.loads(stdout.strip())
+        total = int(row["total"])
+        fresh = int(row["fresh"])
+    except (ValueError, TypeError, KeyError):
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"could not parse the relation mtimes read from {db_name}",
+        )
+
+    if total == 0:
+        return ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE,
+            f"schema '{schema}' in {db_name} has no base tables, so their "
+            "mtimes say nothing about whether a restore ran",
+        )
+    if fresh < total:
+        oldest = row.get("oldest_age_hours")
+        oldest_text = f", oldest {float(oldest):.1f}h" if oldest is not None else ""
+        return ActuationCheck(
+            ActuationVerdict.STALE,
+            f"{total - fresh} of {total} base table(s) in '{schema}' were last "
+            f"written more than {within_hours:.1f}h ago{oldest_text}",
+        )
+    return ActuationCheck(
+        ActuationVerdict.ACTUATED,
+        f"all {total} base table(s) in '{schema}' were written within "
+        f"{within_hours:.1f}h",
+    )
+
+
+def verify_actuation(
+    db_name: str,
+    *,
+    connection_url: str,
+    expected_run_id: str | None = None,
+    max_age_hours: float | None = None,
+) -> ActuationCheck:
+    """Check *db_name*'s receipt against a criterion.
+
+    Exactly one thing makes this useful and it is the criterion:
+
+    - *expected_run_id* — the token the caller minted for **this** run. Used
+      from inside the pipeline: the receipt must name the run now claiming to
+      have written it.
+    - *max_age_hours* — how recently a run must have rewritten the database.
+      Used from outside: this is the question a stale staging database fails.
+
+    Raises:
+        ValueError: If neither criterion is given. Reading a receipt is not a
+            verdict on it — a no-op restore leaves the previous run's receipt in
+            place, so "a row exists" matches every time and would report a
+            database that was never rewritten as proven fresh.
+    """
+    if expected_run_id is None and max_age_hours is None:
+        msg = (
+            "verify_actuation needs a criterion: expected_run_id or "
+            "max_age_hours. A receipt's presence is not proof — a restore that "
+            "never ran leaves the previous run's receipt in place."
+        )
+        raise ValueError(msg)
+
+    check = read_receipt(db_name, connection_url=connection_url)
+    if check.receipt is None:
+        return check
+    receipt = check.receipt
+
+    if expected_run_id is not None and receipt.run_id != expected_run_id:
+        return ActuationCheck(
+            ActuationVerdict.STALE,
+            f"{db_name} still holds the receipt of run {receipt.run_id} "
+            f"(from {receipt.backup_path}, {receipt.age_hours:.1f}h ago); "
+            f"run {expected_run_id} did not rewrite it",
+            receipt,
+        )
+    if max_age_hours is not None and receipt.age_hours > max_age_hours:
+        return ActuationCheck(
+            ActuationVerdict.STALE,
+            f"{db_name} was last rewritten {receipt.age_hours:.1f}h ago by run "
+            f"{receipt.run_id}, which is older than the {max_age_hours:.1f}h "
+            "window",
+            receipt,
+        )
+    return check

--- a/fraisier/dbops/restore.py
+++ b/fraisier/dbops/restore.py
@@ -129,7 +129,21 @@ def restore_backup(
     data section restores its schema completely, so the tables exist and are
     empty and any count passes. The floor catches a restore that produced no
     schema; :func:`fraisier.dbops.archive.verify_archive`, called before the
-    database is dropped, is what catches a truncated archive (#342, #343).
+    database is dropped, is what catches an archive whose *table of contents*
+    is unreadable (#342, #343).
+
+    Neither of them catches a truncation, and neither has to: ``pg_restore``
+    does. It cannot read past the cut, writes a ``pg_restore: error:`` line and
+    exits non-zero, and confiture fails the section on ``returncode != 0 and
+    (exit_on_error or errors)``. That holds for ``jobs > 1`` too, where
+    ``exit_on_error`` is off — the ``or errors`` half carries it, because
+    tolerating a non-zero *exit* is not the same as tolerating an *error line*.
+    Measured, not assumed, and pinned by
+    ``tests/integration/test_restore_truncated_archive.py`` (#358).
+
+    What none of the above can see is a restore that never ran: a database
+    nobody rewrote holds stale data with entirely correct counts. That is what
+    :mod:`fraisier.dbops.receipt` is for.
     """
     validate_pg_identifier(db_name, "database name")
     validate_file_path(backup_path)

--- a/fraisier/introspection.py
+++ b/fraisier/introspection.py
@@ -127,6 +127,7 @@ SUBCOMMAND_CONFIG_SECTIONS: dict[str, frozenset[ConfigPath]] = {
     "db exec": _DB_SECTIONS,
     "db migrate": _DB_SECTIONS,
     "db preflight": _DB_SECTIONS,
+    "db receipt": _DB_SECTIONS,
     "db reset": _DB_SECTIONS,
     "db restore": _DB_SECTIONS,
     "db-check": _DB_SECTIONS,

--- a/fraisier/strategies/_base.py
+++ b/fraisier/strategies/_base.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fraisier.dbops.receipt import ActuationCheck
 
 
 @dataclass
@@ -29,6 +32,18 @@ class StrategyResult:
 
     unchecked_schemas: tuple[str, ...] = ()
     """Schemas in the archive the derived floor did not cover."""
+
+    actuation: ActuationCheck | None = None
+    """Evidence that **this run** rewrote the database, read back out of it.
+
+    The floor above proves the schema arrived. This proves a restore happened at
+    all — the failure no count can see, because a database that was never
+    rewritten holds correct counts of stale data (#358).
+
+    None, and every verdict other than ``ACTUATED``, mean *not proven*. Only
+    ``ACTUATED`` is proof, and it is never a reason to fail a restore: the
+    receipt is bookkeeping written after every real check has already passed.
+    """
 
 
 @dataclass

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -148,7 +148,12 @@ class RestoreMigrateStrategy(Strategy):
                 recovery_hint=hint,
             )
 
-    def _record_actuation(self, backup_file: Path, run_id: str) -> ActuationCheck:
+    def _record_actuation(
+        self,
+        backup_file: Path,
+        run_id: str,
+        floor_schema: str | None = None,
+    ) -> ActuationCheck:
         """Leave *run_id* in the restored database, then read it back.
 
         The token is what makes this a check rather than a formality: a restore
@@ -159,6 +164,13 @@ class RestoreMigrateStrategy(Strategy):
 
         Reading it back is a round trip through the database rather than trust
         in a variable this process just set.
+
+        *floor_schema* is the schema this run derived its table-count floor for.
+        It is recorded because here is the only place it is known: it comes off
+        the archive's table of contents, and ``fraisier db receipt`` — which
+        cross-checks relation mtimes the next morning — has no archive and no
+        configuration key to learn it from. ``None`` when the archive stated no
+        floor; the reader falls back rather than being told a guess.
 
         Never raises, and never fails the restore. It runs after every check the
         restore actually has, so a failure here is bookkeeping that did not
@@ -186,6 +198,7 @@ class RestoreMigrateStrategy(Strategy):
             backup_bytes=backup_bytes,
             restored_at=datetime.now(UTC),
             age_seconds=0.0,
+            floor_schema=floor_schema,
         )
         failure = write_receipt(
             self._config.db_name,
@@ -462,7 +475,14 @@ class RestoreMigrateStrategy(Strategy):
         # receipt; a database rolled back onto it reads as MISSING. That is
         # correct — after a rollback it is not the state any completed run
         # produced, and MISSING says "not proven" rather than "stale".
-        actuation = self._record_actuation(backup_file, run_id)
+        #
+        # `derived[0]`, not `floor_schema`: the fallback above names `public` so
+        # the floor has somewhere to count, but recording that would be
+        # indistinguishable from an archive that actually stated `public`. Only
+        # what the archive said is recorded.
+        actuation = self._record_actuation(
+            backup_file, run_id, derived[0] if derived else None
+        )
 
         # Step 11: Start service
         if self._service_manager and self._service_name:

--- a/fraisier/strategies/_restore.py
+++ b/fraisier/strategies/_restore.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fraisier.config.schema import PreflightConfig
 from fraisier.dbops.confiture import migrate_down, migrate_up
 
 from ._base import Strategy, StrategyResult
+
+if TYPE_CHECKING:
+    from fraisier.dbops.receipt import ActuationCheck
 
 log = logging.getLogger(__name__)
 
@@ -143,6 +148,63 @@ class RestoreMigrateStrategy(Strategy):
                 recovery_hint=hint,
             )
 
+    def _record_actuation(self, backup_file: Path, run_id: str) -> ActuationCheck:
+        """Leave *run_id* in the restored database, then read it back.
+
+        The token is what makes this a check rather than a formality: a restore
+        that never ran leaves the *previous* run's receipt in place, so the
+        presence of a receipt matches every time and proves nothing. Only a
+        receipt naming the run that is asking can distinguish "this pipeline
+        rewrote the database" from "some pipeline once did" (#358).
+
+        Reading it back is a round trip through the database rather than trust
+        in a variable this process just set.
+
+        Never raises, and never fails the restore. It runs after every check the
+        restore actually has, so a failure here is bookkeeping that did not
+        happen — reported as UNVERIFIABLE, which is *not proven* rather than
+        *proven bad*, exactly as an unverifiable archive is at step 2.4.
+        """
+        from fraisier.dbops.receipt import (
+            ActuationCheck,
+            ActuationVerdict,
+            RestoreReceipt,
+            verify_actuation,
+            write_receipt,
+        )
+
+        try:
+            backup_bytes = backup_file.stat().st_size
+        except OSError:
+            # The archive was readable minutes ago; if it is not now, that is
+            # worth recording as unknown rather than guessing a size.
+            backup_bytes = 0
+
+        receipt = RestoreReceipt(
+            run_id=run_id,
+            backup_path=str(backup_file),
+            backup_bytes=backup_bytes,
+            restored_at=datetime.now(UTC),
+            age_seconds=0.0,
+        )
+        failure = write_receipt(
+            self._config.db_name,
+            connection_url=self._admin_url,
+            receipt=receipt,
+        )
+        if failure is not None:
+            log.warning("Could not record the restore receipt: %s", failure)
+            return ActuationCheck(ActuationVerdict.UNVERIFIABLE, failure)
+
+        check = verify_actuation(
+            self._config.db_name,
+            connection_url=self._admin_url,
+            expected_run_id=run_id,
+        )
+        if not check.is_actuated:
+            log.warning("Restore receipt not confirmed: %s", check.detail)
+        return check
+
     def execute(
         self,
         confiture_config: Path,
@@ -169,6 +231,13 @@ class RestoreMigrateStrategy(Strategy):
         from fraisier.errors import DatabaseError
 
         cfg = self._config
+
+        # Minted before anything happens, so the token belongs to this run and
+        # to no other. It is written into the restored database at the end and
+        # read back from it; a pipeline that never ran leaves the previous
+        # run's token behind, which is the only way to tell a stale staging
+        # database from a fresh one whose counts happen to match (#358).
+        run_id = uuid.uuid4().hex
 
         # Step 1: Resolve backup file
         if cfg.backup_path is not None:
@@ -381,6 +450,20 @@ class RestoreMigrateStrategy(Strategy):
                 "for emptiness"
             )
 
+        # Step 10.5: Leave this run's receipt in the database it just rewrote.
+        #
+        # After every check, not before: a receipt written earlier would name a
+        # run that had not finished, and a migration or floor failure would
+        # leave the database asserting an outcome that never happened. A receipt
+        # therefore means "this run completed", which is what a later caller
+        # wants to know.
+        #
+        # The rollback template is taken before `migrate up`, so it carries no
+        # receipt; a database rolled back onto it reads as MISSING. That is
+        # correct — after a rollback it is not the state any completed run
+        # produced, and MISSING says "not proven" rather than "stale".
+        actuation = self._record_actuation(backup_file, run_id)
+
         # Step 11: Start service
         if self._service_manager and self._service_name:
             try:
@@ -415,6 +498,7 @@ class RestoreMigrateStrategy(Strategy):
             total_duration_seconds=total_secs,
             schema_floor=derived,
             unchecked_schemas=check.unchecked_schemas,
+            actuation=actuation,
         )
 
     def rollback(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ license = {text = "MIT"}
 name = "fraisier"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.64.0"
+version = "0.65.0"
 
 [project.optional-dependencies]
 all-databases = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,11 +4,17 @@
 named lock file and holds it until a release event fires. Used by the
 self-upgrade drain regression test to model an in-flight deploy without
 patching the locking primitives.
+
+``socket_dir`` yields the local PostgreSQL server's unix socket directory, and
+skips the test when there is no usable server. Shared because more than one
+end-to-end restore test needs a real ``pg_dump``/``pg_restore`` round trip and
+"is a database reachable here" is one fact, not one per test module.
 """
 
 from __future__ import annotations
 
 import multiprocessing
+import shutil
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -18,6 +24,48 @@ from fraisier.locking import file_deployment_lock
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from pathlib import Path
+
+_CANDIDATE_DSNS = (
+    "postgresql:///postgres",
+    "postgresql:///postgres?host=/run/postgresql",
+    "postgresql:///postgres?host=/var/run/postgresql",
+    "postgresql:///postgres?host=/tmp",
+)
+
+
+def _discover_socket_dir() -> str | None:
+    """Return the server's unix socket directory, or None if unusable.
+
+    None is returned when the client tools are missing, no candidate DSN
+    connects, or the connecting role cannot create databases — all of which make
+    an end-to-end restore test inapplicable rather than failed.
+    """
+    psycopg = pytest.importorskip("psycopg")
+    if not all(shutil.which(tool) for tool in ("pg_dump", "pg_restore")):
+        return None
+    for dsn in _CANDIDATE_DSNS:
+        try:
+            with psycopg.connect(dsn, autocommit=True) as conn:
+                socket_dirs, can_create = conn.execute(
+                    "SELECT current_setting('unix_socket_directories'), "
+                    "(SELECT rolcreatedb OR rolsuper FROM pg_roles "
+                    " WHERE rolname = current_user)"
+                ).fetchone()
+        except Exception:
+            continue
+        if not can_create:
+            return None
+        return socket_dirs.split(",")[0].strip()
+    return None
+
+
+@pytest.fixture
+def socket_dir() -> str:
+    """The local PostgreSQL socket directory, or skip."""
+    resolved = _discover_socket_dir()
+    if resolved is None:
+        pytest.skip("local PostgreSQL with createdb privilege not available")  # ty: ignore[too-many-positional-arguments]
+    return resolved
 
 
 def _hold_flock(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,17 +5,29 @@ named lock file and holds it until a release event fires. Used by the
 self-upgrade drain regression test to model an in-flight deploy without
 patching the locking primitives.
 
-``socket_dir`` yields the local PostgreSQL server's unix socket directory, and
-skips the test when there is no usable server. Shared because more than one
-end-to-end restore test needs a real ``pg_dump``/``pg_restore`` round trip and
-"is a database reachable here" is one fact, not one per test module.
+``pg_target`` yields a PostgreSQL server these tests may create databases on,
+and skips when there is none. Shared because more than one end-to-end restore
+test needs a real ``pg_dump``/``pg_restore`` round trip and "is a database
+reachable here" is one fact, not one per test module.
+
+It discovers **two transports**, and that is not a convenience. A developer runs
+these against a local server over a unix socket; every CI workflow provides one
+as a service container reachable over TCP only, with no socket shared into the
+runner. A harness that looked for a socket alone found nothing in CI, the
+fixture skipped, and eighteen tests carrying #358's central guarantee reported
+green without ever executing. Discovery therefore takes ``FRAISIER_TEST_PG_URL``
+first, and :class:`PgTarget` builds per-database DSNs over whichever transport
+was found — so no test module has to know which one it got.
 """
 
 from __future__ import annotations
 
 import multiprocessing
+import os
 import shutil
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote, unquote, urlparse
 
 import pytest
 
@@ -25,46 +37,119 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from pathlib import Path
 
-_CANDIDATE_DSNS = (
-    "postgresql:///postgres",
-    "postgresql:///postgres?host=/run/postgresql",
-    "postgresql:///postgres?host=/var/run/postgresql",
-    "postgresql:///postgres?host=/tmp",
+#: Probed and created against, because that is what the tests do: every one of
+#: them connects here to ``CREATE``/``DROP`` its own database.
+_MAINTENANCE_DB = "postgres"
+
+_CANDIDATE_SOCKET_DSNS = (
+    f"postgresql:///{_MAINTENANCE_DB}",
+    f"postgresql:///{_MAINTENANCE_DB}?host=/run/postgresql",
+    f"postgresql:///{_MAINTENANCE_DB}?host=/var/run/postgresql",
+    f"postgresql:///{_MAINTENANCE_DB}?host=/tmp",
 )
 
 
-def _discover_socket_dir() -> str | None:
-    """Return the server's unix socket directory, or None if unusable.
+@dataclass(frozen=True)
+class PgTarget:
+    """A server the integration tests may create databases on.
 
-    None is returned when the client tools are missing, no candidate DSN
-    connects, or the connecting role cannot create databases — all of which make
-    an end-to-end restore test inapplicable rather than failed.
+    ``host`` is either a directory — libpq reads a leading ``/`` as a unix
+    socket directory — or a hostname reached over TCP. ``dsn`` is the only thing
+    a test needs: it hands back a URL for one database, in the form the
+    discovered transport requires.
+    """
+
+    host: str
+    port: int | None = None
+    user: str | None = None
+    password: str | None = None
+
+    @property
+    def over_socket(self) -> bool:
+        return self.host.startswith("/")
+
+    def dsn(self, db_name: str) -> str:
+        """A connection URL for *db_name* on this server."""
+        if self.over_socket:
+            return f"postgresql:///{db_name}?host={self.host}"
+        netloc = f"{self.host}:{self.port}" if self.port else self.host
+        if self.user:
+            credentials = quote(self.user, safe="")
+            if self.password:
+                credentials = f"{credentials}:{quote(self.password, safe='')}"
+            netloc = f"{credentials}@{netloc}"
+        return f"postgresql://{netloc}/{db_name}"
+
+
+def _probe(dsn: str) -> str | None:
+    """Is *dsn* usable for these tests, and where is that server's socket?
+
+    Returns the server's first unix socket directory, or None when the DSN did
+    not connect or the role it connects as cannot create databases — both of
+    which make an end-to-end restore test inapplicable rather than failed.
+
+    The socket directory is returned because a socket candidate has to be
+    re-addressed by the path the *server* reports rather than the one that
+    happened to connect: ``postgresql:///postgres`` carries no host at all, and
+    ``pg_dump`` needs somewhere to point.
     """
     psycopg = pytest.importorskip("psycopg")
-    if not all(shutil.which(tool) for tool in ("pg_dump", "pg_restore")):
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            socket_dirs, can_create = conn.execute(
+                "SELECT current_setting('unix_socket_directories'), "
+                "(SELECT rolcreatedb OR rolsuper FROM pg_roles "
+                " WHERE rolname = current_user)"
+            ).fetchone()
+    except Exception:
         return None
-    for dsn in _CANDIDATE_DSNS:
-        try:
-            with psycopg.connect(dsn, autocommit=True) as conn:
-                socket_dirs, can_create = conn.execute(
-                    "SELECT current_setting('unix_socket_directories'), "
-                    "(SELECT rolcreatedb OR rolsuper FROM pg_roles "
-                    " WHERE rolname = current_user)"
-                ).fetchone()
-        except Exception:
-            continue
-        if not can_create:
-            return None
-        return socket_dirs.split(",")[0].strip()
+    if not can_create:
+        return None
+    return socket_dirs.split(",")[0].strip()
+
+
+def _env_target() -> PgTarget | None:
+    """The server named by ``FRAISIER_TEST_PG_URL``, if it names one."""
+    parsed = urlparse(os.getenv("FRAISIER_TEST_PG_URL", ""))
+    if not parsed.hostname:
+        return None
+    return PgTarget(
+        host=parsed.hostname,
+        port=parsed.port,
+        user=unquote(parsed.username) if parsed.username else None,
+        password=unquote(parsed.password) if parsed.password else None,
+    )
+
+
+def _discover_target() -> PgTarget | None:
+    """Return a server to run against, or None if there is none.
+
+    ``FRAISIER_TEST_PG_URL`` is tried first — it is the server CI provides — and
+    a local socket second. An env URL that does not answer falls through rather
+    than deciding the question, so a stale variable cannot hide a working local
+    server.
+    """
+    pytest.importorskip("psycopg")
+    if not all(shutil.which(tool) for tool in ("psql", "pg_dump", "pg_restore")):
+        return None
+
+    from_env = _env_target()
+    if from_env is not None and _probe(from_env.dsn(_MAINTENANCE_DB)) is not None:
+        return from_env
+
+    for dsn in _CANDIDATE_SOCKET_DSNS:
+        socket_dir = _probe(dsn)
+        if socket_dir is not None:
+            return PgTarget(host=socket_dir)
     return None
 
 
 @pytest.fixture
-def socket_dir() -> str:
-    """The local PostgreSQL socket directory, or skip."""
-    resolved = _discover_socket_dir()
+def pg_target() -> PgTarget:
+    """A PostgreSQL server with createdb privilege, or skip."""
+    resolved = _discover_target()
     if resolved is None:
-        pytest.skip("local PostgreSQL with createdb privilege not available")  # ty: ignore[too-many-positional-arguments]
+        pytest.skip("no PostgreSQL with createdb privilege is reachable")  # ty: ignore[too-many-positional-arguments]
     return resolved
 
 

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -9,17 +9,22 @@ fraisier, and the matview must come out populated with the deferral accounting
 reported — the unit tests only prove the options handed to confiture, not that
 the two actually run together.
 
-Skipped unless a local PostgreSQL with ``createdb`` privilege and the client
-tools (``pg_dump`` / ``pg_restore``) are reachable — the shared ``socket_dir``
-fixture in ``conftest.py`` decides that.
+Skipped unless a PostgreSQL with ``createdb`` privilege and the client tools
+(``pg_dump`` / ``pg_restore``) are reachable — over a unix socket locally, or
+over TCP against CI's service container. The shared ``pg_target`` fixture in
+``conftest.py`` decides that.
 """
 
 from __future__ import annotations
 
 import contextlib
 import subprocess
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from tests.integration.conftest import PgTarget
 
 pytestmark = pytest.mark.integration
 
@@ -29,24 +34,20 @@ _SRC_DB = "fraisier_it_mv_src"
 _DST_DB = "fraisier_it_mv_dst"
 
 
-def _dsn(db: str, socket_dir: str) -> str:
-    return f"postgresql:///{db}?host={socket_dir}"
-
-
-def _exec(db: str, socket_dir: str, *statements: str) -> None:
-    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+def _exec(db: str, target: PgTarget, *statements: str) -> None:
+    with psycopg.connect(target.dsn(db), autocommit=True) as conn:
         for statement in statements:
             conn.execute(statement)
 
 
-def _drop_databases(socket_dir: str) -> None:
+def _drop_databases(target: PgTarget) -> None:
     for db in (_SRC_DB, _DST_DB):
         with contextlib.suppress(Exception):
-            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
+            _exec("postgres", target, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
 
 
 @pytest.mark.parametrize("jobs", [1, 4])
-def test_restore_backup_populates_matview_end_to_end(socket_dir, tmp_path, jobs):
+def test_restore_backup_populates_matview_end_to_end(pg_target, tmp_path, jobs):
     """A restored backup with a populated matview comes out populated.
 
     Proves confiture's deferred-refresh path runs through fraisier for both the
@@ -59,12 +60,12 @@ def test_restore_backup_populates_matview_end_to_end(socket_dir, tmp_path, jobs)
     from fraisier.dbops.restore import restore_backup
 
     dump_path = tmp_path / "src.dump"
-    _drop_databases(socket_dir)
+    _drop_databases(pg_target)
     try:
-        _exec("postgres", socket_dir, f"CREATE DATABASE {_SRC_DB}")
+        _exec("postgres", pg_target, f"CREATE DATABASE {_SRC_DB}")
         _exec(
             _SRC_DB,
-            socket_dir,
+            pg_target,
             "CREATE TABLE t (id int PRIMARY KEY, label text)",
             "INSERT INTO t SELECT g, 'row' || g FROM generate_series(1, 500) g",
             "CREATE MATERIALIZED VIEW mv AS "
@@ -74,17 +75,17 @@ def test_restore_backup_populates_matview_end_to_end(socket_dir, tmp_path, jobs)
         # confiture's three-phase restore requires custom (-Fc) or directory
         # format; a plain SQL dump is rejected.
         subprocess.run(
-            ["pg_dump", "-Fc", "-h", socket_dir, "-d", _SRC_DB, "-f", str(dump_path)],
+            ["pg_dump", "-Fc", "-d", pg_target.dsn(_SRC_DB), "-f", str(dump_path)],
             check=True,
             capture_output=True,
             text=True,
         )
-        _exec("postgres", socket_dir, f"CREATE DATABASE {_DST_DB}")
+        _exec("postgres", pg_target, f"CREATE DATABASE {_DST_DB}")
 
         result = restore_backup(
             backup_path=str(dump_path),
             db_name=_DST_DB,
-            connection_url=_dsn("postgres", socket_dir),
+            connection_url=pg_target.dsn("postgres"),
             jobs=jobs,
         )
 
@@ -95,11 +96,11 @@ def test_restore_backup_populates_matview_end_to_end(socket_dir, tmp_path, jobs)
         assert result.matviews_refreshed == 1
         assert result.analyze_ran is True
 
-        with psycopg.connect(_dsn(_DST_DB, socket_dir)) as conn:
+        with psycopg.connect(pg_target.dsn(_DST_DB)) as conn:
             table_rows = conn.execute("SELECT count(*) FROM t").fetchone()[0]
             matview_rows = conn.execute("SELECT count(*) FROM mv").fetchone()[0]
         assert table_rows == 500
         # Populated by the deferred refresh — not left empty.
         assert matview_rows == 500
     finally:
-        _drop_databases(socket_dir)
+        _drop_databases(pg_target)

--- a/tests/integration/test_restore_matview_deferral.py
+++ b/tests/integration/test_restore_matview_deferral.py
@@ -10,13 +10,13 @@ reported — the unit tests only prove the options handed to confiture, not that
 the two actually run together.
 
 Skipped unless a local PostgreSQL with ``createdb`` privilege and the client
-tools (``pg_dump`` / ``pg_restore``) are reachable.
+tools (``pg_dump`` / ``pg_restore``) are reachable — the shared ``socket_dir``
+fixture in ``conftest.py`` decides that.
 """
 
 from __future__ import annotations
 
 import contextlib
-import shutil
 import subprocess
 
 import pytest
@@ -27,45 +27,6 @@ psycopg = pytest.importorskip("psycopg")
 
 _SRC_DB = "fraisier_it_mv_src"
 _DST_DB = "fraisier_it_mv_dst"
-_CANDIDATE_DSNS = (
-    "postgresql:///postgres",
-    "postgresql:///postgres?host=/run/postgresql",
-    "postgresql:///postgres?host=/var/run/postgresql",
-    "postgresql:///postgres?host=/tmp",
-)
-
-
-def _discover_socket_dir() -> str | None:
-    """Return the server's unix socket directory, or None if unusable.
-
-    None is returned when the client tools are missing, no candidate DSN
-    connects, or the connecting role cannot create databases — all of which make
-    this end-to-end test inapplicable rather than failed.
-    """
-    if not all(shutil.which(tool) for tool in ("pg_dump", "pg_restore")):
-        return None
-    for dsn in _CANDIDATE_DSNS:
-        try:
-            with psycopg.connect(dsn, autocommit=True) as conn:
-                socket_dirs, can_create = conn.execute(
-                    "SELECT current_setting('unix_socket_directories'), "
-                    "(SELECT rolcreatedb OR rolsuper FROM pg_roles "
-                    " WHERE rolname = current_user)"
-                ).fetchone()
-        except Exception:
-            continue
-        if not can_create:
-            return None
-        return socket_dirs.split(",")[0].strip()
-    return None
-
-
-@pytest.fixture
-def socket_dir() -> str:
-    resolved = _discover_socket_dir()
-    if resolved is None:
-        pytest.skip("local PostgreSQL with createdb privilege not available")  # ty: ignore[too-many-positional-arguments]
-    return resolved
 
 
 def _dsn(db: str, socket_dir: str) -> str:

--- a/tests/integration/test_restore_receipt_roundtrip.py
+++ b/tests/integration/test_restore_receipt_roundtrip.py
@@ -6,15 +6,21 @@ that a token written by one call is read back by another, and — the part that
 matters to every floor already guarding a restore — that none of it lands in
 ``public``.
 
-Skipped unless a local PostgreSQL with ``createdb`` privilege is reachable.
+Skipped unless a PostgreSQL with ``createdb`` privilege is reachable — over a
+unix socket locally, or over TCP against CI's service container. The shared
+``pg_target`` fixture in ``conftest.py`` decides that and hands back the DSNs.
 """
 
 from __future__ import annotations
 
 import contextlib
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from tests.integration.conftest import PgTarget
 
 pytestmark = pytest.mark.integration
 
@@ -23,30 +29,26 @@ psycopg = pytest.importorskip("psycopg")
 _DB = "fraisier_it_receipt"
 
 
-def _dsn(db: str, socket_dir: str) -> str:
-    return f"postgresql:///{db}?host={socket_dir}"
-
-
-def _exec(db: str, socket_dir: str, *statements: str) -> None:
-    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+def _exec(db: str, target: PgTarget, *statements: str) -> None:
+    with psycopg.connect(target.dsn(db), autocommit=True) as conn:
         for statement in statements:
             conn.execute(statement)
 
 
 @pytest.fixture
-def receipt_db(socket_dir):
+def receipt_db(pg_target):
     """An empty database to write receipts into."""
     with contextlib.suppress(Exception):
-        _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
-    _exec("postgres", socket_dir, f"CREATE DATABASE {_DB}")
+        _exec("postgres", pg_target, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
+    _exec("postgres", pg_target, f"CREATE DATABASE {_DB}")
     try:
-        yield socket_dir
+        yield pg_target
     finally:
         with contextlib.suppress(Exception):
-            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
+            _exec("postgres", pg_target, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
 
 
-def _receipt(run_id: str):
+def _receipt(run_id: str, floor_schema: str | None = None):
     from fraisier.dbops.receipt import RestoreReceipt
 
     return RestoreReceipt(
@@ -55,6 +57,7 @@ def _receipt(run_id: str):
         backup_bytes=123456,
         restored_at=datetime.now(UTC),
         age_seconds=0.0,
+        floor_schema=floor_schema,
     )
 
 
@@ -63,7 +66,7 @@ def test_a_database_with_no_receipt_reads_missing(receipt_db):
     from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
 
     check = verify_actuation(
-        _DB, connection_url=_dsn("postgres", receipt_db), max_age_hours=24
+        _DB, connection_url=receipt_db.dsn("postgres"), max_age_hours=24
     )
     assert check.verdict is ActuationVerdict.MISSING
     assert check.is_bad is False
@@ -76,7 +79,7 @@ def test_written_receipt_reads_back_and_matches_its_token(receipt_db):
         write_receipt,
     )
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     assert write_receipt(_DB, connection_url=url, receipt=_receipt("run-one")) is None
 
     check = verify_actuation(_DB, connection_url=url, expected_run_id="run-one")
@@ -106,10 +109,10 @@ def test_the_receipt_stays_out_of_public(receipt_db):
     """
     from fraisier.dbops.receipt import RECEIPT_SCHEMA, write_receipt
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     assert write_receipt(_DB, connection_url=url, receipt=_receipt("run-one")) is None
 
-    with psycopg.connect(_dsn(_DB, receipt_db)) as conn:
+    with psycopg.connect(receipt_db.dsn(_DB)) as conn:
         public_tables = conn.execute(
             "SELECT count(*) FROM pg_catalog.pg_class c "
             "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
@@ -125,15 +128,112 @@ def test_the_receipt_stays_out_of_public(receipt_db):
     assert own_tables == 1
 
 
+def test_the_schema_the_floor_covered_survives_the_round_trip(receipt_db):
+    """Recorded as data, read back as the default for the mtime cross-check.
+
+    A schema name is bound like every other value, so a host whose heaps live in
+    ``tenant`` gets ``tenant`` back without the operator naming it — and a name
+    with a quote in it is still data.
+    """
+    from fraisier.dbops.receipt import verify_actuation, write_receipt
+
+    url = receipt_db.dsn("postgres")
+    assert (
+        write_receipt(_DB, connection_url=url, receipt=_receipt("run-one", "tenant"))
+        is None
+    )
+
+    check = verify_actuation(_DB, connection_url=url, expected_run_id="run-one")
+    assert check.receipt is not None
+    assert check.receipt.floor_schema == "tenant"
+
+
+def test_a_receipt_recording_no_schema_reads_back_as_none(receipt_db):
+    """NULL, not the empty string psql binds a missing value as."""
+    from fraisier.dbops.receipt import verify_actuation, write_receipt
+
+    url = receipt_db.dsn("postgres")
+    write_receipt(_DB, connection_url=url, receipt=_receipt("run-one"))
+
+    check = verify_actuation(_DB, connection_url=url, expected_run_id="run-one")
+    assert check.receipt is not None
+    assert check.receipt.floor_schema is None
+
+    with psycopg.connect(receipt_db.dsn(_DB)) as conn:
+        stored = conn.execute("SELECT floor_schema FROM fraisier.restore_receipt")
+        assert stored.fetchone()[0] is None
+
+
+def test_a_receipt_predating_the_column_is_still_readable(receipt_db):
+    """``CREATE TABLE IF NOT EXISTS`` never migrates, so the read must not care.
+
+    A database restored by a fraisier that wrote the four-column receipt keeps
+    that table for as long as nothing drops it. Degrading it to UNVERIFIABLE
+    would report "could not check" about a receipt sitting right there.
+    """
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
+
+    _exec(
+        _DB,
+        receipt_db,
+        "CREATE SCHEMA fraisier",
+        "CREATE TABLE fraisier.restore_receipt ("
+        " run_id text PRIMARY KEY, backup_path text NOT NULL,"
+        " backup_bytes bigint NOT NULL,"
+        " restored_at timestamptz NOT NULL DEFAULT now())",
+        "INSERT INTO fraisier.restore_receipt (run_id, backup_path, backup_bytes) "
+        "VALUES ('run-old', '/backup/old.dump', 99)",
+    )
+
+    check = verify_actuation(
+        _DB, connection_url=receipt_db.dsn("postgres"), max_age_hours=24
+    )
+
+    assert check.verdict is ActuationVerdict.ACTUATED
+    assert check.receipt is not None
+    assert check.receipt.run_id == "run-old"
+    assert check.receipt.floor_schema is None
+
+
+def test_a_failed_write_leaves_the_standing_receipt_intact(receipt_db):
+    """The write is one transaction, so a failure part-way changes nothing.
+
+    The script deletes the standing receipt before inserting the new one. Run as
+    separate statements, a failure between the two commits the delete and leaves
+    the table present and empty — which reads as MISSING, a database claiming
+    that no run has ever written it. That is a worse answer than the truth.
+    """
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation, write_receipt
+
+    url = receipt_db.dsn("postgres")
+    assert write_receipt(_DB, connection_url=url, receipt=_receipt("run-one")) is None
+
+    # Fail the INSERT specifically, after the DELETE has already run.
+    _exec(
+        _DB,
+        receipt_db,
+        "ALTER TABLE fraisier.restore_receipt "
+        "ADD CONSTRAINT rejects_run_two CHECK (run_id <> 'run-two')",
+    )
+
+    failure = write_receipt(_DB, connection_url=url, receipt=_receipt("run-two"))
+    assert failure is not None
+
+    survivor = verify_actuation(_DB, connection_url=url, expected_run_id="run-one")
+    assert survivor.verdict is ActuationVerdict.ACTUATED
+    assert survivor.receipt is not None
+    assert survivor.receipt.run_id == "run-one"
+
+
 def test_a_second_write_replaces_the_first(receipt_db):
     """One row: "what wrote this database" has one answer, not a history."""
     from fraisier.dbops.receipt import verify_actuation, write_receipt
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     write_receipt(_DB, connection_url=url, receipt=_receipt("run-one"))
     write_receipt(_DB, connection_url=url, receipt=_receipt("run-two"))
 
-    with psycopg.connect(_dsn(_DB, receipt_db)) as conn:
+    with psycopg.connect(receipt_db.dsn(_DB)) as conn:
         rows = conn.execute("SELECT count(*) FROM fraisier.restore_receipt").fetchone()[
             0
         ]
@@ -147,7 +247,7 @@ def test_a_window_narrower_than_the_receipt_is_stale(receipt_db):
     """The age comparison is real, and it is the server that measures it."""
     from fraisier.dbops.receipt import ActuationVerdict, verify_actuation, write_receipt
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     write_receipt(_DB, connection_url=url, receipt=_receipt("run-one"))
     _exec(
         _DB,
@@ -175,7 +275,7 @@ def test_the_strategy_records_and_confirms_its_own_run(receipt_db, tmp_path):
     from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
     from fraisier.strategies import RestoreConfig, RestoreMigrateStrategy
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     backup = tmp_path / "production.dump"
     backup.write_bytes(b"x" * 2048)
 
@@ -188,13 +288,16 @@ def test_the_strategy_records_and_confirms_its_own_run(receipt_db, tmp_path):
         admin_url=url,
     )
 
-    check = strategy._record_actuation(backup, "run-alpha")
+    check = strategy._record_actuation(backup, "run-alpha", "tenant")
     assert check.verdict is ActuationVerdict.ACTUATED
     assert check.receipt is not None
     assert check.receipt.run_id == "run-alpha"
     assert check.receipt.backup_path == str(backup)
     # The size is read off the file, so the receipt names which archive.
     assert check.receipt.backup_bytes == 2048
+    # And where this database's heaps live, for the caller that reads it back
+    # the next morning with no archive to derive it from.
+    assert check.receipt.floor_schema == "tenant"
 
     # A later run that did *not* rewrite this database learns so.
     assert (
@@ -214,7 +317,7 @@ def test_relation_mtimes_against_a_real_server(receipt_db):
     """
     from fraisier.dbops.receipt import ActuationVerdict, relation_freshness
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     _exec(_DB, receipt_db, "CREATE TABLE fresh_table (id int)")
 
     check = relation_freshness(
@@ -239,7 +342,7 @@ def test_an_empty_schema_is_unverifiable_against_a_real_server(receipt_db):
     check = relation_freshness(
         _DB,
         schema="public",
-        connection_url=_dsn("postgres", receipt_db),
+        connection_url=receipt_db.dsn("postgres"),
         within_hours=24,
     )
 
@@ -251,7 +354,7 @@ def test_a_quoted_backup_path_does_not_break_the_write(receipt_db):
     """Values bind as psql variables, so a quote in a path is data."""
     from fraisier.dbops.receipt import RestoreReceipt, verify_actuation, write_receipt
 
-    url = _dsn("postgres", receipt_db)
+    url = receipt_db.dsn("postgres")
     nasty = "/backup/o'brien'; DROP TABLE fraisier.restore_receipt; --.dump"
     receipt = RestoreReceipt(
         run_id="run-quote",

--- a/tests/integration/test_restore_receipt_roundtrip.py
+++ b/tests/integration/test_restore_receipt_roundtrip.py
@@ -1,0 +1,268 @@
+"""The actuation receipt against a real PostgreSQL (#358).
+
+The unit tests prove what fraisier does with ``psql``'s output. These prove the
+SQL is SQL: that the schema and table are created where they are supposed to be,
+that a token written by one call is read back by another, and — the part that
+matters to every floor already guarding a restore — that none of it lands in
+``public``.
+
+Skipped unless a local PostgreSQL with ``createdb`` privilege is reachable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+psycopg = pytest.importorskip("psycopg")
+
+_DB = "fraisier_it_receipt"
+
+
+def _dsn(db: str, socket_dir: str) -> str:
+    return f"postgresql:///{db}?host={socket_dir}"
+
+
+def _exec(db: str, socket_dir: str, *statements: str) -> None:
+    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+        for statement in statements:
+            conn.execute(statement)
+
+
+@pytest.fixture
+def receipt_db(socket_dir):
+    """An empty database to write receipts into."""
+    with contextlib.suppress(Exception):
+        _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
+    _exec("postgres", socket_dir, f"CREATE DATABASE {_DB}")
+    try:
+        yield socket_dir
+    finally:
+        with contextlib.suppress(Exception):
+            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DB} WITH (FORCE)")
+
+
+def _receipt(run_id: str):
+    from fraisier.dbops.receipt import RestoreReceipt
+
+    return RestoreReceipt(
+        run_id=run_id,
+        backup_path="/backup/production/latest.dump",
+        backup_bytes=123456,
+        restored_at=datetime.now(UTC),
+        age_seconds=0.0,
+    )
+
+
+def test_a_database_with_no_receipt_reads_missing(receipt_db):
+    """MISSING, not STALE: nothing has been claimed about this database yet."""
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
+
+    check = verify_actuation(
+        _DB, connection_url=_dsn("postgres", receipt_db), max_age_hours=24
+    )
+    assert check.verdict is ActuationVerdict.MISSING
+    assert check.is_bad is False
+
+
+def test_written_receipt_reads_back_and_matches_its_token(receipt_db):
+    from fraisier.dbops.receipt import (
+        ActuationVerdict,
+        verify_actuation,
+        write_receipt,
+    )
+
+    url = _dsn("postgres", receipt_db)
+    assert write_receipt(_DB, connection_url=url, receipt=_receipt("run-one")) is None
+
+    check = verify_actuation(_DB, connection_url=url, expected_run_id="run-one")
+    assert check.verdict is ActuationVerdict.ACTUATED
+    assert check.receipt is not None
+    assert check.receipt.backup_path == "/backup/production/latest.dump"
+    assert check.receipt.backup_bytes == 123456
+    # Written seconds ago by the server's own clock.
+    assert check.receipt.age_seconds < 60
+
+    # The failure this whole mechanism exists for: a later run asks whether *it*
+    # rewrote the database, and the answer is no — someone else's receipt is
+    # still there.
+    later = verify_actuation(_DB, connection_url=url, expected_run_id="run-two")
+    assert later.verdict is ActuationVerdict.STALE
+    assert later.is_bad is True
+    assert later.receipt is not None
+    assert later.receipt.run_id == "run-one"
+
+
+def test_the_receipt_stays_out_of_public(receipt_db):
+    """No floor that guards a restore may be moved by a bookkeeping row.
+
+    confiture's pre-migration counter and ``validate_table_count`` both count
+    ``relkind='r'`` in one schema. A receipt in ``public`` would raise both by
+    one, quietly, on every host.
+    """
+    from fraisier.dbops.receipt import RECEIPT_SCHEMA, write_receipt
+
+    url = _dsn("postgres", receipt_db)
+    assert write_receipt(_DB, connection_url=url, receipt=_receipt("run-one")) is None
+
+    with psycopg.connect(_dsn(_DB, receipt_db)) as conn:
+        public_tables = conn.execute(
+            "SELECT count(*) FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relkind = 'r' AND n.nspname = 'public'"
+        ).fetchone()[0]
+        own_tables = conn.execute(
+            "SELECT count(*) FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relkind = 'r' AND n.nspname = %s",
+            (RECEIPT_SCHEMA,),
+        ).fetchone()[0]
+    assert public_tables == 0
+    assert own_tables == 1
+
+
+def test_a_second_write_replaces_the_first(receipt_db):
+    """One row: "what wrote this database" has one answer, not a history."""
+    from fraisier.dbops.receipt import verify_actuation, write_receipt
+
+    url = _dsn("postgres", receipt_db)
+    write_receipt(_DB, connection_url=url, receipt=_receipt("run-one"))
+    write_receipt(_DB, connection_url=url, receipt=_receipt("run-two"))
+
+    with psycopg.connect(_dsn(_DB, receipt_db)) as conn:
+        rows = conn.execute("SELECT count(*) FROM fraisier.restore_receipt").fetchone()[
+            0
+        ]
+    assert rows == 1
+    assert verify_actuation(
+        _DB, connection_url=url, expected_run_id="run-two"
+    ).is_actuated
+
+
+def test_a_window_narrower_than_the_receipt_is_stale(receipt_db):
+    """The age comparison is real, and it is the server that measures it."""
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation, write_receipt
+
+    url = _dsn("postgres", receipt_db)
+    write_receipt(_DB, connection_url=url, receipt=_receipt("run-one"))
+    _exec(
+        _DB,
+        receipt_db,
+        "UPDATE fraisier.restore_receipt SET restored_at = now() - interval '30 hours'",
+    )
+
+    stale = verify_actuation(_DB, connection_url=url, max_age_hours=24)
+    assert stale.verdict is ActuationVerdict.STALE
+    assert stale.receipt is not None
+    assert 29 < stale.receipt.age_hours < 31
+
+    assert verify_actuation(_DB, connection_url=url, max_age_hours=48).is_actuated
+
+
+def test_the_strategy_records_and_confirms_its_own_run(receipt_db, tmp_path):
+    """The pipeline's receipt step, end to end, against real SQL.
+
+    The unit tests mock the seam and prove the strategy calls it correctly. This
+    proves the call works: the strategy's own ``_record_actuation`` writes a
+    token into a real database and reads it back as ACTUATED, and a *different*
+    run asking the same database gets STALE rather than a shrug.
+    """
+    from fraisier.config.schema import PreflightConfig
+    from fraisier.dbops.receipt import ActuationVerdict, verify_actuation
+    from fraisier.strategies import RestoreConfig, RestoreMigrateStrategy
+
+    url = _dsn("postgres", receipt_db)
+    backup = tmp_path / "production.dump"
+    backup.write_bytes(b"x" * 2048)
+
+    strategy = RestoreMigrateStrategy(
+        RestoreConfig(
+            db_name=_DB,
+            backup_dir=tmp_path,
+            preflight=PreflightConfig(enabled=False),
+        ),
+        admin_url=url,
+    )
+
+    check = strategy._record_actuation(backup, "run-alpha")
+    assert check.verdict is ActuationVerdict.ACTUATED
+    assert check.receipt is not None
+    assert check.receipt.run_id == "run-alpha"
+    assert check.receipt.backup_path == str(backup)
+    # The size is read off the file, so the receipt names which archive.
+    assert check.receipt.backup_bytes == 2048
+
+    # A later run that did *not* rewrite this database learns so.
+    assert (
+        verify_actuation(_DB, connection_url=url, expected_run_id="run-beta").verdict
+        is ActuationVerdict.STALE
+    )
+
+
+def test_relation_mtimes_against_a_real_server(receipt_db):
+    """The mtime cross-check, run for real — whichever way this role is allowed.
+
+    Two outcomes are both correct and both asserted, because which one happens
+    is a property of the server rather than of the code: a role that may call
+    ``pg_stat_file`` sees the just-written table as fresh, and a role that may
+    not gets UNVERIFIABLE naming the privilege. What must never happen is a
+    denial reading as a pass.
+    """
+    from fraisier.dbops.receipt import ActuationVerdict, relation_freshness
+
+    url = _dsn("postgres", receipt_db)
+    _exec(_DB, receipt_db, "CREATE TABLE fresh_table (id int)")
+
+    check = relation_freshness(
+        _DB, schema="public", connection_url=url, within_hours=24
+    )
+
+    assert check.verdict in {
+        ActuationVerdict.ACTUATED,
+        ActuationVerdict.UNVERIFIABLE,
+    }, check.detail
+    if check.verdict is ActuationVerdict.UNVERIFIABLE:
+        assert check.is_actuated is False
+        assert "pg_read_server_files" in check.detail
+    else:
+        assert "1 base table(s)" in check.detail
+
+
+def test_an_empty_schema_is_unverifiable_against_a_real_server(receipt_db):
+    """Zero tables is not "everything is fresh"."""
+    from fraisier.dbops.receipt import ActuationVerdict, relation_freshness
+
+    check = relation_freshness(
+        _DB,
+        schema="public",
+        connection_url=_dsn("postgres", receipt_db),
+        within_hours=24,
+    )
+
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+    assert check.is_actuated is False
+
+
+def test_a_quoted_backup_path_does_not_break_the_write(receipt_db):
+    """Values bind as psql variables, so a quote in a path is data."""
+    from fraisier.dbops.receipt import RestoreReceipt, verify_actuation, write_receipt
+
+    url = _dsn("postgres", receipt_db)
+    nasty = "/backup/o'brien'; DROP TABLE fraisier.restore_receipt; --.dump"
+    receipt = RestoreReceipt(
+        run_id="run-quote",
+        backup_path=nasty,
+        backup_bytes=1,
+        restored_at=datetime.now(UTC),
+        age_seconds=0.0,
+    )
+    assert write_receipt(_DB, connection_url=url, receipt=receipt) is None
+
+    check = verify_actuation(_DB, connection_url=url, expected_run_id="run-quote")
+    assert check.is_actuated
+    assert check.receipt is not None
+    assert check.receipt.backup_path == nasty

--- a/tests/integration/test_restore_truncated_archive.py
+++ b/tests/integration/test_restore_truncated_archive.py
@@ -20,16 +20,22 @@ in ``pg_restore``'s stderr. It is asserted here at fraisier's own boundary, on
 ``restore_backup(...).success``, so a confiture bump that reclassifies those
 lines fails this test rather than a nightly.
 
-Skipped unless a local PostgreSQL with ``createdb`` privilege and the client
-tools are reachable.
+Skipped unless a PostgreSQL with ``createdb`` privilege and the client tools are
+reachable — over a unix socket locally, or over TCP against CI's service
+container. The shared ``pg_target`` fixture in ``conftest.py`` decides that; a
+promise this test makes about a confiture bump is only kept where it runs.
 """
 
 from __future__ import annotations
 
 import contextlib
 import subprocess
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from tests.integration.conftest import PgTarget
 
 pytestmark = pytest.mark.integration
 
@@ -49,37 +55,33 @@ _ROWS = 20_000
 _CUT_FRACTIONS = (0.5, 0.9, 0.98)
 
 
-def _dsn(db: str, socket_dir: str) -> str:
-    return f"postgresql:///{db}?host={socket_dir}"
-
-
-def _exec(db: str, socket_dir: str, *statements: str) -> None:
-    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+def _exec(db: str, target: PgTarget, *statements: str) -> None:
+    with psycopg.connect(target.dsn(db), autocommit=True) as conn:
         for statement in statements:
             conn.execute(statement)
 
 
-def _drop_databases(socket_dir: str) -> None:
+def _drop_databases(target: PgTarget) -> None:
     for db in (_SRC_DB, _DST_DB):
         with contextlib.suppress(Exception):
-            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
+            _exec("postgres", target, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
 
 
 @pytest.fixture
-def truncated_dumps(socket_dir, tmp_path):
-    """Yield ``(socket_dir, {fraction: path})`` for one dump cut at each depth.
+def truncated_dumps(pg_target, tmp_path):
+    """Yield ``(pg_target, {fraction: path})`` for one dump cut at each depth.
 
     The source database is built and dumped once; the cuts are byte slices of
     that single dump, so every case describes the same archive truncated at a
     different point.
     """
     full = tmp_path / "src.dump"
-    _drop_databases(socket_dir)
+    _drop_databases(pg_target)
     try:
-        _exec("postgres", socket_dir, f"CREATE DATABASE {_SRC_DB}")
+        _exec("postgres", pg_target, f"CREATE DATABASE {_SRC_DB}")
         _exec(
             _SRC_DB,
-            socket_dir,
+            pg_target,
             "CREATE TABLE t (id int PRIMARY KEY, label text)",
             f"INSERT INTO t SELECT g, repeat('x', 200) || g "
             f"FROM generate_series(1, {_ROWS}) g",
@@ -89,8 +91,10 @@ def truncated_dumps(socket_dir, tmp_path):
         )
         # Custom format: confiture's three-phase restore rejects a plain SQL
         # dump, and only -Fc/-Fd carry the table of contents this is about.
+        # The whole DSN goes in as -d, which addresses either transport and
+        # carries the credentials a TCP server asks for.
         subprocess.run(
-            ["pg_dump", "-Fc", "-h", socket_dir, "-d", _SRC_DB, "-f", str(full)],
+            ["pg_dump", "-Fc", "-d", pg_target.dsn(_SRC_DB), "-f", str(full)],
             check=True,
             capture_output=True,
             text=True,
@@ -101,9 +105,9 @@ def truncated_dumps(socket_dir, tmp_path):
             cut = tmp_path / f"cut_{int(fraction * 100)}.dump"
             cut.write_bytes(payload[: int(len(payload) * fraction)])
             cuts[fraction] = cut
-        yield socket_dir, cuts
+        yield pg_target, cuts
     finally:
-        _drop_databases(socket_dir)
+        _drop_databases(pg_target)
 
 
 @pytest.mark.parametrize("fraction", _CUT_FRACTIONS)
@@ -145,17 +149,17 @@ def test_truncated_dump_fails_the_restore(truncated_dumps, fraction, jobs):
     """
     from fraisier.dbops.restore import restore_backup
 
-    socket_dir, cuts = truncated_dumps
+    pg_target, cuts = truncated_dumps
     cut = cuts[fraction]
 
     with contextlib.suppress(Exception):
-        _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DST_DB} WITH (FORCE)")
-    _exec("postgres", socket_dir, f"CREATE DATABASE {_DST_DB}")
+        _exec("postgres", pg_target, f"DROP DATABASE IF EXISTS {_DST_DB} WITH (FORCE)")
+    _exec("postgres", pg_target, f"CREATE DATABASE {_DST_DB}")
 
     result = restore_backup(
         backup_path=str(cut),
         db_name=_DST_DB,
-        connection_url=_dsn("postgres", socket_dir),
+        connection_url=pg_target.dsn("postgres"),
         jobs=jobs,
         # The floor the archive states about itself — the one v0.64.0 derives and
         # enforces. Passing it here is deliberate: the restore must fail on the

--- a/tests/integration/test_restore_truncated_archive.py
+++ b/tests/integration/test_restore_truncated_archive.py
@@ -1,0 +1,168 @@
+"""A dump truncated inside its data section must fail the restore (#358).
+
+#358 is right about the premise and this test asserts it first: a dump cut off
+partway through its ``COPY`` stream still carries a complete table of contents,
+so ``pg_restore --list`` reports every table, :func:`verify_archive` returns
+VALID, and the floor it derives is satisfied by a database containing no rows.
+Neither the archive check nor any table-count floor of any derivation can see
+the damage.
+
+What catches it is the restore itself. ``pg_restore`` cannot read past the cut,
+writes a ``pg_restore: error:`` line and exits non-zero, and confiture fails the
+section on ``returncode != 0 and (exit_on_error or errors)``
+(``restorer.py:793``). Both halves of that disjunction matter here: ``jobs > 1``
+turns ``exit_on_error`` off, because FK violations during the parallel data phase
+are transient, and the restore survives on the ``or errors`` half instead —
+tolerating a non-zero *exit* is not the same as tolerating an *error line*.
+
+That is a guard on the far side of the confiture seam, keyed on a literal string
+in ``pg_restore``'s stderr. It is asserted here at fraisier's own boundary, on
+``restore_backup(...).success``, so a confiture bump that reclassifies those
+lines fails this test rather than a nightly.
+
+Skipped unless a local PostgreSQL with ``createdb`` privilege and the client
+tools are reachable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+psycopg = pytest.importorskip("psycopg")
+
+_SRC_DB = "fraisier_it_trunc_src"
+_DST_DB = "fraisier_it_trunc_dst"
+
+#: Rows per table, sized so the data section dwarfs the table of contents and a
+#: cut at any of the fractions below lands inside a ``COPY`` stream rather than
+#: in the header.
+_ROWS = 20_000
+
+#: Where to cut, as a fraction of the whole dump. Three depths, because the
+#: failure mode differs down the file: an early cut loses a whole block, a late
+#: one truncates the final table after earlier ones have loaded intact.
+_CUT_FRACTIONS = (0.5, 0.9, 0.98)
+
+
+def _dsn(db: str, socket_dir: str) -> str:
+    return f"postgresql:///{db}?host={socket_dir}"
+
+
+def _exec(db: str, socket_dir: str, *statements: str) -> None:
+    with psycopg.connect(_dsn(db, socket_dir), autocommit=True) as conn:
+        for statement in statements:
+            conn.execute(statement)
+
+
+def _drop_databases(socket_dir: str) -> None:
+    for db in (_SRC_DB, _DST_DB):
+        with contextlib.suppress(Exception):
+            _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {db} WITH (FORCE)")
+
+
+@pytest.fixture
+def truncated_dumps(socket_dir, tmp_path):
+    """Yield ``(socket_dir, {fraction: path})`` for one dump cut at each depth.
+
+    The source database is built and dumped once; the cuts are byte slices of
+    that single dump, so every case describes the same archive truncated at a
+    different point.
+    """
+    full = tmp_path / "src.dump"
+    _drop_databases(socket_dir)
+    try:
+        _exec("postgres", socket_dir, f"CREATE DATABASE {_SRC_DB}")
+        _exec(
+            _SRC_DB,
+            socket_dir,
+            "CREATE TABLE t (id int PRIMARY KEY, label text)",
+            f"INSERT INTO t SELECT g, repeat('x', 200) || g "
+            f"FROM generate_series(1, {_ROWS}) g",
+            "CREATE TABLE t2 (id int PRIMARY KEY, label text)",
+            f"INSERT INTO t2 SELECT g, repeat('y', 200) || g "
+            f"FROM generate_series(1, {_ROWS}) g",
+        )
+        # Custom format: confiture's three-phase restore rejects a plain SQL
+        # dump, and only -Fc/-Fd carry the table of contents this is about.
+        subprocess.run(
+            ["pg_dump", "-Fc", "-h", socket_dir, "-d", _SRC_DB, "-f", str(full)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = full.read_bytes()
+        cuts = {}
+        for fraction in _CUT_FRACTIONS:
+            cut = tmp_path / f"cut_{int(fraction * 100)}.dump"
+            cut.write_bytes(payload[: int(len(payload) * fraction)])
+            cuts[fraction] = cut
+        yield socket_dir, cuts
+    finally:
+        _drop_databases(socket_dir)
+
+
+@pytest.mark.parametrize("fraction", _CUT_FRACTIONS)
+def test_truncated_dump_still_passes_every_check_that_precedes_the_restore(
+    truncated_dumps, fraction
+):
+    """The premise of #358: nothing before the restore can see the truncation.
+
+    This is the half of the issue that is correct and stays correct. It is
+    asserted so that a future change which *does* let an earlier check catch a
+    truncated dump is noticed here rather than assumed.
+    """
+    from fraisier.dbops.archive import ArchiveVerdict, verify_archive
+
+    _, cuts = truncated_dumps
+    cut = cuts[fraction]
+
+    listed = subprocess.run(
+        ["pg_restore", "--list", str(cut)], capture_output=True, text=True, check=False
+    )
+    assert listed.returncode == 0, listed.stderr
+
+    check = verify_archive(cut)
+    assert check.verdict is ArchiveVerdict.VALID
+    assert check.is_bad is False
+    # Both tables are still described by the table of contents, so the floor the
+    # archive states about itself is met by the empty schema a truncated restore
+    # would leave behind.
+    assert check.schema_floor == ("public", 2)
+
+
+@pytest.mark.parametrize("fraction", _CUT_FRACTIONS)
+@pytest.mark.parametrize("jobs", [1, 4])
+def test_truncated_dump_fails_the_restore(truncated_dumps, fraction, jobs):
+    """The restore fails on a truncated archive, serially and in parallel.
+
+    ``jobs=1`` keeps confiture's fail-fast ``exit_on_error``; ``jobs=4`` turns it
+    off and must still fail, on the error lines rather than the exit status.
+    """
+    from fraisier.dbops.restore import restore_backup
+
+    socket_dir, cuts = truncated_dumps
+    cut = cuts[fraction]
+
+    with contextlib.suppress(Exception):
+        _exec("postgres", socket_dir, f"DROP DATABASE IF EXISTS {_DST_DB} WITH (FORCE)")
+    _exec("postgres", socket_dir, f"CREATE DATABASE {_DST_DB}")
+
+    result = restore_backup(
+        backup_path=str(cut),
+        db_name=_DST_DB,
+        connection_url=_dsn("postgres", socket_dir),
+        jobs=jobs,
+        # The floor the archive states about itself — the one v0.64.0 derives and
+        # enforces. Passing it here is deliberate: the restore must fail on the
+        # truncation even with the floor armed, because the floor cannot see it.
+        min_tables=2,
+        min_tables_schema="public",
+    )
+
+    assert result.success is False
+    assert result.error, "a failed restore must say why"

--- a/tests/test_cli_db_receipt.py
+++ b/tests/test_cli_db_receipt.py
@@ -24,7 +24,7 @@ from fraisier.dbops.receipt import ActuationCheck, ActuationVerdict, RestoreRece
 _ADMIN_URL = "postgresql://postgres@localhost:5432/postgres"
 
 
-def _receipt(run_id="run-7", age_hours=1.5):
+def _receipt(run_id="run-7", age_hours=1.5, floor_schema=None):
     from datetime import UTC, datetime
 
     return RestoreReceipt(
@@ -33,10 +33,17 @@ def _receipt(run_id="run-7", age_hours=1.5):
         backup_bytes=987654,
         restored_at=datetime(2026, 8, 10, 3, 0, tzinfo=UTC),
         age_seconds=age_hours * 3600,
+        floor_schema=floor_schema,
     )
 
 
-def _config(*, max_age_hours=48.0, external=False):
+def _config(*, max_age_hours=48.0, max_actuation_age_hours=None, external=False):
+    restore = {
+        "backup_dir": "/backup/production",
+        "max_age_hours": max_age_hours,
+    }
+    if max_actuation_age_hours is not None:
+        restore["max_actuation_age_hours"] = max_actuation_age_hours
     config = MagicMock()
     config.get_fraise.return_value = {"type": "api", "external_db": external}
     config.get_fraise_environment.return_value = {
@@ -45,10 +52,7 @@ def _config(*, max_age_hours=48.0, external=False):
         "database": {
             "name": "mydb_staging",
             "admin_url": _ADMIN_URL,
-            "restore": {
-                "backup_dir": "/backup/production",
-                "max_age_hours": max_age_hours,
-            },
+            "restore": restore,
         },
     }
     config._config = {"backup": {}}
@@ -112,12 +116,46 @@ class TestTheThreeAnswersHaveThreeExits:
 
 
 class TestTheWindow:
-    def test_the_restores_own_max_age_is_the_default(self):
-        """How stale an input may be is reused as how stale an output may be."""
+    """Two different questions, two different knobs.
+
+    ``max_age_hours`` asks how old the *backup file* may be. This command asks
+    how recently a *restore* actually ran. On a nightly cadence those numbers
+    are not the same, and the 48h a backup-age tolerance is comfortable with is
+    far too loose a window to notice that last night's restore never happened —
+    which is the failure the receipt exists to catch.
+    """
+
+    def test_the_actuation_window_is_its_own_key(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        _, verify = _invoke(check, config=_config(max_actuation_age_hours=8.0))
+
+        assert verify.call_args.kwargs["max_age_hours"] == 8.0
+
+    def test_the_backup_age_knob_does_not_move_it(self):
+        """The bug this separation removes: a 48h backup tolerance silently
+        becoming a 48h "did the restore run" window."""
+        from fraisier.cli.db import _DEFAULT_ACTUATION_WINDOW_HOURS
+
         check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
         _, verify = _invoke(check, config=_config(max_age_hours=12.0))
 
-        assert verify.call_args.kwargs["max_age_hours"] == 12.0
+        assert verify.call_args.kwargs["max_age_hours"] == (
+            _DEFAULT_ACTUATION_WINDOW_HOURS
+        )
+
+    def test_the_default_suits_a_nightly_cadence(self):
+        """Longer than a day, so a late nightly is not a page; shorter than two,
+        so a nightly that stopped running is."""
+        from fraisier.cli.db import _DEFAULT_ACTUATION_WINDOW_HOURS
+
+        assert 24.0 < _DEFAULT_ACTUATION_WINDOW_HOURS < 48.0
+
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        _, verify = _invoke(check)
+
+        assert verify.call_args.kwargs["max_age_hours"] == (
+            _DEFAULT_ACTUATION_WINDOW_HOURS
+        )
 
     def test_the_flag_overrides_it(self):
         check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
@@ -213,6 +251,8 @@ class TestTheHeapCheckCorroboratesWithoutVoting:
         assert "all 12 base table(s) fresh" in result.output
 
     def test_it_asks_about_one_named_schema(self):
+        from fraisier.cli.db import _DEFAULT_ACTUATION_WINDOW_HOURS
+
         check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
         heap = ActuationCheck(ActuationVerdict.ACTUATED, "fresh")
         _, freshness = self._invoke_with_heap(
@@ -220,7 +260,55 @@ class TestTheHeapCheckCorroboratesWithoutVoting:
         )
 
         assert freshness.call_args.kwargs["schema"] == "tenant"
-        assert freshness.call_args.kwargs["within_hours"] == 48.0
+        assert freshness.call_args.kwargs["within_hours"] == (
+            _DEFAULT_ACTUATION_WINDOW_HOURS
+        )
+
+    def test_the_schema_defaults_to_the_one_the_restore_derived(self):
+        """The operator should not have to know, and cannot be asked to.
+
+        On a host whose heaps live in ``tenant`` — #356's host — a cross-check
+        hardcoded to ``public`` finds no base tables and returns UNVERIFIABLE:
+        silence, exactly where the check is most needed. The restore knew the
+        schema, so the receipt carries it.
+        """
+        check = ActuationCheck(
+            ActuationVerdict.ACTUATED, "ok", _receipt(floor_schema="tenant")
+        )
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "fresh")
+        _, freshness = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert freshness.call_args.kwargs["schema"] == "tenant"
+
+    def test_the_flag_still_overrides_the_receipt(self):
+        check = ActuationCheck(
+            ActuationVerdict.ACTUATED, "ok", _receipt(floor_schema="tenant")
+        )
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "fresh")
+        _, freshness = self._invoke_with_heap(
+            check, heap, "--check-heap", "--heap-schema", "reporting"
+        )
+
+        assert freshness.call_args.kwargs["schema"] == "reporting"
+
+    @pytest.mark.parametrize(
+        "check",
+        [
+            ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt()),
+            ActuationCheck(ActuationVerdict.MISSING, "no receipt"),
+        ],
+        ids=["receipt-carries-none", "no-receipt-at-all"],
+    )
+    def test_it_falls_back_to_public(self, check):
+        """A receipt written before the column existed, and no receipt at all.
+
+        Both are the pre-#358 world, and both must still get a check rather than
+        a crash — ``public`` is the right guess when nothing better is recorded.
+        """
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "fresh")
+        _, freshness = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert freshness.call_args.kwargs["schema"] == "public"
 
     def test_a_stale_heap_does_not_fail_a_verified_receipt(self):
         """Autovacuum moves mtimes, so this signal cannot be allowed to vote.
@@ -259,6 +347,22 @@ class TestTheHeapCheckCorroboratesWithoutVoting:
         payload = json.loads(result.output)
         assert payload["heap"]["verdict"] == "stale"
         assert payload["heap"]["detail"] == "3 of 12 stale"
+
+    def test_json_names_the_schema_it_resolved(self):
+        """Resolved rather than given, so it has to be reported.
+
+        An operator reading UNVERIFIABLE needs to know which schema was looked
+        in before they can tell a denied privilege from an empty guess.
+        """
+        check = ActuationCheck(
+            ActuationVerdict.ACTUATED, "ok", _receipt(floor_schema="tenant")
+        )
+        heap = ActuationCheck(ActuationVerdict.UNVERIFIABLE, "no base tables")
+        result, _ = self._invoke_with_heap(check, heap, "--check-heap", "--json")
+
+        payload = json.loads(result.output)
+        assert payload["floor_schema"] == "tenant"
+        assert payload["heap"]["schema"] == "tenant"
 
     def test_json_omits_it_when_not_asked(self):
         check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())

--- a/tests/test_cli_db_receipt.py
+++ b/tests/test_cli_db_receipt.py
@@ -1,0 +1,304 @@
+"""``fraisier db receipt`` — asking the database when it was last rewritten (#358).
+
+The restore's own read-back runs inside the process that did the writing. It
+proves the write landed; it cannot prove a run happened, because when the run
+does not happen that code does not execute either. What catches the failure #343
+reported is the *durable* row: an independent caller, the next morning, asking
+staging itself.
+
+So the exit codes carry the three answers apart. A nightly that could not check
+must not exit the same way as a nightly that checked and passed — that is the
+``min_tables=0`` silent hole reappearing somewhere new.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from fraisier.dbops.receipt import ActuationCheck, ActuationVerdict, RestoreReceipt
+
+_ADMIN_URL = "postgresql://postgres@localhost:5432/postgres"
+
+
+def _receipt(run_id="run-7", age_hours=1.5):
+    from datetime import UTC, datetime
+
+    return RestoreReceipt(
+        run_id=run_id,
+        backup_path="/backup/production/latest.dump",
+        backup_bytes=987654,
+        restored_at=datetime(2026, 8, 10, 3, 0, tzinfo=UTC),
+        age_seconds=age_hours * 3600,
+    )
+
+
+def _config(*, max_age_hours=48.0, external=False):
+    config = MagicMock()
+    config.get_fraise.return_value = {"type": "api", "external_db": external}
+    config.get_fraise_environment.return_value = {
+        "type": "api",
+        "app_path": "/var/www/api",
+        "database": {
+            "name": "mydb_staging",
+            "admin_url": _ADMIN_URL,
+            "restore": {
+                "backup_dir": "/backup/production",
+                "max_age_hours": max_age_hours,
+            },
+        },
+    }
+    config._config = {"backup": {}}
+    config.list_fraises_detailed.return_value = []
+    return config
+
+
+def _invoke(check, *args, config=None, external=False):
+    from fraisier.cli.main import main
+
+    with (
+        patch(
+            "fraisier.cli.main.get_config",
+            return_value=config or _config(external=external),
+        ),
+        patch("fraisier.dbops.guard.is_external_db", return_value=external),
+        patch("fraisier.dbops.receipt.verify_actuation", return_value=check) as verify,
+    ):
+        result = CliRunner().invoke(main, ["db", "receipt", "api", "staging", *args])
+    return result, verify
+
+
+class TestTheThreeAnswersHaveThreeExits:
+    def test_a_fresh_receipt_exits_zero(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ran 1.5h ago", _receipt())
+        result, _ = _invoke(check)
+
+        assert result.exit_code == 0, result.output
+
+    def test_a_stale_receipt_exits_one(self):
+        """The #343 signature: staging still holds an old run's receipt."""
+        check = ActuationCheck(
+            ActuationVerdict.STALE, "last rewritten 26.0h ago", _receipt(age_hours=26)
+        )
+        result, _ = _invoke(check)
+
+        assert result.exit_code == 1
+
+    @pytest.mark.parametrize(
+        "verdict", [ActuationVerdict.MISSING, ActuationVerdict.UNVERIFIABLE]
+    )
+    def test_not_checked_exits_three_not_zero(self, verdict):
+        """Distinct from success on purpose.
+
+        Exiting 0 here would let a host that cannot check report the same thing
+        as a host that checked and passed — which is the hole this whole
+        mechanism exists to close, moved into the monitoring layer.
+        """
+        result, _ = _invoke(ActuationCheck(verdict, "no receipt"))
+
+        assert result.exit_code == 3
+
+    def test_the_exit_codes_are_documented_in_help(self):
+        from fraisier.cli.main import main
+
+        result = CliRunner().invoke(main, ["db", "receipt", "--help"])
+
+        assert result.exit_code == 0
+        for code in ("0", "1", "3"):
+            assert code in result.output
+
+
+class TestTheWindow:
+    def test_the_restores_own_max_age_is_the_default(self):
+        """How stale an input may be is reused as how stale an output may be."""
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        _, verify = _invoke(check, config=_config(max_age_hours=12.0))
+
+        assert verify.call_args.kwargs["max_age_hours"] == 12.0
+
+    def test_the_flag_overrides_it(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        _, verify = _invoke(check, "--max-age-hours", "3")
+
+        assert verify.call_args.kwargs["max_age_hours"] == 3.0
+
+    def test_it_asks_about_the_configured_database(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        _, verify = _invoke(check)
+
+        assert verify.call_args.args[0] == "mydb_staging"
+        assert verify.call_args.kwargs["connection_url"] == _ADMIN_URL
+
+
+class TestWhatItPrints:
+    def test_the_run_and_the_backup_are_named(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt("run-alpha"))
+        result, _ = _invoke(check)
+
+        assert "run-alpha" in result.output
+        assert "/backup/production/latest.dump" in result.output
+
+    def test_a_stale_receipt_says_how_old(self):
+        check = ActuationCheck(
+            ActuationVerdict.STALE, "26.0h ago", _receipt(age_hours=26)
+        )
+        result, _ = _invoke(check)
+
+        assert "26.0" in result.output
+
+    def test_missing_does_not_read_as_a_failed_database(self):
+        result, _ = _invoke(
+            ActuationCheck(ActuationVerdict.MISSING, "no fraisier.restore_receipt")
+        )
+
+        lowered = result.output.lower()
+        assert "not checked" in lowered or "says nothing" in lowered
+
+    def test_json_carries_the_verdict_and_the_receipt(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt("run-json"))
+        result, _ = _invoke(check, "--json")
+
+        payload = json.loads(result.output)
+        assert payload["verdict"] == "actuated"
+        assert payload["run_id"] == "run-json"
+        assert payload["backup_path"] == "/backup/production/latest.dump"
+        assert payload["backup_bytes"] == 987654
+        assert payload["age_hours"] == pytest.approx(1.5)
+
+    def test_json_without_a_receipt_is_still_valid_json(self):
+        result, _ = _invoke(ActuationCheck(ActuationVerdict.MISSING, "none"), "--json")
+
+        payload = json.loads(result.output)
+        assert payload["verdict"] == "missing"
+        assert payload["run_id"] is None
+
+
+class TestTheHeapCheckCorroboratesWithoutVoting:
+    """It is opt-in, it is a line, and it never moves the exit code."""
+
+    @staticmethod
+    def _invoke_with_heap(check, heap, *args):
+        from fraisier.cli.main import main
+
+        with (
+            patch("fraisier.cli.main.get_config", return_value=_config()),
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch("fraisier.dbops.receipt.verify_actuation", return_value=check),
+            patch(
+                "fraisier.dbops.receipt.relation_freshness", return_value=heap
+            ) as freshness,
+        ):
+            result = CliRunner().invoke(
+                main, ["db", "receipt", "api", "staging", *args]
+            )
+        return result, freshness
+
+    def test_it_does_not_run_unless_asked(self):
+        """pg_stat_file is denied on most managed Postgres — do not ask by default."""
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        result, freshness = self._invoke_with_heap(check, None)
+
+        assert freshness.call_count == 0
+        assert result.exit_code == 0
+
+    def test_it_reports_when_asked(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "all 12 base table(s) fresh")
+        result, freshness = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert freshness.call_count == 1
+        assert "all 12 base table(s) fresh" in result.output
+
+    def test_it_asks_about_one_named_schema(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "fresh")
+        _, freshness = self._invoke_with_heap(
+            check, heap, "--check-heap", "--heap-schema", "tenant"
+        )
+
+        assert freshness.call_args.kwargs["schema"] == "tenant"
+        assert freshness.call_args.kwargs["within_hours"] == 48.0
+
+    def test_a_stale_heap_does_not_fail_a_verified_receipt(self):
+        """Autovacuum moves mtimes, so this signal cannot be allowed to vote.
+
+        Both are printed: an operator wants to be told the two disagree.
+        """
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        heap = ActuationCheck(ActuationVerdict.STALE, "3 of 12 written 40.0h ago")
+        result, _ = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert result.exit_code == 0
+        assert "3 of 12" in result.output
+
+    def test_a_fresh_heap_does_not_rescue_a_stale_receipt(self):
+        check = ActuationCheck(ActuationVerdict.STALE, "26.0h ago", _receipt(26))
+        heap = ActuationCheck(ActuationVerdict.ACTUATED, "all fresh")
+        result, _ = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert result.exit_code == 1
+
+    def test_an_unverifiable_heap_is_a_note_not_an_error(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        heap = ActuationCheck(
+            ActuationVerdict.UNVERIFIABLE, "needs pg_read_server_files"
+        )
+        result, _ = self._invoke_with_heap(check, heap, "--check-heap")
+
+        assert result.exit_code == 0
+        assert "pg_read_server_files" in result.output
+
+    def test_json_carries_it_too(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        heap = ActuationCheck(ActuationVerdict.STALE, "3 of 12 stale")
+        result, _ = self._invoke_with_heap(check, heap, "--check-heap", "--json")
+
+        payload = json.loads(result.output)
+        assert payload["heap"]["verdict"] == "stale"
+        assert payload["heap"]["detail"] == "3 of 12 stale"
+
+    def test_json_omits_it_when_not_asked(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        result, _ = self._invoke_with_heap(check, None, "--json")
+
+        assert json.loads(result.output)["heap"] is None
+
+
+class TestConfigurationEdges:
+    def test_an_external_database_is_skipped_like_a_restore_is(self):
+        check = ActuationCheck(ActuationVerdict.ACTUATED, "ok", _receipt())
+        result, verify = _invoke(check, external=True)
+
+        assert result.exit_code == 0
+        assert verify.call_count == 0
+
+    def test_a_missing_admin_url_is_an_error_not_a_crash(self):
+        from fraisier.cli.main import main
+
+        config = _config()
+        config.get_fraise_environment.return_value = {
+            "type": "api",
+            "database": {"name": "mydb_staging"},
+        }
+        with (
+            patch("fraisier.cli.main.get_config", return_value=config),
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+        ):
+            result = CliRunner().invoke(main, ["db", "receipt", "api", "staging"])
+
+        assert result.exit_code != 0
+        assert "admin_url" in result.output
+
+    def test_an_unknown_fraise_is_an_error(self):
+        from fraisier.cli.main import main
+
+        config = _config()
+        config.get_fraise.return_value = None
+        config.get_fraise_environment.return_value = None
+        with patch("fraisier.cli.main.get_config", return_value=config):
+            result = CliRunner().invoke(main, ["db", "receipt", "nope", "staging"])
+
+        assert result.exit_code != 0

--- a/tests/test_dbops_receipt.py
+++ b/tests/test_dbops_receipt.py
@@ -1,0 +1,296 @@
+"""The restore actuation receipt (#358).
+
+The receipt answers "which fraisier run last rewrote this database, and when?" —
+the question no table count and no row count can answer, because a database that
+was never rewritten has entirely correct counts.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from fraisier.dbops.receipt import (
+    RECEIPT_TABLE,
+    ActuationVerdict,
+    RestoreReceipt,
+    verify_actuation,
+    write_receipt,
+)
+
+_URL = "postgresql://admin@localhost:5432/postgres"
+
+
+def _row_json(**overrides) -> str:
+    row = {
+        "run_id": "abc123",
+        "backup_path": "/backup/prod.dump",
+        "backup_bytes": 4096,
+        "restored_at": "2026-08-10T09:00:00+00:00",
+        "age_seconds": 120.0,
+    }
+    row.update(overrides)
+    return json.dumps(row)
+
+
+def _responses(*results):
+    """Return a fake ``_pg_cmd`` yielding *results* in order."""
+    calls = list(results)
+
+    def fake(cmd, *, connection_url, input_text=None):
+        return calls.pop(0)
+
+    return fake
+
+
+# --------------------------------------------------------------------------
+# Cycle 1: the verdicts
+# --------------------------------------------------------------------------
+
+
+def test_only_stale_is_bad():
+    """``is_bad`` convicts STALE alone — MISSING and UNVERIFIABLE are silence.
+
+    Same rule as ``ArchiveCheck.is_bad``: a database restored by hand or by an
+    older fraisier carries no receipt, and a host that cannot reach it learned
+    nothing. Neither is evidence of a stale database.
+    """
+    from fraisier.dbops.receipt import ActuationCheck
+
+    assert ActuationCheck(ActuationVerdict.STALE, "d").is_bad is True
+    assert ActuationCheck(ActuationVerdict.MISSING, "d").is_bad is False
+    assert ActuationCheck(ActuationVerdict.UNVERIFIABLE, "d").is_bad is False
+    assert ActuationCheck(ActuationVerdict.ACTUATED, "d").is_bad is False
+
+
+def test_only_actuated_is_proof():
+    """``is_actuated`` is the only verdict a caller may read as "it ran"."""
+    from fraisier.dbops.receipt import ActuationCheck
+
+    assert ActuationCheck(ActuationVerdict.ACTUATED, "d").is_actuated is True
+    for other in (
+        ActuationVerdict.STALE,
+        ActuationVerdict.MISSING,
+        ActuationVerdict.UNVERIFIABLE,
+    ):
+        assert ActuationCheck(other, "d").is_actuated is False
+
+
+# --------------------------------------------------------------------------
+# Cycle 2: writing
+# --------------------------------------------------------------------------
+
+
+def test_write_binds_every_value_and_stops_on_error():
+    """Values reach SQL as psql variables, never by interpolation.
+
+    ``ON_ERROR_STOP=1`` is not decoration: psql exits 0 on a failed statement
+    without it, so the caller would read a failed write as a successful one.
+
+    The script goes in on stdin because ``-c`` would not be lexed by psql at
+    all — the server would receive a literal ``:'run_id'`` and reject it.
+    """
+    seen = {}
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen["cmd"] = cmd
+        seen["url"] = connection_url
+        seen["sql"] = input_text
+        return 0, "", ""
+
+    receipt = RestoreReceipt(
+        run_id="tok",
+        backup_path="/backup/x.dump",
+        backup_bytes=17,
+        restored_at=datetime.now(UTC),
+        age_seconds=0.0,
+    )
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        assert write_receipt("stagingdb", connection_url=_URL, receipt=receipt) is None
+
+    cmd = seen["cmd"]
+    assert cmd[0] == "psql"
+    assert "ON_ERROR_STOP=1" in cmd
+    assert "run_id=tok" in cmd
+    assert "backup_path=/backup/x.dump" in cmd
+    assert "backup_bytes=17" in cmd
+    # Read by psql, not handed to the server unread — otherwise no substitution.
+    assert cmd[-2:] == ["-f", "-"]
+    assert "-c" not in cmd
+    # The SQL body carries placeholders, not the values themselves.
+    sql = seen["sql"]
+    assert ":'run_id'" in sql
+    assert "tok" not in sql
+    assert "/backup/x.dump" not in sql
+
+
+def test_write_reports_failure_instead_of_raising():
+    """A failed write returns why. It must not raise into the restore pipeline."""
+    receipt = RestoreReceipt("t", "/b.dump", 1, datetime.now(UTC), 0.0)
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd", _responses((1, "", "permission denied"))
+    ):
+        detail = write_receipt("stagingdb", connection_url=_URL, receipt=receipt)
+    assert detail is not None
+    assert "permission denied" in detail
+
+
+def test_write_survives_a_host_without_psql():
+    """No client tools is a reported failure, not a traceback."""
+    receipt = RestoreReceipt("t", "/b.dump", 1, datetime.now(UTC), 0.0)
+
+    def boom(cmd, *, connection_url, input_text=None):
+        raise FileNotFoundError("psql")
+
+    with patch("fraisier.dbops.receipt._pg_cmd", boom):
+        detail = write_receipt("stagingdb", connection_url=_URL, receipt=receipt)
+    assert detail is not None
+    assert "psql" in detail
+
+
+def test_write_validates_the_database_name():
+    receipt = RestoreReceipt("t", "/b.dump", 1, datetime.now(UTC), 0.0)
+    with pytest.raises(ValueError, match="database name"):
+        write_receipt('bad"; DROP', connection_url=_URL, receipt=receipt)
+
+
+# --------------------------------------------------------------------------
+# Cycle 3: reading and verifying
+# --------------------------------------------------------------------------
+
+
+def test_absent_table_is_missing_not_stale():
+    """A database that has never been restored by this fraisier has no receipt."""
+    with patch("fraisier.dbops.receipt._pg_cmd", _responses((0, "f\n", ""))):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.MISSING
+    assert check.is_bad is False
+    assert RECEIPT_TABLE in check.detail
+
+
+def test_unreachable_database_is_unverifiable():
+    """Cannot ask is not the same as asked and got a bad answer."""
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((2, "", "could not connect to server")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+    assert check.is_bad is False
+    assert check.is_actuated is False
+
+
+def test_table_present_but_empty_is_missing():
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd", _responses((0, "t\n", ""), (0, "\n", ""))
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.MISSING
+
+
+def test_unparseable_row_is_unverifiable():
+    """Garbage out of psql is not a verdict about the database."""
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, "not json\n", "")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+
+
+def test_matching_token_is_actuated():
+    """The run that minted the token reads it back out of the database."""
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, _row_json(run_id="abc123") + "\n", "")),
+    ):
+        check = verify_actuation(
+            "stagingdb", connection_url=_URL, expected_run_id="abc123"
+        )
+    assert check.verdict is ActuationVerdict.ACTUATED
+    assert check.receipt is not None
+    assert check.receipt.run_id == "abc123"
+    assert check.receipt.backup_bytes == 4096
+
+
+def test_a_different_token_is_stale():
+    """The receipt names someone else's run: this one did not write it.
+
+    This is the #343 signature seen from inside the pipeline — the database was
+    not rewritten by the run now claiming to have rewritten it.
+    """
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, _row_json(run_id="yesterday") + "\n", "")),
+    ):
+        check = verify_actuation(
+            "stagingdb", connection_url=_URL, expected_run_id="today"
+        )
+    assert check.verdict is ActuationVerdict.STALE
+    assert check.is_bad is True
+    # The row is carried even when it fails, so the caller can say whose it is.
+    assert check.receipt is not None
+    assert check.receipt.run_id == "yesterday"
+
+
+def test_a_receipt_inside_the_window_is_actuated():
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, _row_json(age_seconds=3600.0) + "\n", "")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.ACTUATED
+
+
+def test_a_receipt_older_than_the_window_is_stale():
+    """A day-stale staging database, which is what #343 reported."""
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, _row_json(age_seconds=100_000.0) + "\n", "")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+    assert check.verdict is ActuationVerdict.STALE
+    assert "27.8" in check.detail or "27" in check.detail
+
+
+def test_age_is_measured_by_the_server_not_the_client():
+    """``age_seconds`` comes out of the database, so clock skew cannot fake it.
+
+    A host whose clock drifts would otherwise be able to make a stale restore
+    look fresh, or a fresh one look stale.
+    """
+    from fraisier.dbops.receipt import _READ_SQL
+
+    assert "now() - restored_at" in _READ_SQL
+
+
+def test_a_criterion_is_required():
+    """Reading the receipt is not a verdict on it.
+
+    Without something to check against, "a row exists" would be reported as
+    proof — and a no-op restore leaves the previous run's row in place, so
+    presence alone always matches.
+    """
+    with pytest.raises(ValueError, match="criterion"):
+        verify_actuation("stagingdb", connection_url=_URL)
+
+
+def test_verify_validates_the_database_name():
+    with pytest.raises(ValueError, match="database name"):
+        verify_actuation('bad"; DROP', connection_url=_URL, max_age_hours=1)
+
+
+def test_receipt_lives_outside_public():
+    """The receipt cannot inflate a table-count floor or read as schema drift.
+
+    Both floors that guard a restore count ``relkind='r'`` in one schema —
+    confiture's pre-migration counter and ``validate_table_count`` — so a
+    bookkeeping table in ``public`` would quietly raise both.
+    """
+    from fraisier.dbops.receipt import RECEIPT_SCHEMA
+
+    assert RECEIPT_SCHEMA == "fraisier"
+    assert RECEIPT_TABLE.startswith("fraisier.")

--- a/tests/test_dbops_receipt.py
+++ b/tests/test_dbops_receipt.py
@@ -31,6 +31,7 @@ def _row_json(**overrides) -> str:
         "backup_bytes": 4096,
         "restored_at": "2026-08-10T09:00:00+00:00",
         "age_seconds": 120.0,
+        "floor_schema": "public",
     }
     row.update(overrides)
     return json.dumps(row)
@@ -281,6 +282,137 @@ def test_a_criterion_is_required():
 def test_verify_validates_the_database_name():
     with pytest.raises(ValueError, match="database name"):
         verify_actuation('bad"; DROP', connection_url=_URL, max_age_hours=1)
+
+
+def test_the_write_is_one_transaction():
+    """A half-written receipt reads as MISSING, which is a lie about the run.
+
+    The script creates, deletes and inserts. Run as separate statements, a
+    failure at the INSERT commits the DELETE and leaves the table present and
+    empty — the previous run's receipt destroyed and nothing in its place.
+    ``-1`` makes the four statements one unit; ``ON_ERROR_STOP=1`` still decides
+    that a failure is a failure.
+    """
+    seen = {}
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen["cmd"] = cmd
+        return 0, "", ""
+
+    receipt = RestoreReceipt("t", "/b.dump", 1, datetime.now(UTC), 0.0)
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        write_receipt("stagingdb", connection_url=_URL, receipt=receipt)
+
+    assert "-1" in seen["cmd"]
+    assert "ON_ERROR_STOP=1" in seen["cmd"]
+
+
+def test_reads_are_not_wrapped_in_a_transaction():
+    """``-1`` is for the write. A read has nothing to roll back."""
+    seen = []
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen.append(cmd)
+        return 0, "f\n", ""
+
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+
+    assert all("-1" not in cmd for cmd in seen)
+
+
+# --------------------------------------------------------------------------
+# Cycle 4: which schema the heaps are in
+# --------------------------------------------------------------------------
+
+
+def test_the_write_records_the_schema_the_floor_was_derived_for():
+    """The restore knows it; nothing that reads the receipt later can.
+
+    ``min_tables_schema`` is derived from the archive's table of contents at
+    restore time and is not configured anywhere, so a caller arriving the next
+    morning has no source to read it from — unless the receipt carries it. A
+    host whose heaps live in ``tenant`` and a cross-check defaulting to
+    ``public`` is the same mismatch v0.64.0 removed from the floor.
+    """
+    seen = {}
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen["cmd"] = cmd
+        seen["sql"] = input_text
+        return 0, "", ""
+
+    receipt = RestoreReceipt(
+        run_id="tok",
+        backup_path="/backup/x.dump",
+        backup_bytes=17,
+        restored_at=datetime.now(UTC),
+        age_seconds=0.0,
+        floor_schema="tenant",
+    )
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        assert write_receipt("stagingdb", connection_url=_URL, receipt=receipt) is None
+
+    assert "floor_schema=tenant" in seen["cmd"]
+    assert ":'floor_schema'" in seen["sql"]
+    # Bound, not interpolated — an identifier-shaped value is still data.
+    assert "tenant" not in seen["sql"]
+
+
+def test_a_receipt_with_no_schema_writes_null_rather_than_an_empty_name():
+    """psql binds a missing value as ``''``; a schema named "" exists nowhere.
+
+    NULL is the honest record of "this run derived no floor", and it is what
+    the reader falls back to ``public`` on.
+    """
+    from fraisier.dbops.receipt import _WRITE_SQL
+
+    seen = {}
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen["cmd"] = cmd
+        return 0, "", ""
+
+    receipt = RestoreReceipt("t", "/b.dump", 1, datetime.now(UTC), 0.0)
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        write_receipt("stagingdb", connection_url=_URL, receipt=receipt)
+
+    assert "floor_schema=" in seen["cmd"]
+    assert "NULLIF(:'floor_schema', '')" in _WRITE_SQL
+
+
+def test_the_recorded_schema_reads_back():
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, _row_json(floor_schema="tenant") + "\n", "")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+
+    assert check.receipt is not None
+    assert check.receipt.floor_schema == "tenant"
+
+
+@pytest.mark.parametrize("row", [{"floor_schema": None}, {}])
+def test_a_receipt_without_a_schema_is_still_a_receipt(row):
+    """A NULL column, and a table written before the column existed.
+
+    ``CREATE TABLE IF NOT EXISTS`` never migrates an existing table, so the read
+    must survive a receipt that predates the column rather than degrading a
+    perfectly good verdict to UNVERIFIABLE.
+    """
+    payload = json.loads(_row_json())
+    payload.pop("floor_schema", None)
+    payload.update(row)
+
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _responses((0, "t\n", ""), (0, json.dumps(payload) + "\n", "")),
+    ):
+        check = verify_actuation("stagingdb", connection_url=_URL, max_age_hours=24)
+
+    assert check.verdict is ActuationVerdict.ACTUATED
+    assert check.receipt is not None
+    assert check.receipt.floor_schema is None
 
 
 def test_receipt_lives_outside_public():

--- a/tests/test_dbops_receipt_mtime.py
+++ b/tests/test_dbops_receipt_mtime.py
@@ -1,0 +1,143 @@
+"""Relation-file mtimes: the check #358 asks for, as a secondary signal.
+
+#358 names relation-file mtimes as "the only check known to catch" a staging
+database that silently stayed stale, and it is right that they can. It is a
+weaker instrument than the receipt, in two specific ways that belong in the code
+rather than in a postmortem:
+
+- ``pg_stat_file`` needs superuser or ``pg_read_server_files``, which managed
+  PostgreSQL commonly refuses. A denial is UNVERIFIABLE — never a pass, and
+  never a failure either.
+- Autovacuum and HOT pruning touch heap files, so an mtime can move after a
+  no-op. That is a false *pass*, never a false fail. An asymmetry that fails
+  safe is fine for corroboration and disqualifying as a sole guard.
+
+So this corroborates the receipt; it does not replace it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from fraisier.dbops.receipt import ActuationVerdict, relation_freshness
+
+_URL = "postgresql://admin@localhost:5432/postgres"
+
+
+def _one(result):
+    def fake(cmd, *, connection_url, input_text=None):
+        return result
+
+    return fake
+
+
+def _summary(total=4, fresh=4, oldest_age_hours=0.5):
+    return json.dumps(
+        {"total": total, "fresh": fresh, "oldest_age_hours": oldest_age_hours}
+    )
+
+
+def test_every_heap_written_inside_the_window_is_actuated():
+    with patch("fraisier.dbops.receipt._pg_cmd", _one((0, _summary() + "\n", ""))):
+        check = relation_freshness(
+            "stagingdb", schema="public", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.ACTUATED
+
+
+def test_a_heap_older_than_the_window_is_stale():
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _one((0, _summary(total=4, fresh=3, oldest_age_hours=30.0) + "\n", "")),
+    ):
+        check = relation_freshness(
+            "stagingdb", schema="public", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.STALE
+    assert check.is_bad is True
+    assert "1 of 4" in check.detail
+
+
+def test_permission_denied_is_unverifiable_not_a_pass():
+    """A managed Postgres that forbids pg_stat_file has told us nothing.
+
+    Reading a denial as a pass is the original silent hole in a new place; the
+    check must also not demand the privilege, or it only runs where it is least
+    needed.
+    """
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _one((1, "", "ERROR:  permission denied for function pg_stat_file")),
+    ):
+        check = relation_freshness(
+            "stagingdb", schema="public", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+    assert check.is_bad is False
+    assert check.is_actuated is False
+    assert "pg_read_server_files" in check.detail
+
+
+def test_a_schema_with_no_base_tables_is_unverifiable_not_all_fresh():
+    """Zero of zero tables fresh is not evidence that a restore ran."""
+    with patch(
+        "fraisier.dbops.receipt._pg_cmd",
+        _one((0, _summary(total=0, fresh=0, oldest_age_hours=None) + "\n", "")),
+    ):
+        check = relation_freshness(
+            "stagingdb", schema="tenant", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+    assert "tenant" in check.detail
+
+
+def test_unparseable_output_is_unverifiable():
+    with patch("fraisier.dbops.receipt._pg_cmd", _one((0, "nonsense\n", ""))):
+        check = relation_freshness(
+            "stagingdb", schema="public", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+
+
+def test_a_missing_psql_does_not_raise():
+    def boom(cmd, *, connection_url, input_text=None):
+        raise FileNotFoundError("psql")
+
+    with patch("fraisier.dbops.receipt._pg_cmd", boom):
+        check = relation_freshness(
+            "stagingdb", schema="public", connection_url=_URL, within_hours=24
+        )
+    assert check.verdict is ActuationVerdict.UNVERIFIABLE
+
+
+def test_the_schema_is_bound_never_interpolated():
+    seen = {}
+
+    def fake(cmd, *, connection_url, input_text=None):
+        seen["cmd"] = cmd
+        seen["sql"] = input_text
+        return 0, _summary() + "\n", ""
+
+    with patch("fraisier.dbops.receipt._pg_cmd", fake):
+        relation_freshness(
+            "stagingdb", schema="ten'ant", connection_url=_URL, within_hours=24
+        )
+
+    assert "schema=ten'ant" in seen["cmd"]
+    assert "ten'ant" not in seen["sql"]
+    assert ":'schema'" in seen["sql"]
+
+
+def test_the_window_is_measured_by_the_server():
+    """``now()`` server-side, so a drifting client clock cannot fake freshness."""
+    from fraisier.dbops.receipt import _FRESHNESS_SQL
+
+    assert "now() -" in _FRESHNESS_SQL
+
+
+def test_one_schema_never_summed():
+    """The per-schema rule the floor already follows (archive.py:60-71)."""
+    from fraisier.dbops.receipt import _FRESHNESS_SQL
+
+    assert "n.nspname = :'schema'" in _FRESHNESS_SQL

--- a/tests/test_integration_harness.py
+++ b/tests/test_integration_harness.py
@@ -1,0 +1,137 @@
+"""The integration harness must find the server CI actually provides (#358).
+
+Nine tests proving a truncated dump fails the restore, and nine proving the
+actuation receipt round-trips through real SQL, reported green for a release
+without ever running: the harness discovered PostgreSQL over a unix socket
+only, and every CI workflow provides it as a service container over TCP with no
+shared socket. The fixture skipped, pytest counted a skip as not-a-failure, and
+the checkmark said nothing about the behaviour being shipped.
+
+These are unit tests over the discovery itself — they need no database — so the
+harness's own reachability logic is pinned by tests that always run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.conftest import PgTarget, _discover_target
+
+
+class TestPgTargetDsn:
+    """One target, two transports, one DSN builder."""
+
+    def test_a_socket_target_addresses_the_directory(self):
+        target = PgTarget(host="/run/postgresql")
+
+        assert target.over_socket is True
+        assert (
+            target.dsn("fraisier_it")
+            == "postgresql:///fraisier_it?host=/run/postgresql"
+        )
+
+    def test_a_tcp_target_carries_host_port_and_credentials(self):
+        """CI's service container, exactly as the workflows declare it."""
+        target = PgTarget(
+            host="localhost", port=5432, user="fraisier", password="fraisier"
+        )
+
+        assert target.over_socket is False
+        assert (
+            target.dsn("fraisier_it")
+            == "postgresql://fraisier:fraisier@localhost:5432/fraisier_it"
+        )
+
+    def test_credentials_are_percent_encoded(self):
+        """A password is data, not URL syntax."""
+        target = PgTarget(
+            host="db.internal", port=5432, user="a b", password="p@ss/w:d"
+        )
+
+        assert target.dsn("x") == "postgresql://a%20b:p%40ss%2Fw%3Ad@db.internal:5432/x"
+
+    def test_a_tcp_target_without_credentials_omits_the_userinfo(self):
+        target = PgTarget(host="localhost", port=5432)
+
+        assert target.dsn("x") == "postgresql://localhost:5432/x"
+
+
+class TestDiscovery:
+    """Which server the fixtures hand the tests."""
+
+    def test_the_ci_service_container_is_discovered(self, monkeypatch):
+        """FRAISIER_TEST_PG_URL is a candidate, so CI's TCP server is found.
+
+        This is the whole bug: without it ``_discover_target`` returns None on
+        every CI runner and the tests carrying #358's guarantee skip.
+        """
+        monkeypatch.setenv(
+            "FRAISIER_TEST_PG_URL",
+            "postgresql://fraisier:fraisier@localhost:5432/fraisier_test",
+        )
+        monkeypatch.setattr(
+            "tests.integration.conftest._probe", lambda _dsn: "/var/run/postgresql"
+        )
+        monkeypatch.setattr(
+            "tests.integration.conftest.shutil.which", lambda tool: tool
+        )
+
+        target = _discover_target()
+
+        assert target is not None
+        assert target == PgTarget(
+            host="localhost", port=5432, user="fraisier", password="fraisier"
+        )
+        # Addressed over TCP even though the probe reported a socket directory:
+        # the server's own socket is inside the service container and is not
+        # shared with the runner.
+        assert target.dsn("postgres").startswith("postgresql://fraisier:")
+
+    def test_an_unusable_env_url_falls_back_to_the_local_socket(self, monkeypatch):
+        """A stale FRAISIER_TEST_PG_URL must not hide a working local server."""
+        monkeypatch.setenv("FRAISIER_TEST_PG_URL", "postgresql://nobody@127.0.0.1:1/db")
+        monkeypatch.setattr(
+            "tests.integration.conftest.shutil.which", lambda tool: tool
+        )
+        monkeypatch.setattr(
+            "tests.integration.conftest._probe",
+            lambda dsn: None if "127.0.0.1" in dsn else "/run/postgresql",
+        )
+
+        assert _discover_target() == PgTarget(host="/run/postgresql")
+
+    def test_no_env_url_still_discovers_a_socket(self, monkeypatch):
+        """The developer's path is unchanged."""
+        monkeypatch.delenv("FRAISIER_TEST_PG_URL", raising=False)
+        monkeypatch.setattr(
+            "tests.integration.conftest.shutil.which", lambda tool: tool
+        )
+        monkeypatch.setattr(
+            "tests.integration.conftest._probe", lambda _dsn: "/run/postgresql"
+        )
+
+        assert _discover_target() == PgTarget(host="/run/postgresql")
+
+    def test_missing_client_tools_are_not_a_reachable_server(self, monkeypatch):
+        monkeypatch.setenv("FRAISIER_TEST_PG_URL", "postgresql://f:f@localhost:5432/d")
+        monkeypatch.setattr(
+            "tests.integration.conftest.shutil.which", lambda _tool: None
+        )
+
+        assert _discover_target() is None
+
+    @pytest.mark.parametrize("url", ["", "not-a-url", "postgresql:///db"])
+    def test_an_env_url_naming_no_host_is_no_candidate(self, url, monkeypatch):
+        """Only a URL with a host describes a server reachable over TCP."""
+        monkeypatch.setenv("FRAISIER_TEST_PG_URL", url)
+        monkeypatch.setattr(
+            "tests.integration.conftest.shutil.which", lambda tool: tool
+        )
+        monkeypatch.setattr(
+            "tests.integration.conftest._probe",
+            lambda dsn: (
+                "/run/postgresql" if "host=" in dsn or dsn.count("/") == 3 else None
+            ),
+        )
+
+        assert _discover_target() == PgTarget(host="/run/postgresql")

--- a/tests/test_restore_actuation_receipt.py
+++ b/tests/test_restore_actuation_receipt.py
@@ -49,9 +49,14 @@ def _execute(
     verify_result: ActuationCheck | None = None,
     min_tables: int = 0,
     order: list[str] | None = None,
+    table_data_by_schema: dict[str, int] | None = None,
 ):
     """Drive the strategy to completion with the receipt seam mocked."""
-    check = ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 12})
+    # `is None`, not `or`: an empty mapping is a meaningful case — an archive
+    # that stated no floor at all.
+    if table_data_by_schema is None:
+        table_data_by_schema = {"public": 12}
+    check = ArchiveCheck(ArchiveVerdict.VALID, "", table_data_by_schema)
 
     def _note(name, value):
         def _fn(*_args, **_kwargs):
@@ -170,6 +175,27 @@ class TestTheRunLeavesAReceipt:
 
         minted = writer.call_args.kwargs["receipt"].run_id
         assert verifier.call_args.kwargs["expected_run_id"] == minted
+
+    def test_the_receipt_records_the_schema_the_floor_was_derived_for(self):
+        """The one moment this is knowable is the moment the receipt is written.
+
+        ``min_tables_schema`` comes off the archive's table of contents during
+        the restore and is configured nowhere; a caller reading the receipt the
+        next morning has no archive and no key to look up. Recording it here is
+        what lets the mtime cross-check ask about ``tenant`` on a host whose
+        heaps are in ``tenant``, without the operator naming it by hand.
+        """
+        writer, _, _ = _execute(table_data_by_schema={"tenant": 40, "public": 2})
+
+        assert writer.call_args.kwargs["receipt"].floor_schema == "tenant"
+
+    def test_an_archive_stating_no_floor_records_no_schema(self):
+        """Not ``public`` by guess: the reader falls back, the writer does not
+        invent. A recorded ``public`` would be indistinguishable from a run that
+        actually derived ``public``."""
+        writer, _, _ = _execute(table_data_by_schema={})
+
+        assert writer.call_args.kwargs["receipt"].floor_schema is None
 
     def test_the_result_carries_the_verified_receipt(self):
         _, _, result = _execute(verify_result=_actuated("tok-9"))

--- a/tests/test_restore_actuation_receipt.py
+++ b/tests/test_restore_actuation_receipt.py
@@ -1,0 +1,318 @@
+"""The restore leaves a receipt proving *this* run rewrote the database (#358).
+
+#358 asks for a check that the data arrived, and reaches for row counts. The
+failure it was filed against cannot be seen by counting anything: a staging
+database that was never rewritten holds yesterday's data, and yesterday's data
+has entirely correct counts. What distinguishes it is not *what* is in the
+database but *when* it got there, and who put it there.
+
+So the pipeline mints a token per run and writes it into the database it just
+restored. A run that never happened leaves the previous run's token behind — and
+a token is the one thing presence alone cannot fake, which is why the check is
+against a token rather than against the existence of a row.
+
+The receipt is bookkeeping, and bookkeeping does not get to fail a restore that
+passed every check it has. A write that fails is reported as *unverified*, never
+as verified and never as a failure.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fraisier.config.schema import PreflightConfig
+from fraisier.dbops.archive import ArchiveCheck, ArchiveVerdict
+from fraisier.dbops.confiture import MigrationResult
+from fraisier.dbops.receipt import ActuationCheck, ActuationVerdict, RestoreReceipt
+from fraisier.dbops.restore import RestoreResult
+from fraisier.strategies import RestoreConfig, RestoreMigrateStrategy
+
+_ADMIN_URL = "postgresql://postgres@localhost:5432/postgres"
+_BACKUP = Path("/backup/production/db.dump")
+
+
+def _actuated(run_id: str = "tok") -> ActuationCheck:
+    return ActuationCheck(
+        ActuationVerdict.ACTUATED,
+        "ok",
+        RestoreReceipt(run_id, str(_BACKUP), 4096, MagicMock(), 1.0),
+    )
+
+
+def _execute(
+    *,
+    write_result: str | None = None,
+    verify_result: ActuationCheck | None = None,
+    min_tables: int = 0,
+    order: list[str] | None = None,
+):
+    """Drive the strategy to completion with the receipt seam mocked."""
+    check = ArchiveCheck(ArchiveVerdict.VALID, "", {"public": 12})
+
+    def _note(name, value):
+        def _fn(*_args, **_kwargs):
+            if order is not None:
+                order.append(name)
+            return value
+
+        return _fn
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            patch("fraisier.dbops.restore.find_latest_backup", return_value=_BACKUP)
+        )
+        stack.enter_context(
+            patch("fraisier.dbops.restore.validate_backup_age", return_value=True)
+        )
+        stack.enter_context(
+            patch("fraisier.dbops.archive.verify_archive", return_value=check)
+        )
+        stack.enter_context(
+            patch.object(Path, "stat", return_value=MagicMock(st_size=4096))
+        )
+        for target, value in (
+            ("fraisier.dbops.operations.drop_db", (0, "", "")),
+            ("fraisier.dbops.operations.create_db", (0, "", "")),
+            ("fraisier.dbops.operations.terminate_backends", None),
+        ):
+            stack.enter_context(patch(target, return_value=value))
+        stack.enter_context(
+            patch(
+                "fraisier.dbops.restore.restore_backup",
+                side_effect=_note("restore", RestoreResult(True, duration_seconds=0.1)),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "fraisier.strategies._restore.migrate_up",
+                side_effect=_note("migrate", MigrationResult(True, steps_applied=3)),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "fraisier.dbops.restore.validate_table_count", return_value=(True, 99)
+            )
+        )
+        writer = stack.enter_context(
+            patch(
+                "fraisier.dbops.receipt.write_receipt",
+                side_effect=_note("receipt", write_result),
+            )
+        )
+        verifier = stack.enter_context(
+            patch(
+                "fraisier.dbops.receipt.verify_actuation",
+                return_value=verify_result or _actuated(),
+            )
+        )
+        strategy = RestoreMigrateStrategy(
+            RestoreConfig(
+                db_name="staging_db",
+                backup_dir=Path("/backup/production"),
+                preflight=PreflightConfig(enabled=False),
+                min_tables=min_tables,
+            ),
+            admin_url=_ADMIN_URL,
+        )
+        result = strategy.execute(Path("confiture.yaml"))
+    return writer, verifier, result
+
+
+class TestTheRunLeavesAReceipt:
+    def test_the_receipt_is_written_once(self):
+        writer, _, _ = _execute()
+
+        assert writer.call_count == 1
+
+    def test_the_receipt_is_written_after_the_migration(self):
+        """A receipt written earlier would name a run that had not finished.
+
+        The restore succeeding is not the claim; the *pipeline* succeeding is.
+        A migration failure after an early write would leave a receipt asserting
+        an outcome that never happened — the class of lie #356 was about.
+        """
+        order: list[str] = []
+        _execute(order=order)
+
+        assert order == ["restore", "migrate", "receipt"]
+
+    def test_the_receipt_names_the_backup_that_was_restored(self):
+        """Which archive, not merely that some archive was loaded."""
+        writer, _, _ = _execute()
+
+        receipt = writer.call_args.kwargs["receipt"]
+        assert receipt.backup_path == str(_BACKUP)
+        assert receipt.backup_bytes == 4096
+
+    def test_the_receipt_goes_into_the_restored_database(self):
+        writer, _, _ = _execute()
+
+        assert writer.call_args.args[0] == "staging_db"
+        assert writer.call_args.kwargs["connection_url"] == _ADMIN_URL
+
+    def test_each_run_mints_its_own_token(self):
+        """Presence is not proof: a no-op leaves the previous run's token."""
+        first, _, _ = _execute()
+        second, _, _ = _execute()
+
+        assert (
+            first.call_args.kwargs["receipt"].run_id
+            != second.call_args.kwargs["receipt"].run_id
+        )
+
+    def test_the_token_is_read_back_out_of_the_database(self):
+        """A round trip, not a variable the pipeline set and then trusted."""
+        writer, verifier, _ = _execute()
+
+        minted = writer.call_args.kwargs["receipt"].run_id
+        assert verifier.call_args.kwargs["expected_run_id"] == minted
+
+    def test_the_result_carries_the_verified_receipt(self):
+        _, _, result = _execute(verify_result=_actuated("tok-9"))
+
+        assert result.actuation is not None
+        assert result.actuation.is_actuated is True
+        assert result.actuation.receipt is not None
+        assert result.actuation.receipt.run_id == "tok-9"
+
+
+class TestBookkeepingDoesNotFailARestore:
+    """The restore passed every check it has. A receipt is not one of them."""
+
+    def test_a_write_failure_leaves_the_restore_successful(self):
+        _, _, result = _execute(write_result="permission denied for schema fraisier")
+
+        assert result.success is True
+
+    def test_a_write_failure_is_reported_as_unverified(self):
+        """Not checked, never checked-and-passed."""
+        _, _, result = _execute(write_result="permission denied for schema fraisier")
+
+        assert result.actuation is not None
+        assert result.actuation.verdict is ActuationVerdict.UNVERIFIABLE
+        assert result.actuation.is_actuated is False
+        assert result.actuation.is_bad is False
+        assert "permission denied" in result.actuation.detail
+
+    def test_a_failed_write_is_not_then_read_back(self):
+        """Reading back a receipt known not to have been written proves nothing."""
+        _, verifier, _ = _execute(write_result="disk full")
+
+        assert verifier.call_count == 0
+
+    def test_a_read_back_mismatch_does_not_fail_the_restore_either(self):
+        stale = ActuationCheck(ActuationVerdict.STALE, "someone else's receipt")
+        _, _, result = _execute(verify_result=stale)
+
+        assert result.success is True
+        assert result.actuation is not None
+        assert result.actuation.is_bad is True
+
+
+class TestTheConsoleSaysWhetherItWasProven:
+    """An operator reading "Restore complete" should learn what proved it."""
+
+    @staticmethod
+    def _config():
+        config = MagicMock()
+        config.get_fraise.return_value = {"type": "api"}
+        config.get_fraise_environment.return_value = {
+            "type": "api",
+            "app_path": "/var/www/api",
+            "systemd_service": "api.staging.service",
+            "database": {
+                "name": "mydb_staging",
+                "strategy": "restore_migrate",
+                "admin_url": _ADMIN_URL,
+                "confiture_config": "confiture.yaml",
+                "restore": {
+                    "backup_dir": "/backup/production",
+                    "backup_pattern": "*.dump",
+                    "max_age_hours": 48.0,
+                },
+            },
+        }
+        config._config = {"backup": {}}
+        config.deployment = MagicMock()
+        config.deployment.get_strategy.return_value = "restore_migrate"
+        config.list_fraises_detailed.return_value = []
+        return config
+
+    def _invoke(self, actuation):
+        from click.testing import CliRunner
+
+        from fraisier.cli.main import main
+
+        result_mock = MagicMock(
+            success=True,
+            migrations_applied=0,
+            total_duration_seconds=0.0,
+            restore_duration_seconds=0.0,
+            migration_duration_seconds=0.0,
+            schema_floor=("public", 12),
+            unchecked_schemas=(),
+            actuation=actuation,
+        )
+        with (
+            patch("fraisier.cli.main.get_config", return_value=self._config()),
+            patch("fraisier.locking.deployment_lock", MagicMock()),
+            patch("fraisier.dbops.guard.is_external_db", return_value=False),
+            patch(
+                "fraisier.strategies.RestoreMigrateStrategy.execute",
+                return_value=result_mock,
+            ),
+            patch("fraisier.systemd.SystemdServiceManager"),
+            patch(
+                "fraisier.dbops.restore.find_latest_backup",
+                return_value="/backup/production/x.dump",
+            ),
+            patch("fraisier.dbops.restore.validate_backup_age"),
+            patch(
+                "fraisier.post_migrate.run_configured_post_migrate", return_value=None
+            ),
+        ):
+            return CliRunner().invoke(main, ["db", "restore", "api", "staging"])
+
+    def test_a_verified_receipt_names_the_run(self):
+        res = self._invoke(_actuated("abc123def"))
+
+        assert res.exit_code == 0, res.output
+        assert "abc123def" in res.output
+
+    def test_an_unverified_receipt_says_so_without_claiming_a_failure(self):
+        res = self._invoke(
+            ActuationCheck(ActuationVerdict.UNVERIFIABLE, "psql not found on PATH")
+        )
+
+        assert res.exit_code == 0, res.output
+        assert "not verified" in res.output.lower()
+        assert "psql not found" in res.output
+
+    def test_a_stale_receipt_is_surfaced_as_a_warning(self):
+        res = self._invoke(
+            ActuationCheck(ActuationVerdict.STALE, "staging still holds run yesterday")
+        )
+
+        assert "yesterday" in res.output
+
+    def test_the_line_is_absent_when_the_result_predates_the_feature(self):
+        """An older StrategyResult has no `actuation`; the CLI must not crash."""
+        res = self._invoke(None)
+
+        assert res.exit_code == 0, res.output
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [ActuationVerdict.MISSING, ActuationVerdict.UNVERIFIABLE],
+)
+def test_silence_is_never_proof(verdict):
+    """The two verdicts that say nothing must not read as the one that says yes."""
+    check = ActuationCheck(verdict, "d")
+
+    assert check.is_actuated is False
+    assert check.is_bad is False

--- a/tests/test_restore_derived_schema_floor.py
+++ b/tests/test_restore_derived_schema_floor.py
@@ -14,7 +14,13 @@ Two things this deliberately does not do:
   #356's own host keeps its heaps in `tenant`.
 - It does not prove the data arrived. A dump truncated inside its data section
   restores a complete, empty schema and passes any count; `dbops/restore.py`
-  says so in its own docstring. That hole stays open.
+  says so in its own docstring.
+
+  What it took #358 to establish is that the floor not seeing a truncation does
+  not mean nothing does — `pg_restore` fails on one, serially and in parallel,
+  and `test_restore_truncated_archive.py` pins it. The gap the floor really
+  leaves is a restore that never ran at all, which no count can see because a
+  database nobody rewrote holds correct counts. `dbops/receipt.py` covers that.
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "fraisier"
-version = "0.64.0"
+version = "0.65.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## The reframe

#358 was filed against v0.64.0's schema floor with a correct observation — a
dump truncated inside its data section restores a complete, empty schema, so no
table-count floor of any derivation can see it — and reached for row counts as
the answer. Before building that, we measured. The measurement changed the work.

The issue conflates two failures:

- **Partial data** — the schema arrived, the rows did not.
- **Non-actuation** — the pipeline never ran; staging keeps yesterday's
  database. Counts, floors and `pg_restore`'s exit are all *correct*, because
  nothing about the content is wrong. It is only old.

## Step 0 ran first, before any code

A real `-Fc` dump of two populated tables, cut at 50%, 90% and 98%, restored
through fraisier against a real PostgreSQL 17:

| cut | `pg_restore --list` | `verify_archive` | jobs=1 | jobs=4 |
|-----|--------------------|------------------|--------|--------|
| 50% | rc=0, 2 TABLE DATA | VALID, floor `('public', 2)` | **fails** | **fails** |
| 90% | rc=0, 2 TABLE DATA | VALID, floor `('public', 2)` | **fails** | **fails** |
| 98% | rc=0, 2 TABLE DATA | VALID, floor `('public', 2)` | **fails** | **fails** |

The premise holds exactly as #358 states it: the TOC parses, `verify_archive`
returns VALID, and the derived floor is satisfied by an empty schema. But the
restore fails anyway — `pg_restore` cannot read past the cut, writes a
`pg_restore: error:` line and exits non-zero, and confiture fails the section on
`returncode != 0 and (exit_on_error or errors)` (`restorer.py:793`).

The `jobs > 1` path was the open question, since `parallel_restore` turns
`exit_on_error` off. It is carried by the `or errors` half: tolerating a
non-zero *exit* is not the same as tolerating an *error line*.

**So the row-count manifest was not built.** It exists only to close the half
that is already closed, it is the most expensive option on the table — a
producer, a consumer, snapshot skew against `pg_dump`'s own snapshot, a
tolerance band, and a three-valued case for every dump predating it — and it
would not have caught the failure that was actually reported.

## What ships instead

**An actuation receipt.** Each restore mints a token and writes it, with the
backup's path and size, into a `fraisier.restore_receipt` table in the database
it just restored — then reads it straight back. A round trip, not a variable the
pipeline set and then trusted.

The token is the mechanism. A restore that never ran leaves the *previous* run's
receipt in place, so "a receipt exists" matches every time and proves nothing;
`verify_actuation` refuses to answer without a criterion.

Four-valued, following `ArchiveCheck`: `ACTUATED` is the only proof, `STALE` the
only conviction, `MISSING` and `UNVERIFIABLE` say nothing in either direction. A
receipt that cannot be written **does not fail the restore** — it is bookkeeping
written after every real check has already passed.

**`fraisier db receipt <fraise> <env>`** is the half that catches this in the
field. The pipeline's own read-back runs inside the process that did the
writing: it proves the write landed but cannot prove a run happened, because
when the run does not happen that code does not execute either.

| exit | meaning |
|------|---------|
| `0` | rewritten inside the window |
| `1` | stale |
| `3` | not checked — no receipt, or the check could not run |

`3` is not `0` on purpose: a host that cannot check must not report what a host
that checked and passed reports. It is not `1` either — a missing `psql` should
not page the way a stale staging database should.

**`--check-heap`** ships #358's own suggestion, relation-file mtimes, as an
opt-in advisory line. `pg_stat_file` needs a privilege managed PostgreSQL
commonly refuses, and autovacuum moves mtimes after a no-op — a false *pass*,
never a false fail — so it corroborates the receipt and never moves the exit
code. When the two disagree, both are printed.

## Corrections

`dbops/restore.py`'s docstring and v0.64.0's CHANGELOG both described a
truncated dump as an open hole. The *floor* cannot see one — accurate — but the
restore fails on it regardless. Both now say so and point at the test.

## Also in here

`_pg_cmd` accepts stdin, because psql's `:'var'` binding is otherwise unusable:
`-c` hands its string to the server unread, so the variables are never
substituted. Found by a test that put a quote in a backup path.

## Design constraints honoured

- Three-valued, "not checked" ≠ "passed" — `is_bad` narrow, every unreachable
  path UNVERIFIABLE
- Per schema, never summed
- No privilege escalation; `pg_stat_file` degrades rather than demands
- No confiture change and no version floor — the receipt is entirely fraisier's

## Verification

- `uv run pytest` — **5304 passed, 7 skipped** (baseline 5217/7; +87, no regressions) — exit 0
- `uv run ruff check .` — exit 0
- `uv run ruff format --check .` — exit 0 (494 files)
- `uv run ty check` — exit 0 (blocking)

Merge with **rebase**, not squash.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)